### PR TITLE
fix: Slow Queries tab Unauthorized due to __import__ in DTML

### DIFF
--- a/src/plone/pgcatalog/catalog.py
+++ b/src/plone/pgcatalog/catalog.py
@@ -195,6 +195,9 @@ class PlonePGCatalogTool(UniqueObject, Folder):
     security.declareProtected(manage_zcatalog_entries, "manage_get_tika_status")
     security.declareProtected(manage_zcatalog_entries, "manage_slowQueries")
     security.declareProtected(manage_zcatalog_entries, "manage_get_slow_query_stats")
+    security.declareProtected(
+        manage_zcatalog_entries, "manage_get_slow_query_threshold"
+    )
     security.declareProtected(manage_zcatalog_entries, "manage_clear_slow_queries")
     security.declareProtected(manage_zcatalog_entries, "manage_get_catalog_summary")
     security.declareProtected(manage_zcatalog_entries, "manage_get_catalog_objects")
@@ -1086,6 +1089,12 @@ class PlonePGCatalogTool(UniqueObject, Folder):
             "queue_done": queue_stats.get("done", 0),
             "queue_failed": queue_stats.get("failed", 0),
         }
+
+    def manage_get_slow_query_threshold(self):
+        """Return the slow query threshold in ms (for ZMI display)."""
+        import os
+
+        return os.environ.get("PGCATALOG_SLOW_QUERY_MS", "10")
 
     def manage_get_slow_query_stats(self):
         """Return aggregated slow query stats for the Slow Queries tab."""

--- a/src/plone/pgcatalog/www/catalogSlowQueries.dtml
+++ b/src/plone/pgcatalog/www/catalogSlowQueries.dtml
@@ -9,7 +9,7 @@
   <div class="card-header d-flex justify-content-between align-items-center">
     <strong>Slow Query Patterns</strong>
     <div>
-      <span class="text-muted small mr-2">Threshold: <code><dtml-var "__import__('os').environ.get('PGCATALOG_SLOW_QUERY_MS', '10')">ms</code></span>
+      <span class="text-muted small mr-2">Threshold: <code><dtml-var "manage_get_slow_query_threshold()">ms</code></span>
       <a href="manage_clear_slow_queries"
          class="btn btn-sm btn-outline-danger"
          onclick="return confirm('Clear all slow query statistics?')">Clear Stats</a>


### PR DESCRIPTION
Zope's restricted Python blocks `__import__('os')` in DTML templates, causing an Unauthorized error rendered as "Insufficient permissions".

Replaced with a proper `manage_get_slow_query_threshold()` method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)