### PR TITLE
fix: batched allowed_roles backfill (#65 Phase 2)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.0.0b38
+
+### Fixed
+
+- Extract `allowed_roles` backfill from schema DDL into batched startup
+  step (#65 Phase 2). Previously the backfill ran as a single UPDATE
+  on 4.4M rows inside ACCESS EXCLUSIVE, blocking the entire database.
+  Now processes 5000 rows per batch with autocommit and `lock_timeout`.
+  Safe to re-run, idempotent, logs progress.
+
 ## 1.0.0b37
 
 ### Fixed

--- a/src/plone/pgcatalog/schema.py
+++ b/src/plone/pgcatalog/schema.py
@@ -17,13 +17,8 @@ ALTER TABLE object_state ADD COLUMN IF NOT EXISTS searchable_text TSVECTOR;
 
 -- Dedicated column for security filter (used in EVERY query).
 -- Stored as TEXT[] for direct GIN ?| queries without JSONB decompression.
+-- Backfill is done in batches at startup (_backfill_allowed_roles).
 ALTER TABLE object_state ADD COLUMN IF NOT EXISTS allowed_roles TEXT[];
-
--- Backfill from idx JSONB for existing databases (idempotent).
-UPDATE object_state SET allowed_roles = (
-    SELECT array_agg(value::text)
-    FROM jsonb_array_elements_text(idx->'allowedRolesAndUsers')
-) WHERE idx IS NOT NULL AND idx ? 'allowedRolesAndUsers' AND allowed_roles IS NULL;
 """
 
 CATALOG_FUNCTIONS = """\

--- a/src/plone/pgcatalog/startup.py
+++ b/src/plone/pgcatalog/startup.py
@@ -128,6 +128,7 @@ def register_catalog_processor(event):
         _sync_registry_from_db(db)
         _ensure_text_indexes(storage)
         _ensure_field_indexes(storage)
+        _backfill_allowed_roles(storage)
 
         # Install move/rename optimization handlers
         from plone.pgcatalog.move import install_move_handlers
@@ -279,6 +280,78 @@ def _ensure_field_indexes(storage):  # pragma: no cover
             "(lock timeout or other error) --- "
             "custom field queries may be slow until indexes are created. "
             "Indexes will be retried on next startup.",
+            exc_info=True,
+        )
+
+
+_BACKFILL_BATCH = 5000
+
+
+def _backfill_allowed_roles(storage):  # pragma: no cover
+    """Backfill the allowed_roles TEXT[] column from idx JSONB in batches.
+
+    Runs at startup after schema DDL.  Processes rows where
+    ``allowed_roles IS NULL`` but ``idx->'allowedRolesAndUsers'`` exists.
+    Each batch is a small UPDATE with autocommit (short lock, no long
+    transactions).  Safe to re-run (idempotent via IS NULL check).
+    """
+    dsn = getattr(storage, "_dsn", None)
+    if not dsn:
+        return
+
+    try:
+        with psycopg.connect(dsn, autocommit=True) as conn:
+            conn.execute("SET lock_timeout = '5s'")
+
+            # Check if there's anything to backfill
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT COUNT(*) AS cnt FROM object_state "
+                    "WHERE idx IS NOT NULL "
+                    "AND idx ? 'allowedRolesAndUsers' "
+                    "AND allowed_roles IS NULL"
+                )
+                total = cur.fetchone()[0]
+
+            if total == 0:
+                return
+
+            log.info(
+                "Backfilling allowed_roles for %d rows (batch size %d)",
+                total,
+                _BACKFILL_BATCH,
+            )
+
+            done = 0
+            while True:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "UPDATE object_state SET allowed_roles = ("
+                        "  SELECT array_agg(value::text)"
+                        "  FROM jsonb_array_elements_text("
+                        "    idx->'allowedRolesAndUsers')"
+                        ") WHERE zoid IN ("
+                        "  SELECT zoid FROM object_state"
+                        "  WHERE idx IS NOT NULL"
+                        "  AND idx ? 'allowedRolesAndUsers'"
+                        "  AND allowed_roles IS NULL"
+                        "  LIMIT %s"
+                        ")",
+                        (_BACKFILL_BATCH,),
+                    )
+                    updated = cur.rowcount
+
+                if updated == 0:
+                    break
+                done += updated
+                log.info("Backfill allowed_roles: %d / %d rows", done, total)
+
+            log.info("Backfill allowed_roles complete: %d rows", done)
+    except Exception:
+        log.warning(
+            "Failed to backfill allowed_roles "
+            "(lock timeout or other error). "
+            "Will retry on next startup.",
             exc_info=True,
         )
 


### PR DESCRIPTION
## Summary

Phase 2 of https://github.com/bluedynamics/plone-pgcatalog/issues/65

The `allowed_roles` backfill previously ran as a single `UPDATE` on the entire `object_state` table inside the schema DDL (ACCESS EXCLUSIVE lock on 4.4M rows). This blocked the database during rolling deployments.

### Changes

- **schema.py**: Remove backfill UPDATE from `CATALOG_COLUMNS` DDL
- **startup.py**: New `_backfill_allowed_roles()` function that processes 5000 rows per batch with autocommit + `lock_timeout = '5s'`

### How it works

1. Check `COUNT(*) WHERE allowed_roles IS NULL AND idx ? 'allowedRolesAndUsers'`
2. If > 0, process in batches of 5000
3. Each batch: `UPDATE ... WHERE zoid IN (SELECT ... LIMIT 5000)`
4. Autocommit: each batch acquires and releases locks independently
5. Logs progress: "Backfill allowed_roles: 5000 / 137000 rows"
6. Idempotent: `WHERE allowed_roles IS NULL` guard

## Test plan
- [x] 121 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)