### PR TITLE
feat: reindexIndex re-extracts from ZODB + ZMI button (#43)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.0.0b25
+
+### Fixed
+
+- `reindexIndex(name)` now re-extracts index values from ZODB objects
+  instead of reshuffling existing JSONB values. Iterates all cataloged
+  paths, loads via `unrestrictedTraverse`, extracts the requested index,
+  and writes a JSONB merge update. Batched commits for memory. Fixes #43.
+
+### Added
+
+- ZMI [reindex] button per index on the Indexes & Metadata tab with
+  confirmation dialog. Calls new `manage_reindexIndex` endpoint.
+
 ## 1.0.0b24
 
 ### Changed

--- a/src/plone/pgcatalog/catalog.py
+++ b/src/plone/pgcatalog/catalog.py
@@ -43,7 +43,6 @@ from plone.pgcatalog.maintenance import _CatalogCompat
 from plone.pgcatalog.maintenance import _make_unsupported
 from plone.pgcatalog.maintenance import _UNSUPPORTED
 from plone.pgcatalog.maintenance import clear_catalog_data
-from plone.pgcatalog.maintenance import reindex_index
 from plone.pgcatalog.pending import _get_pending
 from plone.pgcatalog.pending import _local
 from plone.pgcatalog.pending import set_partial_pending
@@ -164,6 +163,7 @@ class PlonePGCatalogTool(UniqueObject, Folder):
     security.declareProtected(
         manage_zcatalog_entries, "manage_catalogIndexesAndMetadata"
     )
+    security.declareProtected(manage_zcatalog_entries, "manage_reindexIndex")
     security.declareProtected(manage_zcatalog_entries, "manage_get_catalog_summary")
     security.declareProtected(manage_zcatalog_entries, "manage_get_catalog_objects")
     security.declareProtected(manage_zcatalog_entries, "manage_get_object_detail")
@@ -817,15 +817,64 @@ class PlonePGCatalogTool(UniqueObject, Folder):
         return count
 
     def reindexIndex(self, name, REQUEST=None, pghandler=None):
-        """Re-apply a specific idx key across all cataloged objects.
+        """Re-extract a specific index from all cataloged ZODB objects.
+
+        Iterates all cataloged paths, loads each object via
+        ``unrestrictedTraverse``, extracts the requested index value,
+        and writes a JSONB merge update.  Commits every
+        ``_REBUILD_BATCH`` objects to keep memory flat.
 
         ``pghandler`` is accepted for ZCatalog API compatibility
-        (used by ``manage_reindexIndex`` and plone.distribution)
-        but ignored — PG-based reindexing is fast enough without
-        progress reporting.
+        but ignored.
         """
-        with self._pg_connection() as conn:
-            return reindex_index(conn, name)
+        jar = self._p_jar
+        if jar is None:
+            return 0
+
+        # Get all cataloged paths
+        pool = get_pool(self)
+        pg_conn = pool.getconn()
+        try:
+            with pg_conn.cursor() as cur:
+                cur.execute(
+                    "SELECT path FROM object_state "
+                    "WHERE path IS NOT NULL AND idx IS NOT NULL "
+                    "ORDER BY zoid"
+                )
+                all_paths = [row["path"] for row in cur.fetchall()]
+        finally:
+            pool.putconn(pg_conn)
+
+        count = 0
+        for path in all_paths:
+            try:
+                obj = self.unrestrictedTraverse(path, None)
+            except Exception:
+                continue
+            if obj is None:
+                continue
+
+            if self._partial_reindex(obj, [name]):
+                count += 1
+                if count % _REBUILD_BATCH == 0:
+                    _commit_and_minimize(jar)
+                    log.info("reindexIndex(%r): %d objects re-indexed", name, count)
+
+        if count > 0:
+            _commit_and_minimize(jar)
+        log.info("reindexIndex(%r): %d objects re-indexed total", name, count)
+        return count
+
+    def manage_reindexIndex(self, name, REQUEST=None):
+        """ZMI action: re-extract a specific index from all objects."""
+        count = self.reindexIndex(name)
+        if REQUEST is not None:
+            msg = f"Re-indexed+{count}+objects+for+index+{name}"
+            REQUEST.RESPONSE.redirect(
+                f"{self.absolute_url()}/manage_catalogIndexesAndMetadata"
+                f"?manage_tabs_message={msg}"
+            )
+        return count
 
     def clearFindAndRebuild(self):
         """Clear all catalog data and rebuild from content objects.

--- a/src/plone/pgcatalog/www/catalogIndexesAndMetadata.dtml
+++ b/src/plone/pgcatalog/www/catalogIndexesAndMetadata.dtml
@@ -22,8 +22,9 @@
         <tr>
           <th scope="col" style="width:22%">Name</th>
           <th scope="col" style="width:16%">Index Type</th>
-          <th scope="col" style="width:38%">PG Storage</th>
-          <th scope="col" style="width:24%">Source Attributes</th>
+          <th scope="col" style="width:32%">PG Storage</th>
+          <th scope="col" style="width:20%">Source Attributes</th>
+          <th scope="col" style="width:10%"></th>
         </tr>
       </thead>
       <tbody>
@@ -45,6 +46,11 @@
           </td>
           <td class="text-muted">
             <small><dtml-var "idx['source_attrs']" html_quote></small>
+          </td>
+          <td class="text-right">
+            <a href="manage_reindexIndex?name=<dtml-var "idx['name']" url_quote>"
+               class="btn btn-sm btn-outline-secondary"
+               onclick="return confirm('Re-extract \'' + '<dtml-var "idx['name']" html_quote>' + '\' from all cataloged objects?\n\nThis may take a while on large sites.')">reindex</a>
           </td>
         </tr>
         </dtml-let>

--- a/tests/test_catalog_plone.py
+++ b/tests/test_catalog_plone.py
@@ -766,47 +766,44 @@ class TestMaintenanceMethods:
             # Should not raise TypeError
             tool.refreshCatalog(clear=1, pghandler=mock.Mock())
 
-    def test_reindexIndex(self):
+    def test_reindexIndex_extracts_from_zodb(self):
+        """reindexIndex loads objects and calls _partial_reindex."""
         tool = PlonePGCatalogTool.__new__(PlonePGCatalogTool)
-        mock_conn = mock.Mock()
+        tool._p_jar = mock.Mock()
+        content_obj = mock.Mock()
+
+        mock_pool, _, _ = self._mock_rebuild_pool(["/Plone/doc1", "/Plone/doc2"])
+
         with (
+            mock.patch("plone.pgcatalog.catalog.get_pool", return_value=mock_pool),
             mock.patch.object(
-                PlonePGCatalogTool, "_pg_connection", _mock_pg_connection(mock_conn)
+                PlonePGCatalogTool,
+                "unrestrictedTraverse",
+                return_value=content_obj,
             ),
-            mock.patch(
-                "plone.pgcatalog.catalog.reindex_index", return_value=3
-            ) as reindex_mock,
+            mock.patch.object(
+                PlonePGCatalogTool, "_partial_reindex", return_value=True
+            ) as partial_mock,
         ):
             result = tool.reindexIndex("portal_type")
-            assert result == 3
-            reindex_mock.assert_called_once_with(mock_conn, "portal_type")
+            assert result == 2
+            partial_mock.assert_any_call(content_obj, ["portal_type"])
 
     def test_reindexIndex_accepts_pghandler(self):
         """reindexIndex accepts pghandler kwarg (ZCatalog compat)."""
         tool = PlonePGCatalogTool.__new__(PlonePGCatalogTool)
-        mock_conn = mock.Mock()
-        with (
-            mock.patch.object(
-                PlonePGCatalogTool, "_pg_connection", _mock_pg_connection(mock_conn)
-            ),
-            mock.patch("plone.pgcatalog.catalog.reindex_index", return_value=0),
-        ):
+        tool._p_jar = mock.Mock()
+        mock_pool, _, _ = self._mock_rebuild_pool([])
+
+        with mock.patch("plone.pgcatalog.catalog.get_pool", return_value=mock_pool):
             # Should not raise TypeError
             tool.reindexIndex("portal_type", None, pghandler=mock.Mock())
 
-    def test_reindexIndex_three_positional_args(self):
-        """reindexIndex accepts 3 positional args (manage_reindexIndex compat)."""
+    def test_reindexIndex_no_jar(self):
+        """reindexIndex returns 0 when _p_jar is None."""
         tool = PlonePGCatalogTool.__new__(PlonePGCatalogTool)
-        mock_conn = mock.Mock()
-        handler = mock.Mock()
-        with (
-            mock.patch.object(
-                PlonePGCatalogTool, "_pg_connection", _mock_pg_connection(mock_conn)
-            ),
-            mock.patch("plone.pgcatalog.catalog.reindex_index", return_value=0),
-        ):
-            # Should not raise TypeError — ZMI calls with 3 positional args
-            tool.reindexIndex("portal_type", None, handler)
+        tool._p_jar = None
+        assert tool.reindexIndex("portal_type") == 0
 
     def _mock_rebuild_pool(self, paths):
         """Create a mock pool + cursor returning given paths.


### PR DESCRIPTION
## Summary

Fixes https://github.com/bluedynamics/plone-pgcatalog/issues/43

`reindexIndex(name)` now actually re-extracts the index value from ZODB objects (like ZCatalog does), instead of just reshuffling existing JSONB values.

### Backend
- Iterates all cataloged paths from `object_state`
- Loads each object via `unrestrictedTraverse` (acquisition-wrapped)
- Calls `_partial_reindex(obj, [name])` for a lightweight JSONB merge update
- Batched commits every 500 objects for flat memory
- New `manage_reindexIndex(name)` ZMI endpoint

### ZMI
- [reindex] button per index row on the Indexes & Metadata tab
- `confirm()` dialog: "Re-extract 'portal_type' from all cataloged objects? This may take a while on large sites."
- Redirects back with status message

## Test plan
- [x] 93 unit tests pass (3 updated for new implementation)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)