### PR TITLE
Promote uniqueValuesFor() to supported API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.0b12 (unreleased)
+
+### Changed
+
+- `uniqueValuesFor(name)` is now a supported API (no longer deprecated).
+  It delegates to `catalog.Indexes[name].uniqueValues()`.
+
 ## 1.0.0b10
 
 ### Changed

--- a/docs/sources/explanation/architecture.md
+++ b/docs/sources/explanation/architecture.md
@@ -318,5 +318,5 @@ with PG-backed implementations:
 - **Blocked methods**: ZCatalog methods that would return wrong/empty data
   (`getAllBrains`, `searchAll`, `getobject`, etc.) raise `NotImplementedError`.
 
-- **Deprecated proxies**: `search()` and `uniqueValuesFor()` emit
-  `DeprecationWarning` and delegate to their PG-backed equivalents.
+- **Deprecated proxy**: `search()` emits `DeprecationWarning` and
+  delegates to `searchResults()`.

--- a/docs/sources/llms.txt
+++ b/docs/sources/llms.txt
@@ -135,7 +135,6 @@ getIndexDataForUID, index_objects.
 
 **Deprecated methods** (emit DeprecationWarning):
 - `search()` → use `searchResults()`
-- `uniqueValuesFor(name)` → use `catalog.Indexes[name].uniqueValues()`
 
 **Brain attribute resolution**:
 - Known index/metadata fields → returns None if missing from idx JSONB

--- a/docs/sources/reference/permissions.md
+++ b/docs/sources/reference/permissions.md
@@ -21,7 +21,7 @@ Default roles: **Anonymous**, **Manager**
 | `getpath(rid)` | Path for record ID (ZOID) |
 | `getrid(path)` | Record ID for path |
 | `getIndexDataForRID(rid)` | `idx` JSONB for record |
-| `uniqueValuesFor(name)` | Deprecated proxy |
+| `uniqueValuesFor(name)` | Unique values for an index |
 | `search(*args, **kw)` | Deprecated proxy |
 | `all_meta_types()` | Available index types |
 | `getAllBrains()` | Blocked (NotImplementedError) |

--- a/docs/sources/reference/zcatalog-compat.md
+++ b/docs/sources/reference/zcatalog-compat.md
@@ -29,6 +29,7 @@ These methods behave identically to their ZCatalog counterparts:
 | `delIndex(name)` | Manage ZCatalogIndex Entries | Remove an index |
 | `addColumn(name)` | Manage ZCatalogIndex Entries | Register a metadata column |
 | `delColumn(name)` | Manage ZCatalogIndex Entries | Remove a metadata column |
+| `uniqueValuesFor(name)` | Search ZCatalog | Unique values for an index |
 | `getIndexObjects()` | Manage ZCatalogIndex Entries | List of index objects |
 
 ## Blocked Methods
@@ -56,7 +57,6 @@ These methods work but emit `DeprecationWarning`:
 | Method | Replacement |
 |---|---|
 | `search(*args, **kw)` | `searchResults(*args, **kw)` |
-| `uniqueValuesFor(name)` | `catalog.Indexes[name].uniqueValues()` |
 
 ## _CatalogCompat Shim
 

--- a/src/plone/pgcatalog/catalog.py
+++ b/src/plone/pgcatalog/catalog.py
@@ -573,6 +573,10 @@ class PlonePGCatalogTool(UniqueObject, Folder):
                 URL1 + "/manage_catalogAdvanced?manage_tabs_message=Catalog+cleared."
             )
 
+    def uniqueValuesFor(self, name):
+        """Return unique values for the given index name."""
+        return tuple(self.Indexes._getOb(name).uniqueValues())
+
     # -- Deprecated proxy methods -------------------------------------------
 
     def search(self, *args, **kw):
@@ -583,16 +587,6 @@ class PlonePGCatalogTool(UniqueObject, Folder):
             stacklevel=2,
         )
         return self.searchResults(*args, **kw)
-
-    def uniqueValuesFor(self, name):
-        """Deprecated: use catalog.Indexes[name].uniqueValues() instead."""
-        warnings.warn(
-            "portal_catalog.uniqueValuesFor() is deprecated, "
-            "use catalog.Indexes[name].uniqueValues() instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return tuple(self.Indexes._getOb(name).uniqueValues())
 
     @contextmanager
     def _pg_connection(self):

--- a/tests/test_clean_break.py
+++ b/tests/test_clean_break.py
@@ -256,7 +256,7 @@ class TestAllowedRolesAndUsers:
 
 
 class TestDeprecatedProxies:
-    """Test search() and uniqueValuesFor() deprecation warnings."""
+    """Test that deprecated proxy methods emit warnings."""
 
     def test_search_emits_deprecation_warning(self, tool):
         # Patch searchResults to avoid needing a real PG connection
@@ -273,7 +273,16 @@ class TestDeprecatedProxies:
         assert "searchResults()" in str(w[0].message)
         assert len(called) == 1  # proxied to searchResults
 
-    def test_uniquevaluesfor_emits_deprecation_warning(self, tool, pg_conn):
+
+# ---------------------------------------------------------------------------
+# uniqueValuesFor — supported API
+# ---------------------------------------------------------------------------
+
+
+class TestUniqueValuesFor:
+    """Test uniqueValuesFor() as a supported catalog API."""
+
+    def test_uniquevaluesfor_returns_unique_values(self, tool, pg_conn):
         # Set up a mock index via _catalog.indexes
         class _FakeIndex:
             def __init__(self):
@@ -301,9 +310,8 @@ class TestDeprecatedProxies:
                 warnings.simplefilter("always")
                 result = tool.uniqueValuesFor("portal_type")
 
-            assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
-            assert "uniqueValuesFor()" in str(w[0].message)
+            # No deprecation warning — uniqueValuesFor is a supported API
+            assert len(w) == 0
             assert set(result) == {"Document", "Folder"}
         finally:
             tool.Indexes.__class__._getOb = original_getOb


### PR DESCRIPTION
## Summary

- Remove `DeprecationWarning` from `uniqueValuesFor()` — community feedback confirms this is an important API
- Move method out of the "Deprecated proxy methods" section in `catalog.py` into the regular supported API section
- Move test into its own `TestUniqueValuesFor` class (out of `TestDeprecatedProxies`)
- Update all 5 doc files (zcatalog-compat, permissions, architecture, llms.txt) to reflect supported status
- Add CHANGES.md entry for 1.0.0b12

## Test plan

- [x] All 93 clean-break tests pass
- [x] Pre-commit hooks pass (ruff, ruff-format, trailing whitespace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)