### PR TITLE
fix: ValueError on empty path query

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.0b47
+
+### Fixed
+
+- Fix `ValueError: Invalid path: ''` when path query receives empty
+  string. Empty/blank paths are now silently filtered, matching
+  ZCatalog behavior.
+
 ## 1.0.0b46
 
 ### Fixed

--- a/src/plone/pgcatalog/query.py
+++ b/src/plone/pgcatalog/query.py
@@ -483,6 +483,10 @@ class _QueryBuilder:
         navtree_start = spec.get("navtree_start", 0)
 
         paths = [query_val] if isinstance(query_val, str) else list(query_val)
+        # Filter empty/blank paths — ZCatalog silently ignores them
+        paths = [p for p in paths if p and p.strip()]
+        if not paths:
+            return  # nothing to query
 
         if len(paths) > _MAX_PATHS:
             raise ValueError("Too many paths in query")


### PR DESCRIPTION
## Summary

`lineage.index` (and potentially other addons) passes `path=''` to catalog queries. ZCatalog silently ignores empty paths, but plone.pgcatalog's `_validate_path()` raises `ValueError`. Now filters empty/blank paths before validation.

## Test plan

- [x] Existing tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)