### PR TITLE
feat: register prefetch refs expression for cataloged content (#40)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.0.0b41
+
+### Fixed
+
+- Register refs prefetch expression for cataloged content objects.
+  Uses `CASE WHEN idx IS NOT NULL THEN refs END` so only content
+  objects (with catalog data) trigger prefetch. Requires
+  zodb-pgjsonb >= 1.9.2.
+
 ## 1.0.0b40
 
 ### Added

--- a/src/plone/pgcatalog/startup.py
+++ b/src/plone/pgcatalog/startup.py
@@ -130,6 +130,14 @@ def register_catalog_processor(event):
         _ensure_field_indexes(storage)
         _backfill_allowed_roles(storage)
 
+        # Enable refs prefetch for cataloged content objects only.
+        # Non-content objects (BTrees, PersistentMappings, etc.) have
+        # idx IS NULL and won't trigger prefetch.
+        if hasattr(storage, "register_prefetch_refs_expr"):
+            storage.register_prefetch_refs_expr(
+                "CASE WHEN idx IS NOT NULL THEN refs END"
+            )
+
         # Install move/rename optimization handlers
         from plone.pgcatalog.move import install_move_handlers
 


### PR DESCRIPTION
## Summary

Companion to zodb-pgjsonb PR #42.

Registers `CASE WHEN idx IS NOT NULL THEN refs END` on the storage at startup. Only cataloged content objects (137K of 2.6M) trigger refs prefetch. Non-content objects get NULL refs — no prefetch, no extra data read.

Requires zodb-pgjsonb >= 1.9.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)