### PR TITLE
feat: ZMI Tika status card on Advanced tab (#47)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.0b26
+
+### Added
+
+- ZMI: Tika status card on the Advanced tab showing URL, worker mode,
+  configured content types, extraction queue stats (pending/processing/
+  done/failed), and IFile transform override status. Fixes #47.
+
 ## 1.0.0b25
 
 ### Fixed

--- a/src/plone/pgcatalog/catalog.py
+++ b/src/plone/pgcatalog/catalog.py
@@ -164,6 +164,7 @@ class PlonePGCatalogTool(UniqueObject, Folder):
         manage_zcatalog_entries, "manage_catalogIndexesAndMetadata"
     )
     security.declareProtected(manage_zcatalog_entries, "manage_reindexIndex")
+    security.declareProtected(manage_zcatalog_entries, "manage_get_tika_status")
     security.declareProtected(manage_zcatalog_entries, "manage_get_catalog_summary")
     security.declareProtected(manage_zcatalog_entries, "manage_get_catalog_objects")
     security.declareProtected(manage_zcatalog_entries, "manage_get_object_detail")
@@ -1002,6 +1003,53 @@ class PlonePGCatalogTool(UniqueObject, Folder):
             "backend_name": "BM25" if has_bm25 else "Tsvector",
             "has_bm25": has_bm25,
             "bm25_languages": list(getattr(backend, "languages", [])),
+        }
+
+    def manage_get_tika_status(self):
+        """Return Tika extraction status dict for the Advanced tab."""
+        import os
+
+        tika_url = os.environ.get("PGCATALOG_TIKA_URL", "").strip()
+        if not tika_url:
+            return {"enabled": False}
+
+        tika_inprocess = os.environ.get("PGCATALOG_TIKA_INPROCESS", "").strip().lower()
+        worker_mode = (
+            "in-process thread"
+            if tika_inprocess in ("1", "true", "yes")
+            else "external worker"
+        )
+
+        from plone.pgcatalog.processor import TIKA_CONTENT_TYPES
+
+        # Queue stats
+        queue_stats = {}
+        try:
+            pool = get_pool(self)
+            pg_conn = pool.getconn()
+            try:
+                with pg_conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT status, COUNT(*) AS cnt "
+                        "FROM text_extraction_queue "
+                        "GROUP BY status"
+                    )
+                    for row in cur.fetchall():
+                        queue_stats[row["status"]] = row["cnt"]
+            finally:
+                pool.putconn(pg_conn)
+        except Exception:
+            pass
+
+        return {
+            "enabled": True,
+            "tika_url": tika_url,
+            "worker_mode": worker_mode,
+            "content_types": sorted(TIKA_CONTENT_TYPES),
+            "queue_pending": queue_stats.get("pending", 0),
+            "queue_processing": queue_stats.get("processing", 0),
+            "queue_done": queue_stats.get("done", 0),
+            "queue_failed": queue_stats.get("failed", 0),
         }
 
     def manage_get_catalog_objects(self, batch_start=0, filterpath=""):

--- a/src/plone/pgcatalog/www/catalogAdvanced.dtml
+++ b/src/plone/pgcatalog/www/catalogAdvanced.dtml
@@ -44,6 +44,63 @@
   </div>
 </div>
 
+<dtml-let tika="manage_get_tika_status()">
+
+<div class="card mb-3">
+  <div class="card-header d-flex justify-content-between align-items-center">
+    <strong>Tika Text Extraction</strong>
+    <dtml-if "tika['enabled']">
+      <span class="badge badge-success">enabled</span>
+    <dtml-else>
+      <span class="badge badge-secondary">not configured</span>
+    </dtml-if>
+  </div>
+  <dtml-if "tika['enabled']">
+  <div class="card-body p-3">
+    <table class="table table-sm table-borderless mb-0">
+      <tbody>
+        <tr>
+          <td class="text-muted" style="width:30%">Tika URL</td>
+          <td><code><dtml-var "tika['tika_url']" html_quote></code></td>
+        </tr>
+        <tr>
+          <td class="text-muted">Worker mode</td>
+          <td><dtml-var "tika['worker_mode']" html_quote></td>
+        </tr>
+        <tr>
+          <td class="text-muted">Content types</td>
+          <td><small><dtml-var "', '.join(tika['content_types'])" html_quote></small></td>
+        </tr>
+        <tr>
+          <td class="text-muted">Queue</td>
+          <td>
+            <span class="badge badge-warning"><dtml-var "tika['queue_pending']"> pending</span>
+            <span class="badge badge-info"><dtml-var "tika['queue_processing']"> processing</span>
+            <span class="badge badge-success"><dtml-var "tika['queue_done']"> done</span>
+            <dtml-if "tika['queue_failed']">
+              <span class="badge badge-danger"><dtml-var "tika['queue_failed']"> failed</span>
+            </dtml-if>
+          </td>
+        </tr>
+        <tr>
+          <td class="text-muted">IFile transforms</td>
+          <td>skipped (Tika handles blob text async)</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <dtml-else>
+  <div class="card-body p-3">
+    <p class="text-muted small mb-0">
+      Set <code>PGCATALOG_TIKA_URL</code> to enable async text extraction
+      from PDF, Office, and image files via Apache Tika.
+    </p>
+  </div>
+  </dtml-if>
+</div>
+
+</dtml-let>
+
 </main>
 
 <dtml-var manage_page_footer>


### PR DESCRIPTION
## Summary

Fixes https://github.com/bluedynamics/plone-pgcatalog/issues/47

Adds a Tika status card to the ZMI Advanced tab showing:

- **Tika URL** and enabled/disabled badge
- **Worker mode:** in-process thread or external worker
- **Content types:** all configured MIME types for extraction
- **Queue stats:** pending / processing / done / failed badges from `text_extraction_queue`
- **IFile transforms:** status note that transforms are skipped when Tika is active

When `PGCATALOG_TIKA_URL` is not set, shows a hint about how to enable it.

## Test plan
- [x] 93 unit tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)