### PR TITLE
feat: ZMI confirmation dialogs for catalog maintenance (#44)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@
 - ZMI [reindex] button per index on the Indexes & Metadata tab with
   confirmation dialog. Calls new `manage_reindexIndex` endpoint.
 
+- ZMI: confirmation dialogs on Advanced tab for "Update Catalog" and
+  "Clear and Rebuild" buttons. Warns that operations may take a while
+  and that Clear and Rebuild destroys catalog data temporarily.
+  Fixes #44.
+
 ## 1.0.0b24
 
 ### Changed

--- a/src/plone/pgcatalog/www/catalogAdvanced.dtml
+++ b/src/plone/pgcatalog/www/catalogAdvanced.dtml
@@ -17,7 +17,8 @@
       </div>
       <form action="&dtml-URL1;" class="ml-3">
         <button class="btn btn-sm btn-primary" type="submit"
-                name="manage_catalogReindex:method" value="Update">
+                name="manage_catalogReindex:method" value="Update"
+                onclick="return confirm('Re-index all currently cataloged objects?\n\nThis may take a while on large sites.')">
           Update Catalog
         </button>
       </form>
@@ -34,7 +35,8 @@
       </div>
       <form action="&dtml-URL1;" class="ml-3">
         <button class="btn btn-sm btn-warning" type="submit"
-                name="manage_catalogRebuild:method" value="Rebuild">
+                name="manage_catalogRebuild:method" value="Rebuild"
+                onclick="return confirm('This will DELETE all catalog data and rebuild from scratch.\n\nSearch will not work until the rebuild completes.\nOn large sites this can take hours.\n\nContinue?')">
           Clear and Rebuild
         </button>
       </form>


### PR DESCRIPTION
## Summary

Fixes https://github.com/bluedynamics/plone-pgcatalog/issues/44

Adds `confirm()` dialogs to the Advanced tab buttons:

- **Update Catalog**: "Re-index all currently cataloged objects? This may take a while on large sites."
- **Clear and Rebuild**: "This will DELETE all catalog data and rebuild from scratch. Search will not work until the rebuild completes. On large sites this can take hours. Continue?"

DTML-only change, no Python code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)