### PR TITLE
fix: handle Unix epoch floats/ints in ensure_date_param (#82)

### DIFF
--- a/src/plone/pgcatalog/columns.py
+++ b/src/plone/pgcatalog/columns.py
@@ -12,6 +12,7 @@ This keeps query mapping trivial and brain attribute access natural.
 
 from datetime import date
 from datetime import datetime
+from datetime import UTC
 from enum import Enum
 
 import logging
@@ -286,7 +287,8 @@ def ensure_date_param(value):
     """Convert a date-like value to something psycopg can bind as timestamptz.
 
     Handles Python datetime, date, Zope DateTime (duck-typed via
-    asdatetime/ISO8601), and falls back to str().
+    asdatetime/ISO8601), Unix epoch floats/ints (from time.time()),
+    and falls back to str().
     """
     if isinstance(value, datetime):
         return value
@@ -297,6 +299,9 @@ def ensure_date_param(value):
         return value.asdatetime()
     if hasattr(value, "ISO8601"):
         return value.ISO8601()
+    # Unix epoch timestamp (e.g. from time.time())
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(value, tz=UTC)
     return str(value)
 
 

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -160,3 +160,48 @@ class TestLanguageToRegconfig:
     def test_case_insensitive(self):
         assert language_to_regconfig("DE") == "german"
         assert language_to_regconfig("En-US") == "english"
+
+
+class TestEnsureDateParam:
+    """Test ensure_date_param handles various date-like inputs."""
+
+    def test_datetime_passthrough(self):
+        from datetime import datetime
+        from plone.pgcatalog.columns import ensure_date_param
+
+        dt = datetime(2026, 4, 1, 12, 0, tzinfo=UTC)
+        assert ensure_date_param(dt) is dt
+
+    def test_date_to_datetime(self):
+        from datetime import date
+        from datetime import datetime
+        from plone.pgcatalog.columns import ensure_date_param
+
+        d = date(2026, 4, 1)
+        result = ensure_date_param(d)
+        assert isinstance(result, datetime)
+        assert result.year == 2026
+
+    def test_epoch_float(self):
+        from datetime import datetime
+        from plone.pgcatalog.columns import ensure_date_param
+
+        epoch = 1775181821.433933  # a time.time() value
+        result = ensure_date_param(epoch)
+        assert isinstance(result, datetime)
+        assert result.tzinfo == UTC
+
+    def test_epoch_int(self):
+        from datetime import datetime
+        from plone.pgcatalog.columns import ensure_date_param
+
+        epoch = 1775181821
+        result = ensure_date_param(epoch)
+        assert isinstance(result, datetime)
+        assert result.tzinfo == UTC
+
+    def test_string_passthrough(self):
+        from plone.pgcatalog.columns import ensure_date_param
+
+        result = ensure_date_param("2026-04-01T00:00:00+00:00")
+        assert result == "2026-04-01T00:00:00+00:00"


### PR DESCRIPTION
Fixes https://github.com/bluedynamics/plone-pgcatalog/issues/82

`plone.app.textfield` passes `time.time()` floats as date query params. `ensure_date_param` now converts int/float to `datetime.fromtimestamp(value, tz=UTC)` before the `str()` fallback.

5 new tests for ensure_date_param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)