### PR TITLE
Security hardening: SQL identifier validation, access control, API safety

### DIFF
--- a/src/plone/pgcatalog/catalog.py
+++ b/src/plone/pgcatalog/catalog.py
@@ -222,6 +222,11 @@ class PlonePGCatalogTool(CatalogTool):
     meta_type = "PG Catalog Tool"
     security = ClassSecurityInfo()
 
+    security.declarePrivate("unrestrictedSearchResults")
+    security.declareProtected("Manage ZCatalog Entries", "refreshCatalog")
+    security.declareProtected("Manage ZCatalog Entries", "reindexIndex")
+    security.declareProtected("Manage ZCatalog Entries", "clearFindAndRebuild")
+
     @contextmanager
     def _pg_connection(self):
         """Get a connection, preferring request-scoped reuse.

--- a/src/plone/pgcatalog/config.py
+++ b/src/plone/pgcatalog/config.py
@@ -179,7 +179,7 @@ def release_request_connection(event=None):
         try:
             pool.putconn(conn)
         except Exception:
-            pass  # pool closed or conn already returned
+            log.warning("Failed to return connection to pool", exc_info=True)
     _local.pgcat_conn = None
     _local.pgcat_pool = None
 

--- a/src/plone/pgcatalog/dri.py
+++ b/src/plone/pgcatalog/dri.py
@@ -67,6 +67,9 @@ class DateRecurringIndexTranslator:
     """
 
     def __init__(self, date_attr, recurdef_attr, until_attr=""):
+        from plone.pgcatalog.columns import validate_identifier
+
+        validate_identifier(date_attr)
         self.date_attr = date_attr
         self.recurdef_attr = recurdef_attr
         self.until_attr = until_attr

--- a/src/plone/pgcatalog/interfaces.py
+++ b/src/plone/pgcatalog/interfaces.py
@@ -20,6 +20,16 @@ class IPGIndexTranslator(Interface):
       a fallback when the index is not in the ``IndexRegistry``.
     - ``catalog.py``: ``_extract_from_translators()`` calls ``extract()``
       for all registered translators during indexing.
+
+    **Security contract:**
+
+    Implementations MUST use psycopg parameterized queries for all
+    user-supplied values.  The ``query()`` method returns a raw SQL
+    fragment that is appended directly to the WHERE clause — never
+    interpolate user input into this fragment.  Only use ``%(name)s``
+    placeholders with corresponding entries in the returned params dict.
+    Index/column identifiers in the fragment should be hardcoded constants
+    or validated against ``columns.validate_identifier()``.
     """
 
     def extract(obj, index_name):
@@ -32,6 +42,10 @@ class IPGIndexTranslator(Interface):
     def query(index_name, query_value, query_options):
         """Translate a ZCatalog query dict into a SQL fragment + params.
 
+        The returned SQL fragment is inserted directly into a WHERE clause.
+        All user-supplied values MUST use ``%(name)s`` parameter placeholders
+        — never string-format values into the SQL.
+
         Returns (sql_fragment, params_dict), e.g.:
             ("pgcatalog_to_timestamptz(idx->>'event_start') <= %(drir_date)s",
              {"drir_date": query_value})
@@ -39,6 +53,9 @@ class IPGIndexTranslator(Interface):
 
     def sort(index_name):
         """Return SQL expression for ORDER BY, or None if not sortable.
+
+        The returned expression is inserted directly into an ORDER BY clause.
+        Only use hardcoded column references — never interpolate user input.
 
         Returns e.g.: "pgcatalog_to_timestamptz(idx->>'event_start')"
         """

--- a/src/plone/pgcatalog/schema.py
+++ b/src/plone/pgcatalog/schema.py
@@ -21,6 +21,12 @@ CATALOG_FUNCTIONS = """\
 -- The built-in ::timestamptz cast is STABLE (depends on session timezone),
 -- but our ISO 8601 dates always include timezone info, making the result
 -- deterministic.  This wrapper lets PG accept it in index expressions.
+--
+-- SECURITY NOTE: declared IMMUTABLE despite wrapping a STABLE cast.
+-- Safe because all stored dates include explicit timezone info (ISO 8601).
+-- If a value without timezone were stored, the result would depend on the
+-- session timezone setting and PG could cache incorrect index entries.
+-- Ensure all date values written to idx JSONB include timezone offsets.
 CREATE OR REPLACE FUNCTION pgcatalog_to_timestamptz(text)
 RETURNS timestamptz AS $$
     SELECT $1::timestamptz;

--- a/tests/test_fulltext.py
+++ b/tests/test_fulltext.py
@@ -4,7 +4,7 @@ Tests multilingual text search, ranking, and edge cases.
 """
 
 from plone.pgcatalog.indexing import catalog_object
-from plone.pgcatalog.query import execute_query
+from plone.pgcatalog.query import _execute_query as execute_query
 from tests.conftest import insert_object
 
 

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -5,7 +5,7 @@ navtree, breadcrumbs, navtree_start, multiple paths.
 """
 
 from plone.pgcatalog.indexing import catalog_object
-from plone.pgcatalog.query import execute_query
+from plone.pgcatalog.query import _execute_query as execute_query
 from tests.conftest import insert_object
 
 

--- a/tests/test_query_integration.py
+++ b/tests/test_query_integration.py
@@ -7,7 +7,7 @@ return correct results.
 from datetime import datetime
 from datetime import UTC
 from plone.pgcatalog.indexing import catalog_object
-from plone.pgcatalog.query import execute_query
+from plone.pgcatalog.query import _execute_query as execute_query
 from tests.conftest import insert_object
 
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -7,8 +7,8 @@ secured queries against real PG (integration).
 from datetime import datetime
 from datetime import UTC
 from plone.pgcatalog.indexing import catalog_object
+from plone.pgcatalog.query import _execute_query
 from plone.pgcatalog.query import apply_security_filters
-from plone.pgcatalog.query import execute_query
 from tests.conftest import insert_object
 
 
@@ -150,7 +150,7 @@ def _setup_security_data(conn):
 
 
 def _query_zoids(conn, query_dict):
-    rows = execute_query(conn, query_dict, columns="zoid")
+    rows = _execute_query(conn, query_dict, columns="zoid")
     return sorted(row["zoid"] for row in rows)
 
 


### PR DESCRIPTION
## Summary

Addresses all findings from the security review in #1:

- **SQL identifier validation**: Added `validate_identifier()` that enforces `^[a-zA-Z_][a-zA-Z0-9_]*$` pattern on all `idx_key` values entering the `IndexRegistry` (both `sync_from_catalog()` and `register()`), and on `DateRecurringIndexTranslator` constructor. Prevents SQL injection via crafted index names.
- **Access control declarations**: Added explicit `security.declareProtected` / `security.declarePrivate` on `PlonePGCatalogTool` for `refreshCatalog`, `reindexIndex`, `clearFindAndRebuild` (require `Manage ZCatalog Entries`), and `unrestrictedSearchResults` (private).
- **API safety**: Renamed `execute_query()` to `_execute_query()` to mark the unvalidated `columns` parameter as internal-only.
- **IPGIndexTranslator security contract**: Documented that implementations must use parameterized queries and never interpolate user input into SQL fragments.
- **Path query DoS cap**: Limited path query list size to 100 entries.
- **Connection pool logging**: Changed silent exception swallowing to `log.warning` in `release_request_connection()`.
- **Schema comment**: Added SECURITY NOTE about the IMMUTABLE declaration on `pgcatalog_to_timestamptz`.

## Test plan

- [x] All 480 tests pass
- [ ] Verify `validate_identifier` rejects names with quotes/SQL metacharacters
- [ ] Verify `PlonePGCatalogTool.clearFindAndRebuild` requires `Manage ZCatalog Entries` permission
- [ ] Verify path queries with >100 paths raise `ValueError`

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)