### PR TITLE
fix: revert path subquery — Nested Loop regression (#68)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.0.0b33
+
+### Fixed
+
+- Revert path_parent IN subquery for bounded-depth queries (#68).
+  The subquery caused Nested Loop plans where PG repeated the
+  `allowed_roles` GIN scan per parent path (615ms). Reverts to
+  `LIKE + path_depth` which uses the `path_depth_type` composite
+  index (85-300ms depending on cache state).
+
 ## 1.0.0b32
 
 ### Fixed

--- a/src/plone/pgcatalog/query.py
+++ b/src/plone/pgcatalog/query.py
@@ -543,41 +543,19 @@ class _QueryBuilder:
             self.params[p] = paths
 
     def _path_limited(self, expr_path, expr_depth, path, depth):
-        """depth=N (N>1): subtree limited to N levels below path.
-
-        Rewrites to ``path_parent IN (subquery)`` so PG can use the
-        composite ``(path_parent, portal_type)`` index instead of
-        scanning by ``path LIKE + path_depth``.  The subquery resolves
-        all paths within the depth range — these are the parent folders
-        whose children we want.
-        """
+        """depth=N (N>1): subtree limited to N levels below path."""
         from plone.pgcatalog.columns import compute_path_info
 
         _, base_depth = compute_path_info(path)
         max_depth = base_depth + depth
 
-        # Build the set of parent paths: the base path itself + all
-        # sub-paths up to (max_depth - 1) levels.  Children of these
-        # parents will have depth <= max_depth.
-        key = expr_path.split("'")[1]  # extract key name from "idx->>'path'"
-        parent_key = f"{key}_parent"
-        expr_parent = f"idx->>'{parent_key}'"
-
-        p_path = self._pname("path")
         p_like = self._pname("path_like")
-        p_max_depth = self._pname("max_depth")
+        p_depth = self._pname("max_depth")
         self.clauses.append(
-            f"{expr_parent} IN ("
-            f"SELECT DISTINCT idx->>'{key}' FROM object_state "
-            f"WHERE idx IS NOT NULL "
-            f"AND (idx->>'{key}' = %({p_path})s "
-            f"OR idx->>'{key}' LIKE %({p_like})s) "
-            f"AND {expr_depth} < %({p_max_depth})s"
-            f")"
+            f"({expr_path} LIKE %({p_like})s AND {expr_depth} <= %({p_depth})s)"
         )
-        self.params[p_path] = path
         self.params[p_like] = path.rstrip("/") + "/%"
-        self.params[p_max_depth] = max_depth
+        self.params[p_depth] = max_depth
 
     def _path_navtree(self, expr_path, expr_parent, path, depth, navtree_start):
         """navtree=True: navigation tree query."""

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -302,11 +302,9 @@ class TestPathIndex:
         assert "idx->>'path_parent' =" in qr["where"]
 
     def test_limited_depth(self):
-        """depth>1 rewrites to path_parent IN (subquery) for composite index."""
         qr = build_query({"path": {"query": "/plone/folder", "depth": 2}})
-        assert "idx->>'path_parent' IN" in qr["where"]
-        assert "SELECT DISTINCT" in qr["where"]
-        assert "(idx->>'path_depth')::integer <" in qr["where"]
+        assert "idx->>'path' LIKE" in qr["where"]
+        assert "(idx->>'path_depth')::integer <=" in qr["where"]
 
     def test_navtree_depth_1(self):
         qr = build_query(
@@ -634,9 +632,8 @@ class TestAdditionalPathIndex:
 
     def test_tgpath_limited_depth(self):
         qr = build_query({"tgpath": {"query": "/uuid1/uuid2", "depth": 2}})
-        assert "idx->>'tgpath_parent' IN" in qr["where"]
-        assert "SELECT DISTINCT" in qr["where"]
-        assert "(idx->>'tgpath_depth')::integer <" in qr["where"]
+        assert "idx->>'tgpath' LIKE" in qr["where"]
+        assert "(idx->>'tgpath_depth')::integer <=" in qr["where"]
 
     def test_tgpath_navtree(self):
         qr = build_query(


### PR DESCRIPTION
## Summary

Fixes https://github.com/bluedynamics/plone-pgcatalog/issues/68

Reverts b32's `path_parent IN (subquery)` optimization which caused a Nested Loop where PG repeated the `allowed_roles` GIN scan per parent path (14ms × 34 = 473ms overhead, total 615ms).

Restores the b31 `LIKE + path_depth` approach which uses the `idx_os_cat_path_depth_type` composite index (85-300ms depending on cache).

### EXPLAIN evidence

| Approach | Plan | Time |
|----------|------|------|
| b32 subquery | Nested Loop (allowed_roles GIN × 34) | **615ms** |
| b31 LIKE+depth | BitmapAnd (allowed_roles + path_depth) | **85-300ms** |
| Without allowed_roles (future) | Index Scan composite | **98ms** |

## Test plan
- [x] 104 query tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)