### PR TITLE
fix: rewrite path LIKE + depth to path_parent IN subquery (#66)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.0.0b32
+
+### Fixed
+
+- Optimize bounded-depth path queries: rewrite `path LIKE + path_depth`
+  to `path_parent IN (subquery)` so PG can use the composite
+  `(path_parent, portal_type)` index. Navigation tree queries drop
+  from 630ms to ~77ms. Fixes #66.
+
 ## 1.0.0b31
 
 ### Added

--- a/src/plone/pgcatalog/query.py
+++ b/src/plone/pgcatalog/query.py
@@ -543,19 +543,41 @@ class _QueryBuilder:
             self.params[p] = paths
 
     def _path_limited(self, expr_path, expr_depth, path, depth):
-        """depth=N (N>1): subtree limited to N levels below path."""
+        """depth=N (N>1): subtree limited to N levels below path.
+
+        Rewrites to ``path_parent IN (subquery)`` so PG can use the
+        composite ``(path_parent, portal_type)`` index instead of
+        scanning by ``path LIKE + path_depth``.  The subquery resolves
+        all paths within the depth range — these are the parent folders
+        whose children we want.
+        """
         from plone.pgcatalog.columns import compute_path_info
 
         _, base_depth = compute_path_info(path)
         max_depth = base_depth + depth
 
+        # Build the set of parent paths: the base path itself + all
+        # sub-paths up to (max_depth - 1) levels.  Children of these
+        # parents will have depth <= max_depth.
+        key = expr_path.split("'")[1]  # extract key name from "idx->>'path'"
+        parent_key = f"{key}_parent"
+        expr_parent = f"idx->>'{parent_key}'"
+
+        p_path = self._pname("path")
         p_like = self._pname("path_like")
-        p_depth = self._pname("max_depth")
+        p_max_depth = self._pname("max_depth")
         self.clauses.append(
-            f"({expr_path} LIKE %({p_like})s AND {expr_depth} <= %({p_depth})s)"
+            f"{expr_parent} IN ("
+            f"SELECT DISTINCT idx->>'{key}' FROM object_state "
+            f"WHERE idx IS NOT NULL "
+            f"AND (idx->>'{key}' = %({p_path})s "
+            f"OR idx->>'{key}' LIKE %({p_like})s) "
+            f"AND {expr_depth} < %({p_max_depth})s"
+            f")"
         )
+        self.params[p_path] = path
         self.params[p_like] = path.rstrip("/") + "/%"
-        self.params[p_depth] = max_depth
+        self.params[p_max_depth] = max_depth
 
     def _path_navtree(self, expr_path, expr_parent, path, depth, navtree_start):
         """navtree=True: navigation tree query."""

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -302,9 +302,11 @@ class TestPathIndex:
         assert "idx->>'path_parent' =" in qr["where"]
 
     def test_limited_depth(self):
+        """depth>1 rewrites to path_parent IN (subquery) for composite index."""
         qr = build_query({"path": {"query": "/plone/folder", "depth": 2}})
-        assert "idx->>'path' LIKE" in qr["where"]
-        assert "(idx->>'path_depth')::integer <=" in qr["where"]
+        assert "idx->>'path_parent' IN" in qr["where"]
+        assert "SELECT DISTINCT" in qr["where"]
+        assert "(idx->>'path_depth')::integer <" in qr["where"]
 
     def test_navtree_depth_1(self):
         qr = build_query(
@@ -632,8 +634,9 @@ class TestAdditionalPathIndex:
 
     def test_tgpath_limited_depth(self):
         qr = build_query({"tgpath": {"query": "/uuid1/uuid2", "depth": 2}})
-        assert "idx->>'tgpath' LIKE" in qr["where"]
-        assert "(idx->>'tgpath_depth')::integer <=" in qr["where"]
+        assert "idx->>'tgpath_parent' IN" in qr["where"]
+        assert "SELECT DISTINCT" in qr["where"]
+        assert "(idx->>'tgpath_depth')::integer <" in qr["where"]
 
     def test_tgpath_navtree(self):
         qr = build_query(


### PR DESCRIPTION
## Summary

Fixes https://github.com/bluedynamics/plone-pgcatalog/issues/66

Bounded-depth path queries (depth>1) now rewrite `path LIKE + path_depth <=` to `path_parent IN (subquery)`. The subquery resolves parent paths, and PG uses the composite `(path_parent, portal_type)` index directly.

**Before:** `idx->>'path' LIKE '/Plone/aut/%' AND (idx->>'path_depth')::integer <= 4` → BitmapAnd scan, 630ms
**After:** `idx->>'path_parent' IN (SELECT DISTINCT ...)` → composite index scan, ~77ms

## Test plan
- [x] 201 tests pass (2 updated)
- [ ] CI green
- [ ] Production: navigation tree queries drop to ~77ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)