### PR TITLE
fix: Slow Queries tab KeyError when PGCATALOG_SLOW_QUERY_MS not set (#58)

### DIFF
--- a/src/plone/pgcatalog/www/catalogSlowQueries.dtml
+++ b/src/plone/pgcatalog/www/catalogSlowQueries.dtml
@@ -9,7 +9,7 @@
   <div class="card-header d-flex justify-content-between align-items-center">
     <strong>Slow Query Patterns</strong>
     <div>
-      <span class="text-muted small mr-2">Threshold: <code><dtml-var "_.getitem('PGCATALOG_SLOW_QUERY_MS', '10')">ms</code></span>
+      <span class="text-muted small mr-2">Threshold: <code><dtml-var "__import__('os').environ.get('PGCATALOG_SLOW_QUERY_MS', '10')">ms</code></span>
       <a href="manage_clear_slow_queries"
          class="btn btn-sm btn-outline-danger"
          onclick="return confirm('Clear all slow query statistics?')">Clear Stats</a>


### PR DESCRIPTION
Fixes https://github.com/bluedynamics/plone-pgcatalog/issues/58

`TemplateDict.getitem(key, call=1)` does not accept a default value. Use `os.environ.get()` instead.

One-line DTML fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)