### PR TITLE
fix: add lock_timeout to startup index creation (#65)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.0.0b37
+
+### Fixed
+
+- Prevent database lockup during rolling deployments (#65).
+  `_ensure_text_indexes()` and `_ensure_field_indexes()` now set
+  `lock_timeout = '5s'` to prevent indefinite blocking on ACCESS
+  EXCLUSIVE locks from concurrent REPEATABLE READ sessions.
+  Log level changed from `error` to `warning` since indexes are
+  retried on next startup.
+
 ## 1.0.0b36
 
 ### Added

--- a/src/plone/pgcatalog/startup.py
+++ b/src/plone/pgcatalog/startup.py
@@ -168,6 +168,7 @@ def _ensure_text_indexes(storage):  # pragma: no cover
         from psycopg import sql as pgsql
 
         with psycopg.connect(dsn, autocommit=True) as conn:
+            conn.execute("SET lock_timeout = '5s'")
             for name, idx_key in text_indexes:
                 validate_identifier(idx_key)
                 idx_name = f"idx_os_cat_{idx_key.lower()}_tsv"
@@ -184,9 +185,11 @@ def _ensure_text_indexes(storage):  # pragma: no cover
                 conn.execute(stmt)
                 log.info("Ensured GIN text index %s for %s", idx_name, name)
     except Exception:
-        log.error(
-            "Failed to create text expression indexes — "
-            "text field queries may be slow until indexes are created",
+        log.warning(
+            "Failed to create text expression indexes "
+            "(lock timeout or other error) — "
+            "text field queries may be slow until indexes are created. "
+            "Indexes will be retried on next startup.",
             exc_info=True,
         )
 
@@ -246,6 +249,7 @@ def _ensure_field_indexes(storage):  # pragma: no cover
         from psycopg import sql as pgsql
 
         with psycopg.connect(dsn, autocommit=True) as conn:
+            conn.execute("SET lock_timeout = '5s'")
             for name, idx_type, idx_key in candidates:
                 validate_identifier(idx_key)
                 idx_name = f"idx_os_cat_{idx_key.lower()}"
@@ -270,9 +274,11 @@ def _ensure_field_indexes(storage):  # pragma: no cover
                     idx_type.value,
                 )
     except Exception:
-        log.error(
-            "Failed to create field expression indexes --- "
-            "custom field queries may be slow until indexes are created",
+        log.warning(
+            "Failed to create field expression indexes "
+            "(lock timeout or other error) --- "
+            "custom field queries may be slow until indexes are created. "
+            "Indexes will be retried on next startup.",
             exc_info=True,
         )
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/bluedynamics/plone-pgcatalog/issues/65 (Phase 1)

During rolling deployments, `_ensure_text_indexes()` and `_ensure_field_indexes()` could block indefinitely waiting for ACCESS EXCLUSIVE locks while old pods held ACCESS SHARE via idle-in-transaction sessions.

Now sets `lock_timeout = '5s'` on both functions. If the lock cannot be acquired, the error is logged as a warning and indexes are retried on next startup.

Companion PR for zodb-pgjsonb: deferred DDL also gets `lock_timeout = '30s'`.

## Test plan
- [x] 225 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)