### PR TITLE
Re-add Python 3.14 to CI, upgrade to Plone 6.2 constraints

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14"]
 
     services:
       postgres:
@@ -68,7 +68,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv venv
-          uv pip install -c https://dist.plone.org/release/6.1-latest/constraints.txt -e ".[test]"
+          uv pip install -c https://dist.plone.org/release/6.2-latest/constraints.txt -e ".[test]"
 
       - name: Run tests with coverage
         run: uv run pytest --cov --cov-report=
@@ -101,7 +101,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv venv
-          uv pip install -c https://dist.plone.org/release/6.1-latest/constraints.txt -e ".[test]"
+          uv pip install -c https://dist.plone.org/release/6.2-latest/constraints.txt -e ".[test]"
 
       - uses: actions/download-artifact@v5
         with:

--- a/development/requirements.txt
+++ b/development/requirements.txt
@@ -1,4 +1,4 @@
--c https://dist.plone.org/release/6.1-latest/constraints.txt
--r https://dist.plone.org/release/6.1-latest/requirements.txt
+-c https://dist.plone.org/release/6.2-latest/constraints.txt
+-r https://dist.plone.org/release/6.2-latest/requirements.txt
 Plone
 -e .


### PR DESCRIPTION
## Summary

- Re-add Python 3.14 to the CI test matrix (removed in #31 due to zodbpickle build failure)
- Switch constraints from Plone 6.1-latest to 6.2-latest

## Why

Plone 6.1-latest pins `zodbpickle==4.1.1` which doesn't compile on Python 3.14.
Plone 6.2-latest (rc1 released) pins `zodbpickle==4.3` which ships cp314 wheels.

Closes #32

🤖 Generated with [Claude Code](https://claude.ai/code)