### PR TITLE
Language-aware full-text search + Title/Description fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 1.0.0b4
+
+### Added
+
+- **Language-aware full-text search**: SearchableText now uses per-object
+  language for stemming. The `pgcatalog_lang_to_regconfig()` PL/pgSQL function
+  maps Plone language codes (ISO 639-1, 30 languages) to PostgreSQL text search
+  configurations (e.g. `"de"` → `german`). Falls back to `'simple'` for
+  unmapped or missing languages. Non-multilingual sites are unaffected.
+
+  Python mirror: `columns.language_to_regconfig()` for testing/validation.
+
+- **Title/Description text search**: Title and Description queries now use
+  tsvector word-level matching instead of exact JSONB containment.
+  `catalog(Title="Hello")` now correctly matches `"Hello World"`.
+  Backed by GIN expression indexes with `'simple'` config (no stemming).
+
+- **Automatic addon ZCTextIndex support**: Addon-registered ZCTextIndex fields
+  are automatically discovered at startup. GIN expression indexes are created
+  dynamically by `_ensure_text_indexes()`, and queries use tsvector matching --
+  zero addon code needed.
+
+### Fixed
+
+- **Title/Description query broken**: Previously, querying Title or Description
+  as ZCTextIndex used JSONB exact containment (`idx @> '{"Title":"Hello"}'`),
+  which only matched exact values, not words within text. Now uses
+  `to_tsvector`/`plainto_tsquery` for proper word-level matching.
+
 ## 1.0.0b3
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Requires [zodb-pgjsonb](https://github.com/bluedynamics/zodb-pgjsonb) as the ZOD
 - **Extensible** via `IPGIndexTranslator` named utilities for custom index types
 - **Dynamic index discovery** from ZCatalog at startup -- addons adding indexes via `catalog.xml` just work
 - **Transactional writes** -- catalog data written atomically alongside object state during ZODB commit
-- **Full-text search** via PostgreSQL `tsvector`/`tsquery`
+- **Full-text search** via PostgreSQL `tsvector`/`tsquery` -- language-aware stemming for SearchableText (30 languages), word-level matching for Title/Description/addon ZCTextIndex fields
 - **Zero ZODB cache pressure** -- no BTree/Bucket objects stored in ZODB
 - **Container-friendly** -- works on standard `postgres:17` Docker images, no extensions required
 
@@ -51,6 +51,8 @@ Once installed, `portal_catalog` is replaced with `PlonePGCatalogTool`. All cata
 results = catalog(portal_type="Document", review_state="published")
 results = catalog(Subject={"query": ["Python", "Plone"], "operator": "or"})
 results = catalog(SearchableText="my search term")
+results = catalog(SearchableText="Katzen", Language="de")  # language-aware stemming
+results = catalog(Title="quick fox")  # word-level match (finds "The Quick Brown Fox")
 results = catalog(path={"query": "/plone/folder", "depth": 1})
 
 # Recurring events (DateRecurringIndex)

--- a/src/plone/pgcatalog/columns.py
+++ b/src/plone/pgcatalog/columns.py
@@ -270,6 +270,61 @@ def _convert_zope_datetime(dt):
 
 
 # --------------------------------------------------------------------------
+# Language → PG text search configuration mapping
+# --------------------------------------------------------------------------
+
+# Plone language code (ISO 639-1) → PostgreSQL regconfig name.
+# Mirrors the SQL function pgcatalog_lang_to_regconfig() in schema.py.
+_LANG_TO_REGCONFIG = {
+    "ar": "arabic",
+    "hy": "armenian",
+    "eu": "basque",
+    "ca": "catalan",
+    "da": "danish",
+    "nl": "dutch",
+    "en": "english",
+    "fi": "finnish",
+    "fr": "french",
+    "de": "german",
+    "el": "greek",
+    "hi": "hindi",
+    "hu": "hungarian",
+    "id": "indonesian",
+    "ga": "irish",
+    "it": "italian",
+    "lt": "lithuanian",
+    "ne": "nepali",
+    "nb": "norwegian",
+    "nn": "norwegian",
+    "no": "norwegian",
+    "pt": "portuguese",
+    "ro": "romanian",
+    "ru": "russian",
+    "sr": "serbian",
+    "es": "spanish",
+    "sv": "swedish",
+    "ta": "tamil",
+    "tr": "turkish",
+    "yi": "yiddish",
+}
+
+
+def language_to_regconfig(lang):
+    """Map a Plone language code to a PG text search configuration name.
+
+    Args:
+        lang: Plone language code (e.g. "de", "en-us") or None/""
+
+    Returns:
+        PG regconfig name (e.g. "german", "english") or "simple"
+    """
+    if not lang:
+        return "simple"
+    base = lang.lower().split("-")[0].split("_")[0]
+    return _LANG_TO_REGCONFIG.get(base, "simple")
+
+
+# --------------------------------------------------------------------------
 # Path utilities
 # --------------------------------------------------------------------------
 

--- a/src/plone/pgcatalog/config.py
+++ b/src/plone/pgcatalog/config.py
@@ -310,7 +310,9 @@ class CatalogStateProcessor:
             ExtraColumn("idx", "%(idx)s"),
             ExtraColumn(
                 "searchable_text",
-                "to_tsvector('simple'::regconfig, %(searchable_text)s)",
+                "to_tsvector("
+                "pgcatalog_lang_to_regconfig(%(idx)s::jsonb->>'Language')"
+                "::regconfig, %(searchable_text)s)",
             ),
         ]
 
@@ -324,9 +326,16 @@ class CatalogStateProcessor:
         from plone.pgcatalog.schema import CATALOG_COLUMNS
         from plone.pgcatalog.schema import CATALOG_FUNCTIONS
         from plone.pgcatalog.schema import CATALOG_INDEXES
+        from plone.pgcatalog.schema import CATALOG_LANG_FUNCTION
         from plone.pgcatalog.schema import RRULE_FUNCTIONS
 
-        return CATALOG_COLUMNS + CATALOG_FUNCTIONS + CATALOG_INDEXES + RRULE_FUNCTIONS
+        return (
+            CATALOG_COLUMNS
+            + CATALOG_FUNCTIONS
+            + CATALOG_LANG_FUNCTION
+            + CATALOG_INDEXES
+            + RRULE_FUNCTIONS
+        )
 
     def process(self, zoid, class_mod, class_name, state):
         # Look up pending data from the thread-local store (set by
@@ -393,8 +402,53 @@ def register_catalog_processor(event):
         storage.register_state_processor(processor)
         log.info("Registered CatalogStateProcessor on %s", storage)
         _sync_registry_from_db(db)
+        _ensure_text_indexes(storage)
     else:
         log.debug("Storage %s does not support state processors", storage)
+
+
+def _ensure_text_indexes(storage):
+    """Create GIN expression indexes for dynamically discovered TEXT indexes.
+
+    For each TEXT-type index with idx_key != None (not SearchableText),
+    creates a GIN expression index on to_tsvector('simple', idx->>'{key}')
+    if it doesn't already exist.  Uses an autocommit connection to avoid
+    REPEATABLE READ lock conflicts.
+    """
+    from plone.pgcatalog.columns import get_registry
+    from plone.pgcatalog.columns import IndexType
+    from plone.pgcatalog.columns import validate_identifier
+
+    registry = get_registry()
+    text_indexes = [
+        (name, idx_key)
+        for name, (idx_type, idx_key, _) in registry.items()
+        if idx_type == IndexType.TEXT and idx_key is not None
+    ]
+    if not text_indexes:
+        return
+
+    dsn = getattr(storage, "_dsn", None)
+    if not dsn:
+        return
+
+    import psycopg
+
+    try:
+        with psycopg.connect(dsn, autocommit=True) as conn:
+            for name, idx_key in text_indexes:
+                validate_identifier(idx_key)
+                idx_name = f"idx_os_cat_{idx_key.lower()}_tsv"
+                conn.execute(
+                    f"CREATE INDEX IF NOT EXISTS {idx_name} "
+                    f"ON object_state USING gin ("
+                    f"to_tsvector('simple'::regconfig, "
+                    f"COALESCE(idx->>'{idx_key}', ''))) "
+                    f"WHERE idx IS NOT NULL"
+                )
+                log.info("Ensured GIN text index %s for %s", idx_name, name)
+    except Exception:
+        log.warning("Failed to create text expression indexes", exc_info=True)
 
 
 def _register_dri_translators(catalog):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,8 @@ _PLONE_DEFAULT_INDEXES = [
     ("effectiveRange", IndexType.DATE_RANGE, None),
     # UUIDIndex
     ("UID", IndexType.UUID, "UID"),
+    # FieldIndex (language — from plone.app.multilingual)
+    ("Language", IndexType.FIELD, "Language"),
     # ZCTextIndex
     ("SearchableText", IndexType.TEXT, None),
     ("Title", IndexType.TEXT, "Title"),

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -1,10 +1,11 @@
-"""Tests for plone.pgcatalog.columns — value conversion + path utilities."""
+"""Tests for plone.pgcatalog.columns — value conversion + path utilities + lang mapping."""
 
 from datetime import date
 from datetime import datetime
 from datetime import UTC
 from plone.pgcatalog.columns import compute_path_info
 from plone.pgcatalog.columns import convert_value
+from plone.pgcatalog.columns import language_to_regconfig
 
 
 class TestConvertValue:
@@ -116,3 +117,46 @@ class TestComputePathInfo:
         parent, depth = compute_path_info("/plone/folder/")
         assert parent == "/plone"
         assert depth == 2
+
+
+class TestLanguageToRegconfig:
+    """Verify Plone language code → PG regconfig mapping."""
+
+    def test_german(self):
+        assert language_to_regconfig("de") == "german"
+
+    def test_english(self):
+        assert language_to_regconfig("en") == "english"
+
+    def test_french(self):
+        assert language_to_regconfig("fr") == "french"
+
+    def test_spanish(self):
+        assert language_to_regconfig("es") == "spanish"
+
+    def test_portuguese(self):
+        assert language_to_regconfig("pt") == "portuguese"
+
+    def test_locale_variant_hyphen(self):
+        assert language_to_regconfig("en-us") == "english"
+
+    def test_locale_variant_underscore(self):
+        assert language_to_regconfig("pt_BR") == "portuguese"
+
+    def test_norwegian_variants(self):
+        assert language_to_regconfig("no") == "norwegian"
+        assert language_to_regconfig("nb") == "norwegian"
+        assert language_to_regconfig("nn") == "norwegian"
+
+    def test_none_returns_simple(self):
+        assert language_to_regconfig(None) == "simple"
+
+    def test_empty_returns_simple(self):
+        assert language_to_regconfig("") == "simple"
+
+    def test_unknown_returns_simple(self):
+        assert language_to_regconfig("xx") == "simple"
+
+    def test_case_insensitive(self):
+        assert language_to_regconfig("DE") == "german"
+        assert language_to_regconfig("En-US") == "english"

--- a/tests/test_fulltext.py
+++ b/tests/test_fulltext.py
@@ -288,3 +288,238 @@ class TestFulltextEdgeCases:
             {"SearchableText": "Python", "portal_type": "Document"},
         )
         assert zoids == [360]
+
+
+# ---------------------------------------------------------------------------
+# Language-aware search via query dict
+# ---------------------------------------------------------------------------
+
+
+class TestLanguageAwareSearch:
+    def test_german_stemming_via_language_field(self, pg_conn_with_catalog):
+        """SearchableText indexed with 'german' matches stems when Language filter used."""
+        conn = pg_conn_with_catalog
+        insert_object(conn, zoid=370)
+        catalog_object(
+            conn,
+            zoid=370,
+            path="/plone/de/doc",
+            idx={"portal_type": "Document", "Language": "de"},
+            searchable_text="Die Katzen spielen im Garten",
+            language="german",
+        )
+        conn.commit()
+
+        # Query with Language=de → pgcatalog_lang_to_regconfig('de') = 'german'
+        # German stemmer: "Katze" (singular) matches "Katzen" (plural)
+        zoids = _query_zoids(conn, {"SearchableText": "Katze", "Language": "de"})
+        assert 370 in zoids
+
+    def test_english_stemming_via_language_field(self, pg_conn_with_catalog):
+        """English stemming works via Language filter."""
+        conn = pg_conn_with_catalog
+        insert_object(conn, zoid=371)
+        catalog_object(
+            conn,
+            zoid=371,
+            path="/plone/en/doc",
+            idx={"portal_type": "Document", "Language": "en"},
+            searchable_text="The children are running quickly",
+            language="english",
+        )
+        conn.commit()
+
+        # "run" matches "running" with english stemmer
+        zoids = _query_zoids(conn, {"SearchableText": "run", "Language": "en"})
+        assert 371 in zoids
+
+    def test_no_language_falls_back_to_simple(self, pg_conn_with_catalog):
+        """Without Language filter, query uses 'simple' (no stemming)."""
+        conn = pg_conn_with_catalog
+        insert_object(conn, zoid=372)
+        catalog_object(
+            conn,
+            zoid=372,
+            path="/plone/doc",
+            idx={"portal_type": "Document"},
+            searchable_text="The children are running",
+        )
+        conn.commit()
+
+        # 'simple' config: exact word match, no stemming
+        zoids = _query_zoids(conn, {"SearchableText": "running"})
+        assert 372 in zoids
+        # "run" won't match "running" with 'simple' config
+        zoids = _query_zoids(conn, {"SearchableText": "run"})
+        assert 372 not in zoids
+
+    def test_locale_variant_language(self, pg_conn_with_catalog):
+        """Language code with locale variant (e.g. 'en-us') maps correctly."""
+        conn = pg_conn_with_catalog
+        insert_object(conn, zoid=373)
+        catalog_object(
+            conn,
+            zoid=373,
+            path="/plone/en/doc",
+            idx={"portal_type": "Document", "Language": "en-us"},
+            searchable_text="The children are running",
+            language="english",
+        )
+        conn.commit()
+
+        # "en-us" → pgcatalog_lang_to_regconfig strips to "en" → "english"
+        zoids = _query_zoids(conn, {"SearchableText": "run", "Language": "en-us"})
+        assert 373 in zoids
+
+
+# ---------------------------------------------------------------------------
+# Title / Description text search (tsvector expression on idx JSONB)
+# ---------------------------------------------------------------------------
+
+
+class TestTitleTextSearch:
+    def test_title_word_match(self, pg_conn_with_catalog):
+        """Title query matches individual words (not just exact string)."""
+        conn = pg_conn_with_catalog
+        insert_object(conn, zoid=380)
+        catalog_object(
+            conn,
+            zoid=380,
+            path="/plone/doc",
+            idx={"portal_type": "Document", "Title": "Hello World"},
+        )
+        conn.commit()
+
+        zoids = _query_zoids(conn, {"Title": "Hello"})
+        assert 380 in zoids
+
+    def test_title_multi_word(self, pg_conn_with_catalog):
+        """Multi-word Title query matches when all words present."""
+        conn = pg_conn_with_catalog
+        insert_object(conn, zoid=381)
+        catalog_object(
+            conn,
+            zoid=381,
+            path="/plone/doc",
+            idx={"portal_type": "Document", "Title": "The Quick Brown Fox"},
+        )
+        conn.commit()
+
+        zoids = _query_zoids(conn, {"Title": "quick fox"})
+        assert 381 in zoids
+
+    def test_title_no_match(self, pg_conn_with_catalog):
+        """Title query with non-matching word returns nothing."""
+        conn = pg_conn_with_catalog
+        insert_object(conn, zoid=382)
+        catalog_object(
+            conn,
+            zoid=382,
+            path="/plone/doc",
+            idx={"portal_type": "Document", "Title": "Hello World"},
+        )
+        conn.commit()
+
+        zoids = _query_zoids(conn, {"Title": "Nonexistent"})
+        assert 382 not in zoids
+
+    def test_title_case_insensitive(self, pg_conn_with_catalog):
+        """tsvector 'simple' config lowercases tokens — case insensitive."""
+        conn = pg_conn_with_catalog
+        insert_object(conn, zoid=383)
+        catalog_object(
+            conn,
+            zoid=383,
+            path="/plone/doc",
+            idx={"portal_type": "Document", "Title": "UPPERCASE TITLE"},
+        )
+        conn.commit()
+
+        zoids = _query_zoids(conn, {"Title": "uppercase"})
+        assert 383 in zoids
+
+
+class TestDescriptionTextSearch:
+    def test_description_word_match(self, pg_conn_with_catalog):
+        """Description query uses tsvector matching for word search."""
+        conn = pg_conn_with_catalog
+        insert_object(conn, zoid=390)
+        catalog_object(
+            conn,
+            zoid=390,
+            path="/plone/doc",
+            idx={
+                "portal_type": "Document",
+                "Description": "A comprehensive overview of the system",
+            },
+        )
+        conn.commit()
+
+        zoids = _query_zoids(conn, {"Description": "comprehensive"})
+        assert 390 in zoids
+
+    def test_description_no_match(self, pg_conn_with_catalog):
+        conn = pg_conn_with_catalog
+        insert_object(conn, zoid=391)
+        catalog_object(
+            conn,
+            zoid=391,
+            path="/plone/doc",
+            idx={
+                "portal_type": "Document",
+                "Description": "A simple description",
+            },
+        )
+        conn.commit()
+
+        zoids = _query_zoids(conn, {"Description": "nonexistent"})
+        assert 391 not in zoids
+
+
+# ---------------------------------------------------------------------------
+# SQL function: pgcatalog_lang_to_regconfig
+# ---------------------------------------------------------------------------
+
+
+class TestLangToRegconfigFunction:
+    def test_german(self, pg_conn_with_catalog):
+        conn = pg_conn_with_catalog
+        with conn.cursor() as cur:
+            cur.execute("SELECT pgcatalog_lang_to_regconfig('de')")
+            assert cur.fetchone()["pgcatalog_lang_to_regconfig"] == "german"
+
+    def test_english(self, pg_conn_with_catalog):
+        conn = pg_conn_with_catalog
+        with conn.cursor() as cur:
+            cur.execute("SELECT pgcatalog_lang_to_regconfig('en')")
+            assert cur.fetchone()["pgcatalog_lang_to_regconfig"] == "english"
+
+    def test_locale_variant(self, pg_conn_with_catalog):
+        conn = pg_conn_with_catalog
+        with conn.cursor() as cur:
+            cur.execute("SELECT pgcatalog_lang_to_regconfig('en-us')")
+            assert cur.fetchone()["pgcatalog_lang_to_regconfig"] == "english"
+
+    def test_underscore_variant(self, pg_conn_with_catalog):
+        conn = pg_conn_with_catalog
+        with conn.cursor() as cur:
+            cur.execute("SELECT pgcatalog_lang_to_regconfig('pt_BR')")
+            assert cur.fetchone()["pgcatalog_lang_to_regconfig"] == "portuguese"
+
+    def test_unknown_returns_simple(self, pg_conn_with_catalog):
+        conn = pg_conn_with_catalog
+        with conn.cursor() as cur:
+            cur.execute("SELECT pgcatalog_lang_to_regconfig('xx')")
+            assert cur.fetchone()["pgcatalog_lang_to_regconfig"] == "simple"
+
+    def test_empty_returns_simple(self, pg_conn_with_catalog):
+        conn = pg_conn_with_catalog
+        with conn.cursor() as cur:
+            cur.execute("SELECT pgcatalog_lang_to_regconfig('')")
+            assert cur.fetchone()["pgcatalog_lang_to_regconfig"] == "simple"
+
+    def test_null_returns_simple(self, pg_conn_with_catalog):
+        conn = pg_conn_with_catalog
+        with conn.cursor() as cur:
+            cur.execute("SELECT pgcatalog_lang_to_regconfig(NULL)")
+            assert cur.fetchone()["pgcatalog_lang_to_regconfig"] == "simple"

--- a/tests/test_query_integration.py
+++ b/tests/test_query_integration.py
@@ -318,6 +318,32 @@ class TestSearchableTextIntegration:
 
 
 # ---------------------------------------------------------------------------
+# Title / Description text search (tsvector expression on idx JSONB)
+# ---------------------------------------------------------------------------
+
+
+class TestTitleTextSearchIntegration:
+    def test_title_word_match(self, pg_conn_with_catalog):
+        """Title="Hello" matches Title="Hello World" (word-level match)."""
+        conn = pg_conn_with_catalog
+        _setup_test_data(conn)
+        zoids = _query_zoids(conn, {"Title": "Hello"})
+        assert 100 in zoids  # Title="Hello World"
+
+    def test_title_combined_with_portal_type(self, pg_conn_with_catalog):
+        conn = pg_conn_with_catalog
+        _setup_test_data(conn)
+        zoids = _query_zoids(conn, {"Title": "Hello", "portal_type": "Document"})
+        assert 100 in zoids
+
+    def test_title_no_match(self, pg_conn_with_catalog):
+        conn = pg_conn_with_catalog
+        _setup_test_data(conn)
+        zoids = _query_zoids(conn, {"Title": "Nonexistent"})
+        assert zoids == []
+
+
+# ---------------------------------------------------------------------------
 # Path queries
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **Language-aware SearchableText**: per-object `Language` field maps to PG regconfig via `pgcatalog_lang_to_regconfig()` (30 languages, falls back to `'simple'`). Stemming at both write and query time.
- **Title/Description text search fixed**: queries now use `to_tsvector`/`plainto_tsquery` word-level matching instead of broken JSONB exact containment. `catalog(Title="Hello")` correctly matches `"Hello World"`.
- **Automatic addon ZCTextIndex support**: addon-registered ZCTextIndex fields auto-discovered at startup, GIN expression indexes created dynamically by `_ensure_text_indexes()`, zero addon code needed.

## Changes

| File | Change |
|---|---|
| `schema.py` | `pgcatalog_lang_to_regconfig()` PL/pgSQL function, Title/Description GIN expression indexes |
| `columns.py` | Python `language_to_regconfig()` mirror |
| `query.py` | Rewritten `_handle_text()` with SearchableText (language-aware) and idx JSONB (tsvector expression) branches |
| `config.py` | Language-aware ExtraColumn, `_ensure_text_indexes()` |
| tests | 37 new tests (language stemming, Title/Description word search, SQL function, Python mirror) |
| docs | ARCHITECTURE.md, README.md, CHANGES.md updated |

## Test plan

- [x] All 550 tests pass (`pytest tests/`)
- [ ] Manual: `catalog(Title="Hello")` matches "Hello World"
- [ ] Manual: `catalog(SearchableText="Katze", Language="de")` matches "Die Katzen spielen"
- [ ] Verify GIN indexes: `\di idx_os_cat_*_tsv`
- [ ] Verify function: `SELECT pgcatalog_lang_to_regconfig('de')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)