### PR TITLE
feat: extract @meta, object_provides, allowedRolesAndUsers from idx JSONB

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.0.0b48
+
+### Changed
+
+- Extract `@meta`, `object_provides`, and `allowedRolesAndUsers` from
+  `idx` JSONB into dedicated columns via generic `ExtraIdxColumn` mechanism.
+  Reduces `idx` size by ~85% (from ~3.2 KB to ~400 B avg, below TOAST
+  threshold). Run `clear_and_rebuild` after upgrading. (#98)
+- `object_provides` queries now use a dedicated `TEXT[]` column with GIN
+  index instead of JSONB containment.
+- Removed `_backfill_allowed_roles` startup function (superseded by
+  generic extraction mechanism).
+
 ## 1.0.0b47
 
 ### Fixed

--- a/benchmarks/bench_object_provides.sql
+++ b/benchmarks/bench_object_provides.sql
@@ -1,0 +1,237 @@
+-- ============================================================================
+-- Benchmark: object_provides — JSONB GIN vs dedicated TEXT[] GIN
+-- ============================================================================
+--
+-- Compares the old query path (object_provides stored inside idx JSONB,
+-- queried via idx->'object_provides' ?|) against the new path
+-- (dedicated object_provides TEXT[] column, queried via &&).
+--
+-- This script is SAFE to run on a production database:
+--   - It adds a column and index (IF NOT EXISTS, idempotent)
+--   - It does NOT modify existing data or drop existing indexes
+--   - The backfill UPDATE touches only the new column
+--   - Cleanup instructions at the bottom (commented out)
+--
+-- How to run
+-- ----------
+--
+--   1. Connect to the database:
+--
+--        psql "dbname=zodb host=<host> port=5432 user=zodb"
+--
+--   2. Run the full script:
+--
+--        \i benchmarks/bench_object_provides.sql
+--
+--      Or from the shell:
+--
+--        psql "dbname=zodb ..." -f benchmarks/bench_object_provides.sql
+--
+--   3. The script runs in four phases:
+--
+--      a) SETUP    — adds object_provides TEXT[] column, backfills from
+--                    idx JSONB, creates GIN index, runs ANALYZE.
+--                    On 137k cataloged rows this takes ~10-30 seconds.
+--
+--      b) EXPLAIN  — runs EXPLAIN (ANALYZE, BUFFERS) for five query
+--                    patterns, each in both JSONB and TEXT[] variants.
+--                    Compare "Execution Time" and "Buffers" lines.
+--
+--      c) LATENCY  — runs each query 10x without EXPLAIN overhead to
+--                    measure raw throughput.  Compare \timing output.
+--
+--      d) CLEANUP  — instructions to drop the test column + index
+--                    (commented out, run manually if desired).
+--
+--   4. What to look for in the output:
+--
+--      - "Execution Time" in EXPLAIN ANALYZE (lower = better)
+--      - "Buffers: shared hit/read" (fewer = less I/O)
+--      - "\timing" output for the x10 latency queries
+--      - Index size comparison (TEXT[] GIN should be smaller)
+--
+-- ============================================================================
+
+\timing on
+\echo ''
+\echo '================================================================='
+\echo '  Setup: create object_provides TEXT[] column + GIN index'
+\echo '================================================================='
+
+-- Add column (IF NOT EXISTS — safe to re-run)
+ALTER TABLE object_state ADD COLUMN IF NOT EXISTS object_provides TEXT[];
+
+-- Populate from idx JSONB (one-time backfill)
+\echo 'Populating object_provides from idx...'
+UPDATE object_state SET object_provides = (
+    SELECT array_agg(value::text)
+    FROM jsonb_array_elements_text(idx->'object_provides')
+)
+WHERE idx IS NOT NULL
+  AND idx ? 'object_provides'
+  AND object_provides IS NULL;
+
+-- Create GIN index on TEXT[] column
+\echo 'Creating TEXT[] GIN index...'
+CREATE INDEX IF NOT EXISTS idx_os_object_provides
+    ON object_state USING gin (object_provides)
+    WHERE object_provides IS NOT NULL;
+
+ANALYZE object_state;
+
+-- Row counts
+\echo ''
+SELECT
+    COUNT(*) FILTER (WHERE idx IS NOT NULL AND idx ? 'object_provides') AS "rows_with_provides_in_idx",
+    COUNT(*) FILTER (WHERE object_provides IS NOT NULL) AS "rows_with_provides_column"
+FROM object_state;
+
+-- Index sizes
+\echo ''
+\echo 'Index sizes:'
+SELECT indexname, pg_size_pretty(pg_relation_size(indexname::regclass)) AS size
+FROM pg_indexes
+WHERE tablename = 'object_state'
+  AND indexname IN ('idx_os_cat_provides_gin', 'idx_os_object_provides');
+
+\echo ''
+\echo '================================================================='
+\echo '  Benchmark: IContentish (broad — matches most objects)'
+\echo '================================================================='
+
+-- Pick the most common interface
+\echo ''
+\echo '--- OLD: JSONB GIN (idx->''object_provides'' ?|) ---'
+EXPLAIN (ANALYZE, BUFFERS, COSTS)
+SELECT zoid, path
+FROM object_state
+WHERE idx->'object_provides' ?| ARRAY['Products.CMFCore.interfaces._content.IContentish'];
+
+\echo ''
+\echo '--- NEW: TEXT[] GIN (object_provides &&) ---'
+EXPLAIN (ANALYZE, BUFFERS, COSTS)
+SELECT zoid, path
+FROM object_state
+WHERE object_provides && ARRAY['Products.CMFCore.interfaces._content.IContentish'];
+
+\echo ''
+\echo '================================================================='
+\echo '  Benchmark: IDocument (selective — ~60% of objects)'
+\echo '================================================================='
+
+\echo ''
+\echo '--- OLD: JSONB GIN ---'
+EXPLAIN (ANALYZE, BUFFERS, COSTS)
+SELECT zoid, path
+FROM object_state
+WHERE idx->'object_provides' ?| ARRAY['plone.app.contenttypes.interfaces.IDocument'];
+
+\echo ''
+\echo '--- NEW: TEXT[] GIN ---'
+EXPLAIN (ANALYZE, BUFFERS, COSTS)
+SELECT zoid, path
+FROM object_state
+WHERE object_provides && ARRAY['plone.app.contenttypes.interfaces.IDocument'];
+
+\echo ''
+\echo '================================================================='
+\echo '  Benchmark: IFolderish (very selective — ~20% of objects)'
+\echo '================================================================='
+
+\echo ''
+\echo '--- OLD: JSONB GIN ---'
+EXPLAIN (ANALYZE, BUFFERS, COSTS)
+SELECT zoid, path
+FROM object_state
+WHERE idx->'object_provides' ?| ARRAY['Products.CMFCore.interfaces._content.IFolderish'];
+
+\echo ''
+\echo '--- NEW: TEXT[] GIN ---'
+EXPLAIN (ANALYZE, BUFFERS, COSTS)
+SELECT zoid, path
+FROM object_state
+WHERE object_provides && ARRAY['Products.CMFCore.interfaces._content.IFolderish'];
+
+\echo ''
+\echo '================================================================='
+\echo '  Benchmark: Combined with security filter (realistic query)'
+\echo '================================================================='
+
+\echo ''
+\echo '--- OLD: JSONB for both ---'
+EXPLAIN (ANALYZE, BUFFERS, COSTS)
+SELECT zoid, path
+FROM object_state
+WHERE idx->'object_provides' ?| ARRAY['plone.app.contenttypes.interfaces.IDocument']
+  AND allowed_roles && ARRAY['Anonymous'];
+
+\echo ''
+\echo '--- NEW: TEXT[] for both ---'
+EXPLAIN (ANALYZE, BUFFERS, COSTS)
+SELECT zoid, path
+FROM object_state
+WHERE object_provides && ARRAY['plone.app.contenttypes.interfaces.IDocument']
+  AND allowed_roles && ARRAY['Anonymous'];
+
+\echo ''
+\echo '================================================================='
+\echo '  Benchmark: AND operator (multiple interfaces)'
+\echo '================================================================='
+
+\echo ''
+\echo '--- OLD: JSONB containment ---'
+EXPLAIN (ANALYZE, BUFFERS, COSTS)
+SELECT zoid, path
+FROM object_state
+WHERE idx @> '{"object_provides": ["plone.dexterity.interfaces.IDexterityContent", "plone.app.contenttypes.interfaces.IDocument"]}'::jsonb;
+
+\echo ''
+\echo '--- NEW: TEXT[] @> ---'
+EXPLAIN (ANALYZE, BUFFERS, COSTS)
+SELECT zoid, path
+FROM object_state
+WHERE object_provides @> ARRAY['plone.dexterity.interfaces.IDexterityContent', 'plone.app.contenttypes.interfaces.IDocument'];
+
+\echo ''
+\echo '================================================================='
+\echo '  Latency comparison (median of 10 runs, no EXPLAIN overhead)'
+\echo '================================================================='
+
+-- Run each query 10x and measure total time
+\echo ''
+\echo '--- OLD: JSONB GIN x10 ---'
+\timing on
+SELECT COUNT(*) FROM (
+    SELECT 1 FROM object_state WHERE idx->'object_provides' ?| ARRAY['plone.app.contenttypes.interfaces.IDocument']
+    UNION ALL SELECT 1 FROM object_state WHERE idx->'object_provides' ?| ARRAY['plone.app.contenttypes.interfaces.IDocument']
+    UNION ALL SELECT 1 FROM object_state WHERE idx->'object_provides' ?| ARRAY['plone.app.contenttypes.interfaces.IDocument']
+    UNION ALL SELECT 1 FROM object_state WHERE idx->'object_provides' ?| ARRAY['plone.app.contenttypes.interfaces.IDocument']
+    UNION ALL SELECT 1 FROM object_state WHERE idx->'object_provides' ?| ARRAY['plone.app.contenttypes.interfaces.IDocument']
+    UNION ALL SELECT 1 FROM object_state WHERE idx->'object_provides' ?| ARRAY['plone.app.contenttypes.interfaces.IDocument']
+    UNION ALL SELECT 1 FROM object_state WHERE idx->'object_provides' ?| ARRAY['plone.app.contenttypes.interfaces.IDocument']
+    UNION ALL SELECT 1 FROM object_state WHERE idx->'object_provides' ?| ARRAY['plone.app.contenttypes.interfaces.IDocument']
+    UNION ALL SELECT 1 FROM object_state WHERE idx->'object_provides' ?| ARRAY['plone.app.contenttypes.interfaces.IDocument']
+    UNION ALL SELECT 1 FROM object_state WHERE idx->'object_provides' ?| ARRAY['plone.app.contenttypes.interfaces.IDocument']
+) t;
+
+\echo '--- NEW: TEXT[] GIN x10 ---'
+SELECT COUNT(*) FROM (
+    SELECT 1 FROM object_state WHERE object_provides && ARRAY['plone.app.contenttypes.interfaces.IDocument']
+    UNION ALL SELECT 1 FROM object_state WHERE object_provides && ARRAY['plone.app.contenttypes.interfaces.IDocument']
+    UNION ALL SELECT 1 FROM object_state WHERE object_provides && ARRAY['plone.app.contenttypes.interfaces.IDocument']
+    UNION ALL SELECT 1 FROM object_state WHERE object_provides && ARRAY['plone.app.contenttypes.interfaces.IDocument']
+    UNION ALL SELECT 1 FROM object_state WHERE object_provides && ARRAY['plone.app.contenttypes.interfaces.IDocument']
+    UNION ALL SELECT 1 FROM object_state WHERE object_provides && ARRAY['plone.app.contenttypes.interfaces.IDocument']
+    UNION ALL SELECT 1 FROM object_state WHERE object_provides && ARRAY['plone.app.contenttypes.interfaces.IDocument']
+    UNION ALL SELECT 1 FROM object_state WHERE object_provides && ARRAY['plone.app.contenttypes.interfaces.IDocument']
+    UNION ALL SELECT 1 FROM object_state WHERE object_provides && ARRAY['plone.app.contenttypes.interfaces.IDocument']
+    UNION ALL SELECT 1 FROM object_state WHERE object_provides && ARRAY['plone.app.contenttypes.interfaces.IDocument']
+) t;
+
+\echo ''
+\echo '================================================================='
+\echo '  Cleanup (optional — run after benchmarking)'
+\echo '================================================================='
+\echo '  -- DROP INDEX IF EXISTS idx_os_object_provides;'
+\echo '  -- ALTER TABLE object_state DROP COLUMN IF EXISTS object_provides;'
+\echo ''

--- a/docs/sources/explanation/architecture.md
+++ b/docs/sources/explanation/architecture.md
@@ -232,9 +232,10 @@ query, and returns lightweight `_PendingBrain` instances with just enough interf
    `ICatalogBrain` for Plone compatibility and supports attribute access into the
    `idx` JSONB for catalog metadata.
    Non-JSON-native metadata (such as Zope
-   `DateTime` objects) is stored under `idx["@meta"]` via the Rust codec and
-   decoded on first access with per-brain caching (see {doc}`../reference/schema`
-   for the `@meta` structure).
+   `DateTime` objects) is stored in a dedicated `meta` JSONB column
+   (extracted from `idx` at write time) and decoded on first access with
+   per-brain caching (see {doc}`../reference/schema` for the extracted
+   columns mechanism).
 
 ## Lazy loading
 
@@ -410,10 +411,11 @@ with PG-backed implementations:
 
 - **Brain attribute resolution** distinguishes known from unknown fields. Known
   catalog fields (registered indexes or metadata) are resolved first from the
-  `idx["@meta"]` dict (for non-JSON-native types like `DateTime`), then from the
-  top-level `idx` JSONB.
-  Fields missing from both return `None` -- matching
-  ZCatalog's Missing Value behavior.
+  dedicated `meta` column (for non-JSON-native types like `DateTime`), then
+  from `idx["@meta"]` (pre-migration fallback), then from the top-level `idx`
+  JSONB.
+  Fields missing from all return `None` -- matching ZCatalog's Missing
+  Value behavior.
   Unknown fields raise `AttributeError`,
   which triggers the `getObject()` fallback in
   `CatalogContentListingObject.__getattr__()`.

--- a/docs/sources/explanation/performance.md
+++ b/docs/sources/explanation/performance.md
@@ -264,12 +264,25 @@ suggests composite index DDL for frequent patterns.
 This is a self-tuning feedback loop: deploy the site, let it accumulate
 slow query data under real load, then add the suggested indexes.
 
-### Dedicated security column
+### Extracted columns (`ExtraIdxColumn`)
 
-`allowedRolesAndUsers` is in every catalog query (security filter). Storing
-it as a dedicated `allowed_roles TEXT[]` column with its own GIN index
-eliminates JSONB decompression from query evaluation. PG can BitmapAnd the
-security GIN with btree composite indexes directly.
+Heavy keys are extracted from the `idx` JSONB into dedicated columns to
+keep `idx` below the PostgreSQL TOAST threshold (~2 KB). This avoids
+TOAST decompression on every `idx` access.
+Three keys are extracted by default:
+
+- **`allowedRolesAndUsers`** → `allowed_roles TEXT[]` with GIN index.
+  Present in every catalog query (security filter).
+  PG can BitmapAnd the
+  security GIN with btree composite indexes directly.
+- **`object_provides`** → `object_provides TEXT[]` with GIN index.
+  Interface-based lookups are faster on native `TEXT[]` than JSONB containment.
+- **`@meta`** → `meta JSONB`.
+  Non-JSON-native metadata (`DateTime`, etc.)
+  that is only accessed by brains, never queried via SQL.
+
+On a production site with 137k cataloged objects, this reduces `idx` from
+~3.2 KB to ~400 B average per row (85% reduction, ~370 MB saved).
 
 ### Partial indexes for common patterns
 

--- a/docs/sources/explanation/security.md
+++ b/docs/sources/explanation/security.md
@@ -120,8 +120,9 @@ reaches `build_query()`:
 - **`allowedRolesAndUsers`**: Plone's security index. The current user's roles and
   group memberships are passed as a keyword query, filtering results to objects the
   user is allowed to see.
-  This is a KeywordIndex query using JSONB `?|` overlap,
-  matching the same semantics as ZCatalog's `allowedRolesAndUsers` index.
+  This index is stored in a dedicated `allowed_roles TEXT[]`
+  column (extracted from `idx` at write time) with a GIN index for fast array
+  overlap queries.
 
 - **`effectiveRange`**: Plone's publication date filtering. Content with a future
   `effective` date or a past `expires` date is excluded unless the user has the

--- a/docs/sources/how-to/query-raw-sql.md
+++ b/docs/sources/how-to/query-raw-sql.md
@@ -21,8 +21,11 @@ All catalog data lives in `object_state` alongside ZODB object pickles:
 | `path` | `TEXT` | Physical path (for example, `/plone/folder/doc`) |
 | `parent_path` | `TEXT` | Parent's path (for example, `/plone/folder`) |
 | `path_depth` | `INTEGER` | Number of path components |
-| `idx` | `JSONB` | All index and metadata values |
+| `idx` | `JSONB` | Index and metadata values |
 | `searchable_text` | `TSVECTOR` | Weighted full-text vector |
+| `meta` | `JSONB` | Non-JSON-native metadata (`DateTime`, etc.) |
+| `object_provides` | `TEXT[]` | Interface-based lookups |
+| `allowed_roles` | `TEXT[]` | Security filter (allowedRolesAndUsers) |
 
 ## Common query patterns
 
@@ -62,7 +65,15 @@ ORDER BY pgcatalog_to_timestamptz(idx->>'modified') DESC;
 SELECT path, idx->>'Title' AS title
 FROM object_state
 WHERE idx @> '{"portal_type": "Document"}'::jsonb
-  AND idx->'allowedRolesAndUsers' ?| ARRAY['Anonymous', 'Member'];
+  AND allowed_roles && ARRAY['Anonymous', 'Member'];
+```
+
+### Interface query (`object_provides`)
+
+```sql
+SELECT path, idx->>'Title' AS title
+FROM object_state
+WHERE object_provides && ARRAY['Products.CMFCore.interfaces._content.IContentish'];
 ```
 
 ### Keyword query (Subject)

--- a/docs/sources/reference/query-api.md
+++ b/docs/sources/reference/query-api.md
@@ -346,18 +346,19 @@ Implements
 All registered indexes and metadata columns are accessible as
 attributes (for example, `brain.portal_type`, `brain.Title`, `brain.Subject`).
 
-- Non-JSON-native metadata (Zope `DateTime`, `datetime`, `date`, etc.)
-  is stored in `idx["@meta"]` via the Rust codec and decoded on first
-  access with per-brain caching.
-  This means `brain.effective` returns
-  a `DateTime` object, not an ISO string.
-  See {doc}`schema` for the
-  `@meta` JSONB structure.
+- Non-JSON-native metadata (Zope `DateTime`, `datetime`, `date`,
+  `image_scales`, etc.) is stored in a dedicated `meta` JSONB column
+  (extracted from `idx` at write time) and decoded on first access via
+  the Rust codec with per-brain caching.
+  This means `brain.effective`
+  returns a `DateTime` object, not an ISO string.
+  See {doc}`schema` for
+  the extracted columns mechanism.
 - JSON-native metadata (str, int, float, bool, None, lists/dicts of
   these) is stored directly in the top-level `idx` JSONB.
 - For registered indexes/metadata: returns `None` if the field is
-  missing from both `@meta` and top-level `idx` (Missing Value
-  behavior, matching ZCatalog).
+  missing from `meta`, `idx["@meta"]` (pre-migration fallback), and
+  top-level `idx` (Missing Value behavior, matching ZCatalog).
 - For unknown attributes: raises `AttributeError`. This is intentional:
   `CatalogContentListingObject.__getattr__()` catches `AttributeError`
   and falls back to `getObject()`, loading the real content object.

--- a/docs/sources/reference/schema.md
+++ b/docs/sources/reference/schema.md
@@ -23,7 +23,8 @@ with the following columns:
 | `search_bm25` | `BM25VECTOR` | BM25 fallback column (when BM25 active) |
 | `search_bm25_{lang}` | `BM25VECTOR` | Per-language BM25 column (when BM25 active) |
 
-The first eight columns are always present.
+The first eight columns are present after schema DDL has been applied
+(automatically on first startup with a registered `CatalogStateProcessor`).
 
 `parent_path` and `path_depth` are derived from `path` (the parent is
 the path with its last segment removed; the depth is the number of

--- a/docs/sources/reference/schema.md
+++ b/docs/sources/reference/schema.md
@@ -15,13 +15,15 @@ with the following columns:
 | `path` | `TEXT` | Physical object path (for example, `/plone/folder/doc`) |
 | `parent_path` | `TEXT` | Parent path (for path queries) |
 | `path_depth` | `INTEGER` | Path depth (for depth-limited queries) |
-| `idx` | `JSONB` | All index and metadata values |
+| `idx` | `JSONB` | Index and metadata values (lightweight after extraction) |
 | `searchable_text` | `TSVECTOR` | Weighted full-text search vector |
+| `meta` | `JSONB` | Non-JSON-native metadata (`DateTime`, `image_scales`, etc.) |
+| `object_provides` | `TEXT[]` | Interface-based lookups (extracted from idx) |
 | `allowed_roles` | `TEXT[]` | Dedicated security filter column (allowedRolesAndUsers) |
 | `search_bm25` | `BM25VECTOR` | BM25 fallback column (when BM25 active) |
 | `search_bm25_{lang}` | `BM25VECTOR` | Per-language BM25 column (when BM25 active) |
 
-The first six columns are always present.
+The first eight columns are always present.
 
 `parent_path` and `path_depth` are derived from `path` (the parent is
 the path with its last segment removed; the depth is the number of
@@ -86,7 +88,7 @@ VectorChord-BM25 extensions are detected at startup.
 | Index Name | Type | Expression | Purpose |
 |---|---|---|---|
 | `idx_os_allowed_roles` | GIN | `allowed_roles` | Security filter (every query) |
-| `idx_os_cat_provides_gin` | GIN | `idx->'object_provides'` | Interface-based lookups |
+| `idx_os_object_provides` | GIN | `object_provides` | Interface-based lookups |
 | `idx_os_cat_subject_gin` | GIN | `idx->'Subject'` | Subject keyword queries |
 
 ### Partial indexes
@@ -128,8 +130,10 @@ partial index predicates to exclude uncataloged rows.
 
 ## idx JSONB structure
 
-All standard Plone catalog indexes and metadata columns are stored
+Standard Plone catalog indexes and JSON-native metadata are stored
 together in a single JSONB document.
+Heavy or high-cardinality keys are extracted into dedicated columns
+(see {ref}`extracted-columns` below).
 Example for a typical Plone Page:
 
 ```json
@@ -148,13 +152,11 @@ Example for a typical Plone Page:
   "is_folderish": false,
   "is_default_page": false,
   "sortable_title": "my document",
-  "allowedRolesAndUsers": ["Anonymous"],
   "Language": "en",
   "path": "/plone/my-document",
   "path_parent": "/plone",
   "path_depth": 2,
-  "getObjPositionInParent": 5,
-  "image_scales": null
+  "getObjPositionInParent": 5
 }
 ```
 
@@ -165,15 +167,7 @@ Key conventions:
   These live at the top level of idx.
 - **Metadata values** that are JSON-native (str, int, float, bool, None,
   and lists/dicts of these) also live at the top level of idx.
-- **Non-JSON-native metadata** (Zope `DateTime`, stdlib `datetime`, `date`,
-  etc.) is encoded via the Rust codec (`zodb-json-codec`) into a nested
-  `"@meta"` key.
-  This preserves original Python types so that
-  `brain.effective` returns a `DateTime` object, not a string.
-  The `@meta` dict uses codec type markers (for example `@dt`, `@cls`+`@s`) and
-  is decoded once per brain on first access (cached thereafter).
-- Multi-value fields (for example, `Subject`, `allowedRolesAndUsers`) are
-  stored as JSON arrays.
+- Multi-value fields (for example, `Subject`) are stored as JSON arrays.
 - Boolean fields are stored as JSON `true`/`false`.
 - `null` values are stored explicitly where the object has no value
   for that field.
@@ -182,8 +176,48 @@ Key conventions:
   path query support.
 - Fields that are both indexes and metadata (for example `effective`) appear
   in both places: top-level idx holds the converted ISO string (for
-  PG queries), while `@meta` holds the original `DateTime` (for brain
-  attribute access).
+  PG queries), while the `meta` column holds the original `DateTime`
+  (for brain attribute access).
+
+(extracted-columns)=
+## Extracted columns (`ExtraIdxColumn`)
+
+To keep `idx` compact (below the PostgreSQL TOAST threshold of ~2 KB),
+heavy or high-cardinality keys are **extracted** from the idx dict at
+write time and stored in dedicated columns.
+The extraction is managed by a
+generic `ExtraIdxColumn` registry in `columns.py`.
+
+| idx key | Column | Type | Reason |
+|---|---|---|---|
+| `@meta` | `meta` | `JSONB` | Non-JSON-native metadata (`DateTime`, etc.); never queried via SQL, only used for brain attribute access |
+| `object_provides` | `object_provides` | `TEXT[]` | Interface-based lookups; native GIN on `TEXT[]` is faster than JSONB containment |
+| `allowedRolesAndUsers` | `allowed_roles` | `TEXT[]` | Security filter in every query; same optimization as `object_provides` |
+
+Extracted keys are **popped** from the idx dict before it is written to
+the `idx` column.
+They do not appear in `idx` for newly written rows.
+Pre-migration rows (written before this feature) may still contain these
+keys in `idx`; the brain falls back to `idx["@meta"]` when the `meta`
+column is `NULL`.
+
+The `meta` column stores codec-encoded non-JSON-native metadata (Zope
+`DateTime`, stdlib `datetime`, `date`, `image_scales`, etc.) via the Rust
+codec (`zodb-json-codec`).
+This preserves original Python types so that
+`brain.effective` returns a `DateTime` object, not a string.
+The `meta` dict uses codec type markers (for example `@dt`, `@cls`+`@s`) and
+is decoded once per brain on first access (cached thereafter).
+
+```{note}
+Extracted keys are no longer accessible via `brain.object_provides` or
+`brain.allowedRolesAndUsers`.
+These are query-only index fields — not
+catalog metadata — so brain attribute access is not needed.
+If a custom addon registers one of these as metadata, the data is still in
+the database (in its dedicated column) but would need a brain extension to
+be surfaced.
+```
 
 ## Text Extraction Queue (Optional)
 

--- a/docs/sources/reference/zcatalog-compat.md
+++ b/docs/sources/reference/zcatalog-compat.md
@@ -96,16 +96,19 @@ index._index.get("Document")   # PG query returning matching ZOIDs
 
 | Attribute Type | Resolution Order |
 |---|---|
-| Known index or metadata (in `IndexRegistry`) | 1. `idx["@meta"]` (codec-decoded, for non-JSON-native types like `DateTime`) → 2. top-level `idx` JSONB → 3. `None` if missing from both |
+| Known index or metadata (in `IndexRegistry`) | 1. `meta` column (codec-decoded, for non-JSON-native types like `DateTime`) → 2. `idx["@meta"]` fallback (pre-migration data) → 3. top-level `idx` JSONB → 4. `None` if missing from all |
 | Unknown attribute | Raises `AttributeError` |
 
 Non-JSON-native metadata values (Zope `DateTime`, `datetime`, `date`,
-etc.) are stored under `idx["@meta"]` at write time via the Rust codec
-(`pickle_to_dict`).  On first access, the `@meta` dict is decoded via
-`dict_to_pickle` + `pickle.loads` and cached per brain for the lifetime
+`image_scales`, etc.) are stored in a dedicated `meta` JSONB column
+(extracted from `idx` at write time via the `ExtraIdxColumn` mechanism).
+On first access, the `meta` dict is decoded via the Rust codec
+(`dict_to_pickle` + `pickle.loads`) and cached per brain for the lifetime
 of the result set.
 This ensures `brain.effective` returns a `DateTime`
 object, not an ISO string.
+For pre-migration data (where `meta` is `NULL`), the brain falls back to
+`idx["@meta"]`.
 
 The `AttributeError` for unknown attributes is intentional:
 `CatalogContentListingObject.__getattr__()` catches it and falls back to

--- a/src/plone/pgcatalog/brain.py
+++ b/src/plone/pgcatalog/brain.py
@@ -150,9 +150,14 @@ class PGCatalogBrain:
             if result_set is not None:
                 result_set._load_idx_batch()
                 idx = self._row.get("idx")
+        # Check dedicated meta column first
+        meta_col = self._row.get("meta")
+        if meta_col is not None and name in meta_col:
+            return True
         if idx:
             if name in idx:
                 return True
+            # Fallback: pre-migration data with @meta still in idx
             meta = idx.get("@meta")
             if meta is not None and name in meta:
                 return True
@@ -165,20 +170,27 @@ class PGCatalogBrain:
 
         Resolution order:
 
-        1. ``idx["@meta"]`` — codec-encoded non-JSON-native metadata values
-           (DateTime, datetime, date, …).  Decoded once via the Rust codec
-           and cached in ``_row["_meta_decoded"]``.
-        2. Top-level ``idx[name]`` — JSON-native values (str, int, bool, …)
+        1. Dedicated ``meta`` column (codec-encoded non-JSON-native metadata).
+        2. Fallback: ``idx["@meta"]`` (pre-migration data still in idx).
+        3. Top-level ``idx[name]`` — JSON-native values (str, int, bool, …)
            and converted index data.
-        3. Known field not present → ``None`` (Missing Value, matching ZCatalog).
-        4. Unknown field → ``AttributeError`` (lets callers fall back to
+        4. Known field not present → ``None`` (Missing Value, matching ZCatalog).
+        5. Unknown field → ``AttributeError`` (lets callers fall back to
            ``getObject()``).
         """
+        row = object.__getattribute__(self, "_row")
+
+        # Check dedicated meta column first (new path)
+        meta_col = row.get("meta")
+        if meta_col is not None and name in meta_col:
+            decoded = self._decode_meta_source(meta_col)
+            return decoded.get(name)
+
         if idx is not None:
-            # Check @meta first (codec-encoded non-native types)
+            # Fallback: pre-migration data with @meta still in idx
             meta = idx.get("@meta")
             if meta is not None and name in meta:
-                decoded = self._decode_meta(idx)
+                decoded = self._decode_meta_source(meta)
                 return decoded.get(name)
             # Fall back to top-level idx (JSON-native values + index data)
             if name in idx:
@@ -188,18 +200,18 @@ class PGCatalogBrain:
             return None
         raise AttributeError(name)
 
-    def _decode_meta(self, idx):
-        """Decode the ``@meta`` sub-dict via the Rust codec (cached).
+    def _decode_meta_source(self, meta_dict):
+        """Decode a meta dict via the Rust codec (cached).
 
-        First call: ``dict_to_pickle(@meta) → pickle.loads()`` restores
-        original Python types.  Result is cached in ``_row["_meta_decoded"]``
-        so subsequent attribute accesses skip the codec round-trip.
+        Works with both the dedicated ``meta`` column and the legacy
+        ``idx["@meta"]`` sub-dict.  Result is cached in
+        ``_row["_meta_decoded"]`` so subsequent accesses skip the codec.
         """
         row = object.__getattribute__(self, "_row")
         cached = row.get("_meta_decoded")
         if cached is not None:
             return cached
-        decoded = decode_meta(idx["@meta"])
+        decoded = decode_meta(meta_dict)
         row["_meta_decoded"] = decoded
         return decoded
 
@@ -277,7 +289,7 @@ class CatalogSearchResults(Lazy):
 
         with self._conn.cursor() as cur:
             cur.execute(
-                "SELECT zoid, idx FROM object_state WHERE zoid = ANY(%(zoids)s)",
+                "SELECT zoid, idx, meta FROM object_state WHERE zoid = ANY(%(zoids)s)",
                 {"zoids": zoids},
                 prepare=True,
             )
@@ -285,6 +297,8 @@ class CatalogSearchResults(Lazy):
                 brain = brain_map.get(row["zoid"])
                 if brain is not None:
                     brain._row["idx"] = row["idx"]
+                    if "meta" in row:
+                        brain._row["meta"] = row["meta"]
 
     def _maybe_prefetch_objects(self, brain):
         """Prefetch ZODB objects for a batch of brains around *brain*.

--- a/src/plone/pgcatalog/columns.py
+++ b/src/plone/pgcatalog/columns.py
@@ -27,6 +27,7 @@ __all__ = [
     "compute_path_info",
     "convert_value",
     "ensure_date_param",
+    "extract_extra_idx_columns",
     "get_extra_idx_column_for_key",
     "get_extra_idx_columns",
     "get_registry",
@@ -416,7 +417,13 @@ _extra_idx_columns: list[ExtraIdxColumn] = []
 
 
 def register_extra_idx_column(col):
-    """Register an ExtraIdxColumn for extraction."""
+    """Register an ExtraIdxColumn for extraction.
+
+    Must be called at import time only (module-level).  The registry
+    is not protected by a lock and is assumed to be immutable after
+    all modules have loaded.
+    """
+    validate_identifier(col.column_name)
     _extra_idx_columns.append(col)
 
 
@@ -461,3 +468,30 @@ _DEFAULT_EXTRA_IDX_COLUMNS = [
 
 for _col in _DEFAULT_EXTRA_IDX_COLUMNS:
     register_extra_idx_column(_col)
+
+
+def extract_extra_idx_columns(idx):
+    """Pop registered extra idx keys from *idx* dict, return column values.
+
+    Returns a dict mapping column_name → value (Json-wrapped for JSONB
+    columns, plain value for others, None if key absent).
+
+    This is the single source of truth for extraction logic — used by
+    ``CatalogStateProcessor.process()``, ``finalize()`` (partial reindex),
+    and ``indexing.py`` (direct SQL writes).
+    """
+    from psycopg.types.json import Json
+
+    if not idx:
+        return {}
+    extra = {}
+    for col in _extra_idx_columns:
+        value = idx.pop(col.idx_key, None)
+        if value is not None:
+            if col.column_type == "JSONB":
+                extra[col.column_name] = Json(value)
+            else:
+                extra[col.column_name] = value
+        else:
+            extra[col.column_name] = None
+    return extra

--- a/src/plone/pgcatalog/columns.py
+++ b/src/plone/pgcatalog/columns.py
@@ -15,18 +15,23 @@ from datetime import datetime
 from datetime import UTC
 from enum import Enum
 
+import dataclasses
 import logging
 import re
 
 
 __all__ = [
+    "ExtraIdxColumn",
     "IndexRegistry",
     "IndexType",
     "compute_path_info",
     "convert_value",
     "ensure_date_param",
+    "get_extra_idx_column_for_key",
+    "get_extra_idx_columns",
     "get_registry",
     "language_to_regconfig",
+    "register_extra_idx_column",
     "validate_identifier",
 ]
 
@@ -383,3 +388,76 @@ def compute_path_info(path):
     parent = "/" if depth <= 1 else "/" + "/".join(parts[:-1])
 
     return parent, depth
+
+
+# --------------------------------------------------------------------------
+# Extra idx column extraction
+# --------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class ExtraIdxColumn:
+    """Declare an idx key to be extracted into a dedicated PG column.
+
+    When registered, the key is popped from the idx dict at write time
+    and stored in its own column.  Queries and brain attribute access
+    are redirected transparently.
+    """
+
+    idx_key: str  # key in the idx dict (e.g. "object_provides", "@meta")
+    column_name: str  # PG column name (e.g. "object_provides", "meta")
+    column_type: str  # PG type (e.g. "TEXT[]", "JSONB")
+    value_expr: str  # SQL value expression for psycopg (e.g. "%(meta)s")
+    gin_index: bool = False
+
+
+# Module-level registry
+_extra_idx_columns: list[ExtraIdxColumn] = []
+
+
+def register_extra_idx_column(col):
+    """Register an ExtraIdxColumn for extraction."""
+    _extra_idx_columns.append(col)
+
+
+def get_extra_idx_columns():
+    """Return all registered ExtraIdxColumn declarations."""
+    return list(_extra_idx_columns)
+
+
+def get_extra_idx_column_for_key(idx_key):
+    """Look up an ExtraIdxColumn by its idx_key.  Returns None if not found."""
+    for col in _extra_idx_columns:
+        if col.idx_key == idx_key:
+            return col
+    return None
+
+
+# -- Default extra idx columns ------------------------------------------------
+
+_DEFAULT_EXTRA_IDX_COLUMNS = [
+    ExtraIdxColumn(
+        idx_key="@meta",
+        column_name="meta",
+        column_type="JSONB",
+        value_expr="%(meta)s",
+        gin_index=False,
+    ),
+    ExtraIdxColumn(
+        idx_key="object_provides",
+        column_name="object_provides",
+        column_type="TEXT[]",
+        value_expr="%(object_provides)s",
+        gin_index=True,
+    ),
+    ExtraIdxColumn(
+        idx_key="allowedRolesAndUsers",
+        column_name="allowed_roles",
+        column_type="TEXT[]",
+        value_expr="%(allowed_roles)s",
+        gin_index=True,
+    ),
+]
+
+for _col in _DEFAULT_EXTRA_IDX_COLUMNS:
+    register_extra_idx_column(_col)

--- a/src/plone/pgcatalog/indexing.py
+++ b/src/plone/pgcatalog/indexing.py
@@ -7,6 +7,7 @@ these after extracting values via plone.indexer.
 """
 
 from plone.pgcatalog.columns import compute_path_info
+from plone.pgcatalog.columns import extract_extra_idx_columns
 from plone.pgcatalog.columns import get_extra_idx_columns
 from psycopg.types.json import Json
 
@@ -24,23 +25,6 @@ _WEIGHTED_TSVECTOR = (
     "COALESCE({idx_expr}->>'Description', '')), 'B') || "
     "setweight(to_tsvector({lang_expr}::regconfig, {text_expr}), 'D')"
 )
-
-
-def _extract_extra_columns(idx):
-    """Pop registered extra idx keys from idx dict, return column values."""
-    if not idx:
-        return {}
-    extra = {}
-    for col in get_extra_idx_columns():
-        value = idx.pop(col.idx_key, None)
-        if value is not None:
-            if col.column_type == "JSONB":
-                extra[col.column_name] = Json(value)
-            else:
-                extra[col.column_name] = value
-        else:
-            extra[col.column_name] = None
-    return extra
 
 
 def catalog_object(conn, zoid, path, idx, searchable_text=None, language="simple"):
@@ -62,7 +46,7 @@ def catalog_object(conn, zoid, path, idx, searchable_text=None, language="simple
     idx.setdefault("path_depth", path_depth)
 
     # Extract registered extra idx columns (pops from idx → dedicated columns)
-    extra = _extract_extra_columns(idx)
+    extra = extract_extra_idx_columns(idx)
     extra_set_clauses = "".join(
         f",\n                {col} = %({col})s" for col in extra
     )
@@ -164,7 +148,7 @@ def reindex_object(
         language: PostgreSQL text search config name (default "simple")
     """
     # Extract any extra idx columns from updates
-    extra = _extract_extra_columns(idx_updates)
+    extra = extract_extra_idx_columns(idx_updates)
     extra_set_clauses = "".join(
         f",\n                {col} = %({col})s"
         for col, val in extra.items()

--- a/src/plone/pgcatalog/indexing.py
+++ b/src/plone/pgcatalog/indexing.py
@@ -7,6 +7,7 @@ these after extracting values via plone.indexer.
 """
 
 from plone.pgcatalog.columns import compute_path_info
+from plone.pgcatalog.columns import get_extra_idx_columns
 from psycopg.types.json import Json
 
 
@@ -23,6 +24,23 @@ _WEIGHTED_TSVECTOR = (
     "COALESCE({idx_expr}->>'Description', '')), 'B') || "
     "setweight(to_tsvector({lang_expr}::regconfig, {text_expr}), 'D')"
 )
+
+
+def _extract_extra_columns(idx):
+    """Pop registered extra idx keys from idx dict, return column values."""
+    if not idx:
+        return {}
+    extra = {}
+    for col in get_extra_idx_columns():
+        value = idx.pop(col.idx_key, None)
+        if value is not None:
+            if col.column_type == "JSONB":
+                extra[col.column_name] = Json(value)
+            else:
+                extra[col.column_name] = value
+        else:
+            extra[col.column_name] = None
+    return extra
 
 
 def catalog_object(conn, zoid, path, idx, searchable_text=None, language="simple"):
@@ -43,9 +61,20 @@ def catalog_object(conn, zoid, path, idx, searchable_text=None, language="simple
     idx.setdefault("path_parent", parent_path)
     idx.setdefault("path_depth", path_depth)
 
-    # Extract allowedRolesAndUsers for the dedicated TEXT[] column
-    allowed = idx.get("allowedRolesAndUsers")
-    allowed_roles = allowed if isinstance(allowed, list) else None
+    # Extract registered extra idx columns (pops from idx → dedicated columns)
+    extra = _extract_extra_columns(idx)
+    extra_set_clauses = "".join(
+        f",\n                {col} = %({col})s" for col in extra
+    )
+
+    params = {
+        "zoid": zoid,
+        "path": path,
+        "parent_path": parent_path,
+        "path_depth": path_depth,
+        "idx": Json(idx),
+        **extra,
+    }
 
     if searchable_text is not None:
         tsvector_sql = _WEIGHTED_TSVECTOR.format(
@@ -53,6 +82,8 @@ def catalog_object(conn, zoid, path, idx, searchable_text=None, language="simple
             lang_expr="%(lang)s",
             text_expr="%(text)s",
         )
+        params["text"] = searchable_text
+        params["lang"] = language
         conn.execute(
             f"""
             UPDATE object_state SET
@@ -60,49 +91,31 @@ def catalog_object(conn, zoid, path, idx, searchable_text=None, language="simple
                 parent_path = %(parent_path)s,
                 path_depth = %(path_depth)s,
                 idx = %(idx)s,
-                allowed_roles = %(allowed_roles)s,
-                searchable_text = {tsvector_sql}
+                searchable_text = {tsvector_sql}{extra_set_clauses}
             WHERE zoid = %(zoid)s
             """,
-            {
-                "zoid": zoid,
-                "path": path,
-                "parent_path": parent_path,
-                "path_depth": path_depth,
-                "idx": Json(idx),
-                "allowed_roles": allowed_roles,
-                "text": searchable_text,
-                "lang": language,
-            },
+            params,
         )
     else:
         conn.execute(
-            """
+            f"""
             UPDATE object_state SET
                 path = %(path)s,
                 parent_path = %(parent_path)s,
                 path_depth = %(path_depth)s,
                 idx = %(idx)s,
-                allowed_roles = %(allowed_roles)s,
-                searchable_text = NULL
+                searchable_text = NULL{extra_set_clauses}
             WHERE zoid = %(zoid)s
             """,
-            {
-                "zoid": zoid,
-                "path": path,
-                "parent_path": parent_path,
-                "path_depth": path_depth,
-                "allowed_roles": allowed_roles,
-                "idx": Json(idx),
-            },
+            params,
         )
 
 
 def uncatalog_object(conn, zoid):
     """Clear all catalog data for an object.
 
-    Sets path, parent_path, path_depth, idx, searchable_text (and
-    search_bm25 if BM25 backend is active) to NULL.
+    Sets path, parent_path, path_depth, idx, searchable_text, and all
+    extra idx columns to NULL.
     The base object_state row (zoid, tid, state, etc.) is preserved.
 
     Args:
@@ -113,6 +126,10 @@ def uncatalog_object(conn, zoid):
 
     extra_nulls = get_backend().uncatalog_extra()
     extra_sql = "".join(f",\n            {col} = NULL" for col in extra_nulls)
+
+    # Also NULL all extra idx columns
+    for col in get_extra_idx_columns():
+        extra_sql += f",\n            {col.column_name} = NULL"
 
     conn.execute(
         f"""
@@ -136,6 +153,9 @@ def reindex_object(
     Merges idx_updates into the existing idx JSONB (||).  Keys present in
     idx_updates overwrite existing values; keys not mentioned are preserved.
 
+    If idx_updates contains registered extra idx column keys, those are
+    extracted and written to their dedicated columns as well.
+
     Args:
         conn: psycopg connection
         zoid: integer object id
@@ -143,16 +163,26 @@ def reindex_object(
         searchable_text: if provided, update the tsvector; if omitted, leave unchanged
         language: PostgreSQL text search config name (default "simple")
     """
+    # Extract any extra idx columns from updates
+    extra = _extract_extra_columns(idx_updates)
+    extra_set_clauses = "".join(
+        f",\n                {col} = %({col})s"
+        for col, val in extra.items()
+        if val is not None
+    )
+    extra_params = {col: val for col, val in extra.items() if val is not None}
+
     if searchable_text is _SENTINEL:
         conn.execute(
-            """
+            f"""
             UPDATE object_state SET
-                idx = COALESCE(idx, '{}'::jsonb) || %(updates)s::jsonb
+                idx = COALESCE(idx, '{{}}'::jsonb) || %(updates)s::jsonb{extra_set_clauses}
             WHERE zoid = %(zoid)s
             """,
             {
                 "zoid": zoid,
                 "updates": Json(idx_updates),
+                **extra_params,
             },
         )
     elif searchable_text is not None:
@@ -166,7 +196,7 @@ def reindex_object(
             f"""
             UPDATE object_state SET
                 idx = {merged_idx},
-                searchable_text = {tsvector_sql}
+                searchable_text = {tsvector_sql}{extra_set_clauses}
             WHERE zoid = %(zoid)s
             """,
             {
@@ -174,18 +204,20 @@ def reindex_object(
                 "updates": Json(idx_updates),
                 "text": searchable_text,
                 "lang": language,
+                **extra_params,
             },
         )
     else:
         conn.execute(
-            """
+            f"""
             UPDATE object_state SET
-                idx = COALESCE(idx, '{}'::jsonb) || %(updates)s::jsonb,
-                searchable_text = NULL
+                idx = COALESCE(idx, '{{}}'::jsonb) || %(updates)s::jsonb,
+                searchable_text = NULL{extra_set_clauses}
             WHERE zoid = %(zoid)s
             """,
             {
                 "zoid": zoid,
                 "updates": Json(idx_updates),
+                **extra_params,
             },
         )

--- a/src/plone/pgcatalog/processor.py
+++ b/src/plone/pgcatalog/processor.py
@@ -6,6 +6,8 @@ state during tpc_vote.
 """
 
 from plone.pgcatalog.backends import get_backend
+from plone.pgcatalog.columns import extract_extra_idx_columns
+from plone.pgcatalog.columns import get_extra_idx_columns
 from plone.pgcatalog.pending import _MISSING
 from plone.pgcatalog.pending import pop_all_partial_pending
 from plone.pgcatalog.pending import pop_all_pending_moves
@@ -116,8 +118,6 @@ class CatalogStateProcessor:
     """
 
     def get_extra_columns(self):
-        from plone.pgcatalog.columns import get_extra_idx_columns
-
         extra = [
             ExtraColumn(col.column_name, col.value_expr)
             for col in get_extra_idx_columns()
@@ -195,8 +195,6 @@ class CatalogStateProcessor:
 
         if pending is None:
             # Uncatalog sentinel: NULL all catalog columns
-            from plone.pgcatalog.columns import get_extra_idx_columns
-
             result = {
                 "path": None,
                 "parent_path": None,
@@ -227,20 +225,8 @@ class CatalogStateProcessor:
                     )
 
         # Normal catalog: extract registered extra idx columns
-        from plone.pgcatalog.columns import get_extra_idx_columns
-
         idx = pending.get("idx")
-        extra_values = {}
-        if idx:
-            for col in get_extra_idx_columns():
-                value = idx.pop(col.idx_key, None)
-                if value is not None:
-                    if col.column_type == "JSONB":
-                        extra_values[col.column_name] = Json(value)
-                    else:
-                        extra_values[col.column_name] = value
-                else:
-                    extra_values[col.column_name] = None
+        extra_values = extract_extra_idx_columns(idx)
 
         result = {
             "path": pending.get("path"),
@@ -271,11 +257,22 @@ class CatalogStateProcessor:
         partial = pop_all_partial_pending()
         if partial:
             for zoid, idx_updates in partial.items():
+                # Extract extra idx columns before merging into idx JSONB
+                extra = extract_extra_idx_columns(idx_updates)
+                extra_set = "".join(
+                    f", {col} = %({col})s"
+                    for col, val in extra.items()
+                    if val is not None
+                )
+                extra_params = {
+                    col: val for col, val in extra.items() if val is not None
+                }
                 cursor.execute(
                     "UPDATE object_state SET "
-                    "idx = COALESCE(idx, '{}'::jsonb) || %(patch)s::jsonb "
+                    "idx = COALESCE(idx, '{}'::jsonb) || %(patch)s::jsonb"
+                    f"{extra_set} "
                     "WHERE zoid = %(zoid)s AND idx IS NOT NULL",
-                    {"zoid": zoid, "patch": Json(idx_updates)},
+                    {"zoid": zoid, "patch": Json(idx_updates), **extra_params},
                 )
 
         # Execute bulk path moves (one SQL per moved subtree)

--- a/src/plone/pgcatalog/processor.py
+++ b/src/plone/pgcatalog/processor.py
@@ -116,12 +116,18 @@ class CatalogStateProcessor:
     """
 
     def get_extra_columns(self):
+        from plone.pgcatalog.columns import get_extra_idx_columns
+
+        extra = [
+            ExtraColumn(col.column_name, col.value_expr)
+            for col in get_extra_idx_columns()
+        ]
         return [
             ExtraColumn("path", "%(path)s"),
             ExtraColumn("parent_path", "%(parent_path)s"),
             ExtraColumn("path_depth", "%(path_depth)s"),
             ExtraColumn("idx", "%(idx)s"),
-            ExtraColumn("allowed_roles", "%(allowed_roles)s"),
+            *extra,
             *get_backend().get_extra_columns(),
         ]
 
@@ -189,14 +195,17 @@ class CatalogStateProcessor:
 
         if pending is None:
             # Uncatalog sentinel: NULL all catalog columns
+            from plone.pgcatalog.columns import get_extra_idx_columns
+
             result = {
                 "path": None,
                 "parent_path": None,
                 "path_depth": None,
                 "idx": None,
                 "searchable_text": None,
-                "allowed_roles": None,
             }
+            for col in get_extra_idx_columns():
+                result[col.column_name] = None
             result.update(get_backend().uncatalog_extra())
             return result
 
@@ -217,17 +226,29 @@ class CatalogStateProcessor:
                         }
                     )
 
-        # Normal catalog: return column values
+        # Normal catalog: extract registered extra idx columns
+        from plone.pgcatalog.columns import get_extra_idx_columns
+
         idx = pending.get("idx")
-        # Extract allowedRolesAndUsers as a dedicated TEXT[] column
-        allowed = idx.get("allowedRolesAndUsers") if idx else None
+        extra_values = {}
+        if idx:
+            for col in get_extra_idx_columns():
+                value = idx.pop(col.idx_key, None)
+                if value is not None:
+                    if col.column_type == "JSONB":
+                        extra_values[col.column_name] = Json(value)
+                    else:
+                        extra_values[col.column_name] = value
+                else:
+                    extra_values[col.column_name] = None
+
         result = {
             "path": pending.get("path"),
             "parent_path": idx.get("path_parent") if idx else None,
             "path_depth": idx.get("path_depth") if idx else None,
             "idx": Json(idx) if idx else None,
             "searchable_text": pending.get("searchable_text"),
-            "allowed_roles": allowed if isinstance(allowed, list) else None,
+            **extra_values,
         }
         result.update(get_backend().process_search_data(pending))
         return result

--- a/src/plone/pgcatalog/query.py
+++ b/src/plone/pgcatalog/query.py
@@ -322,15 +322,16 @@ class _QueryBuilder:
 
         query_val = [query_val] if isinstance(query_val, str) else list(query_val)
 
-        # allowedRolesAndUsers uses a dedicated TEXT[] column for
-        # direct GIN queries without JSONB decompression.
-        # Uses array operators: && (overlap/or), @> (contains/and).
-        if idx_key == "allowedRolesAndUsers":
+        # Check for dedicated TEXT[] column (generic ExtraIdxColumn mechanism)
+        from plone.pgcatalog.columns import get_extra_idx_column_for_key
+
+        extra_col = get_extra_idx_column_for_key(idx_key)
+        if extra_col is not None and extra_col.column_type == "TEXT[]":
             p = self._pname(name)
             if operator == "and":
-                self.clauses.append(f"allowed_roles @> %({p})s::text[]")
+                self.clauses.append(f"{extra_col.column_name} @> %({p})s::text[]")
             else:
-                self.clauses.append(f"allowed_roles && %({p})s::text[]")
+                self.clauses.append(f"{extra_col.column_name} && %({p})s::text[]")
             self.params[p] = query_val
             return
 

--- a/src/plone/pgcatalog/schema.py
+++ b/src/plone/pgcatalog/schema.py
@@ -16,9 +16,14 @@ ALTER TABLE object_state ADD COLUMN IF NOT EXISTS idx JSONB;
 ALTER TABLE object_state ADD COLUMN IF NOT EXISTS searchable_text TSVECTOR;
 
 -- Dedicated column for security filter (used in EVERY query).
--- Stored as TEXT[] for direct GIN ?| queries without JSONB decompression.
--- Backfill is done in batches at startup (_backfill_allowed_roles).
+-- Stored as TEXT[] for direct GIN queries without JSONB decompression.
 ALTER TABLE object_state ADD COLUMN IF NOT EXISTS allowed_roles TEXT[];
+
+-- Dedicated column for non-JSON-native metadata (image_scales, DateTime, etc.)
+ALTER TABLE object_state ADD COLUMN IF NOT EXISTS meta JSONB;
+
+-- Dedicated column for interface-based lookups (object_provides KeywordIndex)
+ALTER TABLE object_state ADD COLUMN IF NOT EXISTS object_provides TEXT[];
 """
 
 CATALOG_FUNCTIONS = """\
@@ -179,10 +184,10 @@ DROP INDEX IF EXISTS idx_os_cat_allowed_gin;
 CREATE INDEX IF NOT EXISTS idx_os_allowed_roles
     ON object_state USING gin (allowed_roles) WHERE allowed_roles IS NOT NULL;
 
--- Interface-based lookups (object_provides)
-CREATE INDEX IF NOT EXISTS idx_os_cat_provides_gin
-    ON object_state USING gin ((idx->'object_provides'))
-    WHERE idx IS NOT NULL AND idx ? 'object_provides';
+-- Interface-based lookups (object_provides) — dedicated TEXT[] column
+DROP INDEX IF EXISTS idx_os_cat_provides_gin;
+CREATE INDEX IF NOT EXISTS idx_os_object_provides
+    ON object_state USING gin (object_provides) WHERE object_provides IS NOT NULL;
 
 -- Subject keywords
 CREATE INDEX IF NOT EXISTS idx_os_cat_subject_gin
@@ -216,6 +221,8 @@ EXPECTED_COLUMNS = {
     "idx": "jsonb",
     "searchable_text": "tsvector",
     "allowed_roles": "ARRAY",
+    "meta": "jsonb",
+    "object_provides": "ARRAY",
 }
 
 # All expected catalog indexes
@@ -239,6 +246,7 @@ EXPECTED_INDEXES = [
     "idx_os_searchable_text",
     "idx_os_cat_title_tsv",
     "idx_os_cat_description_tsv",
+    "idx_os_object_provides",
 ]
 
 

--- a/src/plone/pgcatalog/search.py
+++ b/src/plone/pgcatalog/search.py
@@ -68,8 +68,8 @@ class _PendingBrain:
 # Eager mode: includes idx (backward compat for direct _run_search calls).
 _SELECT_COLS_LAZY = "zoid, path"
 _SELECT_COLS_LAZY_COUNTED = "zoid, path, COUNT(*) OVER() AS _total_count"
-_SELECT_COLS_EAGER = "zoid, path, idx"
-_SELECT_COLS_EAGER_COUNTED = "zoid, path, idx, COUNT(*) OVER() AS _total_count"
+_SELECT_COLS_EAGER = "zoid, path, idx, meta"
+_SELECT_COLS_EAGER_COUNTED = "zoid, path, idx, meta, COUNT(*) OVER() AS _total_count"
 
 
 def _build_results(rows, actual_count, catalog, lazy_conn):

--- a/src/plone/pgcatalog/startup.py
+++ b/src/plone/pgcatalog/startup.py
@@ -128,7 +128,6 @@ def register_catalog_processor(event):
         _sync_registry_from_db(db)
         _ensure_text_indexes(storage)
         _ensure_field_indexes(storage)
-        _backfill_allowed_roles(storage)
 
         # Enable refs prefetch for cataloged content objects only.
         # Non-content objects (BTrees, PersistentMappings, etc.) have
@@ -288,78 +287,6 @@ def _ensure_field_indexes(storage):  # pragma: no cover
             "(lock timeout or other error) --- "
             "custom field queries may be slow until indexes are created. "
             "Indexes will be retried on next startup.",
-            exc_info=True,
-        )
-
-
-_BACKFILL_BATCH = 5000
-
-
-def _backfill_allowed_roles(storage):  # pragma: no cover
-    """Backfill the allowed_roles TEXT[] column from idx JSONB in batches.
-
-    Runs at startup after schema DDL.  Processes rows where
-    ``allowed_roles IS NULL`` but ``idx->'allowedRolesAndUsers'`` exists.
-    Each batch is a small UPDATE with autocommit (short lock, no long
-    transactions).  Safe to re-run (idempotent via IS NULL check).
-    """
-    dsn = getattr(storage, "_dsn", None)
-    if not dsn:
-        return
-
-    try:
-        with psycopg.connect(dsn, autocommit=True) as conn:
-            conn.execute("SET lock_timeout = '5s'")
-
-            # Check if there's anything to backfill
-            with conn.cursor() as cur:
-                cur.execute(
-                    "SELECT COUNT(*) AS cnt FROM object_state "
-                    "WHERE idx IS NOT NULL "
-                    "AND idx ? 'allowedRolesAndUsers' "
-                    "AND allowed_roles IS NULL"
-                )
-                total = cur.fetchone()[0]
-
-            if total == 0:
-                return
-
-            log.info(
-                "Backfilling allowed_roles for %d rows (batch size %d)",
-                total,
-                _BACKFILL_BATCH,
-            )
-
-            done = 0
-            while True:
-                with conn.cursor() as cur:
-                    cur.execute(
-                        "UPDATE object_state SET allowed_roles = ("
-                        "  SELECT array_agg(value::text)"
-                        "  FROM jsonb_array_elements_text("
-                        "    idx->'allowedRolesAndUsers')"
-                        ") WHERE zoid IN ("
-                        "  SELECT zoid FROM object_state"
-                        "  WHERE idx IS NOT NULL"
-                        "  AND idx ? 'allowedRolesAndUsers'"
-                        "  AND allowed_roles IS NULL"
-                        "  LIMIT %s"
-                        ")",
-                        (_BACKFILL_BATCH,),
-                    )
-                    updated = cur.rowcount
-
-                if updated == 0:
-                    break
-                done += updated
-                log.info("Backfill allowed_roles: %d / %d rows", done, total)
-
-            log.info("Backfill allowed_roles complete: %d rows", done)
-    except Exception:
-        log.warning(
-            "Failed to backfill allowed_roles "
-            "(lock timeout or other error). "
-            "Will retry on next startup.",
             exc_info=True,
         )
 

--- a/src/plone/pgcatalog/startup.py
+++ b/src/plone/pgcatalog/startup.py
@@ -128,6 +128,7 @@ def register_catalog_processor(event):
         _sync_registry_from_db(db)
         _ensure_text_indexes(storage)
         _ensure_field_indexes(storage)
+        _backfill_extra_idx_columns(storage)
 
         # Enable refs prefetch for cataloged content objects only.
         # Non-content objects (BTrees, PersistentMappings, etc.) have
@@ -287,6 +288,124 @@ def _ensure_field_indexes(storage):  # pragma: no cover
             "(lock timeout or other error) --- "
             "custom field queries may be slow until indexes are created. "
             "Indexes will be retried on next startup.",
+            exc_info=True,
+        )
+
+
+_BACKFILL_BATCH = 5000
+
+
+def _backfill_extra_idx_columns(storage):  # pragma: no cover
+    """Backfill dedicated columns from idx JSONB for extracted keys.
+
+    Runs at startup after schema DDL.  Processes rows where the dedicated
+    column is NULL but the key exists in idx JSONB.  Each batch is a small
+    UPDATE with autocommit (short lock, no long transactions).
+    Safe to re-run (idempotent via IS NULL check).
+    """
+    dsn = getattr(storage, "_dsn", None)
+    if not dsn:
+        return
+
+    # Define backfill queries for each extracted column.
+    # Each tuple: (column_name, idx_key, SQL to extract value from idx)
+    backfills = [
+        (
+            "object_provides",
+            "object_provides",
+            "SELECT array_agg(value::text) "
+            "FROM jsonb_array_elements_text(idx->'object_provides')",
+        ),
+        (
+            "allowed_roles",
+            "allowedRolesAndUsers",
+            "SELECT array_agg(value::text) "
+            "FROM jsonb_array_elements_text(idx->'allowedRolesAndUsers')",
+        ),
+        (
+            "meta",
+            "@meta",
+            None,  # JSONB: direct assignment idx->'@meta'
+        ),
+    ]
+
+    try:
+        with psycopg.connect(dsn, autocommit=True) as conn:
+            conn.execute("SET lock_timeout = '5s'")
+
+            for col_name, idx_key, extract_sql in backfills:
+                # Check if column exists (may not if DDL hasn't run yet)
+                try:
+                    conn.execute(
+                        f"SELECT 1 FROM object_state WHERE {col_name} IS NULL LIMIT 1"
+                    )
+                except Exception:
+                    continue
+
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT COUNT(*) AS cnt FROM object_state "
+                        "WHERE idx IS NOT NULL "
+                        f"AND idx ? %s "
+                        f"AND {col_name} IS NULL",
+                        (idx_key,),
+                    )
+                    total = cur.fetchone()[0]
+
+                if total == 0:
+                    continue
+
+                log.info(
+                    "Backfilling %s for %d rows (batch size %d)",
+                    col_name,
+                    total,
+                    _BACKFILL_BATCH,
+                )
+
+                done = 0
+                while True:
+                    with conn.cursor() as cur:
+                        if extract_sql:
+                            # TEXT[] columns: use subquery extraction
+                            cur.execute(
+                                f"UPDATE object_state SET {col_name} = ("
+                                f"  {extract_sql}"
+                                ") WHERE zoid IN ("
+                                "  SELECT zoid FROM object_state"
+                                "  WHERE idx IS NOT NULL"
+                                f"  AND idx ? %s"
+                                f"  AND {col_name} IS NULL"
+                                "  LIMIT %s"
+                                ")",
+                                (idx_key, _BACKFILL_BATCH),
+                            )
+                        else:
+                            # JSONB columns: direct assignment
+                            cur.execute(
+                                f"UPDATE object_state SET {col_name} = "
+                                f"idx->%s "
+                                "WHERE zoid IN ("
+                                "  SELECT zoid FROM object_state"
+                                "  WHERE idx IS NOT NULL"
+                                f"  AND idx ? %s"
+                                f"  AND {col_name} IS NULL"
+                                "  LIMIT %s"
+                                ")",
+                                (idx_key, idx_key, _BACKFILL_BATCH),
+                            )
+                        updated = cur.rowcount
+
+                    if updated == 0:
+                        break
+                    done += updated
+                    log.info("Backfill %s: %d / %d rows", col_name, done, total)
+
+                log.info("Backfill %s complete: %d rows", col_name, done)
+    except Exception:
+        log.warning(
+            "Failed to backfill extra idx columns "
+            "(lock timeout or other error). "
+            "Will retry on next startup.",
             exc_info=True,
         )
 

--- a/src/plone/pgcatalog/suggestions.py
+++ b/src/plone/pgcatalog/suggestions.py
@@ -42,7 +42,7 @@ _NON_IDX_FIELDS = frozenset(
 _DEDICATED_FIELDS = {
     "allowedRolesAndUsers": "allowed_roles (dedicated TEXT[] column + GIN)",
     "SearchableText": "searchable_text (dedicated tsvector column + GIN)",
-    "object_provides": "idx_os_cat_provides_gin (dedicated GIN index)",
+    "object_provides": "object_provides (dedicated TEXT[] column + GIN)",
     "Subject": "idx_os_cat_subject_gin (dedicated GIN index)",
 }
 

--- a/tests/test_clean_break.py
+++ b/tests/test_clean_break.py
@@ -205,7 +205,8 @@ class TestCounter:
     def test_counter_with_pg(self, pg_conn, tool):
         """getCounter returns last_value from pgcatalog_change_seq."""
         tool._get_pg_read_connection = lambda: pg_conn
-        pg_conn.execute("CREATE SEQUENCE IF NOT EXISTS pgcatalog_change_seq")
+        pg_conn.execute("DROP SEQUENCE IF EXISTS pgcatalog_change_seq")
+        pg_conn.execute("CREATE SEQUENCE pgcatalog_change_seq")
         pg_conn.commit()
         # Advance the sequence
         pg_conn.execute("SELECT nextval('pgcatalog_change_seq')")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -441,12 +441,13 @@ class TestCatalogStateProcessor:
 
         processor = CatalogStateProcessor()
         columns = processor.get_extra_columns()
-        assert len(columns) == 6
         names = [c.name for c in columns]
         assert "path" in names
         assert "parent_path" in names
         assert "path_depth" in names
         assert "idx" in names
+        assert "meta" in names
+        assert "object_provides" in names
         assert "allowed_roles" in names
         assert "searchable_text" in names
 
@@ -496,6 +497,8 @@ class TestCatalogStateProcessor:
             "path_depth": None,
             "idx": None,
             "searchable_text": None,
+            "meta": None,
+            "object_provides": None,
             "allowed_roles": None,
         }
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -533,6 +533,226 @@ class TestCatalogStateProcessor:
         assert result["searchable_text"] is None
 
 
+class TestExtraIdxColumns:
+    """Tests for ExtraIdxColumn registry and extraction."""
+
+    def test_default_registrations(self):
+        from plone.pgcatalog.columns import get_extra_idx_column_for_key
+
+        meta = get_extra_idx_column_for_key("@meta")
+        assert meta is not None
+        assert meta.column_name == "meta"
+        assert meta.column_type == "JSONB"
+
+        provides = get_extra_idx_column_for_key("object_provides")
+        assert provides is not None
+        assert provides.column_name == "object_provides"
+        assert provides.column_type == "TEXT[]"
+        assert provides.gin_index is True
+
+        roles = get_extra_idx_column_for_key("allowedRolesAndUsers")
+        assert roles is not None
+        assert roles.column_name == "allowed_roles"
+        assert roles.column_type == "TEXT[]"
+
+    def test_lookup_nonexistent_returns_none(self):
+        from plone.pgcatalog.columns import get_extra_idx_column_for_key
+
+        assert get_extra_idx_column_for_key("nonexistent") is None
+
+    def test_extract_pops_keys_from_idx(self):
+        from plone.pgcatalog.columns import extract_extra_idx_columns
+
+        idx = {
+            "Title": "Test",
+            "@meta": {"image_scales": {}},
+            "object_provides": ["IContentish"],
+            "allowedRolesAndUsers": ["Anonymous"],
+        }
+        extra = extract_extra_idx_columns(idx)
+
+        # Keys popped from idx
+        assert "@meta" not in idx
+        assert "object_provides" not in idx
+        assert "allowedRolesAndUsers" not in idx
+        assert idx["Title"] == "Test"
+
+        # Values in extra dict
+        assert extra["object_provides"] == ["IContentish"]
+        assert extra["allowed_roles"] == ["Anonymous"]
+        # meta is Json-wrapped
+        assert extra["meta"].obj == {"image_scales": {}}
+
+    def test_extract_missing_keys_returns_none(self):
+        from plone.pgcatalog.columns import extract_extra_idx_columns
+
+        idx = {"Title": "Test"}
+        extra = extract_extra_idx_columns(idx)
+
+        assert extra["meta"] is None
+        assert extra["object_provides"] is None
+        assert extra["allowed_roles"] is None
+
+    def test_extract_empty_dict_returns_empty(self):
+        from plone.pgcatalog.columns import extract_extra_idx_columns
+
+        assert extract_extra_idx_columns({}) == {}
+        assert extract_extra_idx_columns(None) == {}
+
+    def test_validate_identifier_on_register(self):
+        from plone.pgcatalog.columns import ExtraIdxColumn
+        from plone.pgcatalog.columns import register_extra_idx_column
+
+        with pytest.raises(ValueError, match="Invalid identifier"):
+            register_extra_idx_column(
+                ExtraIdxColumn(
+                    idx_key="test",
+                    column_name="Robert'; DROP TABLE --",
+                    column_type="TEXT",
+                    value_expr="%(x)s",
+                )
+            )
+
+
+class TestExtraIdxProcess:
+    """Tests for ExtraIdxColumn extraction in CatalogStateProcessor."""
+
+    def setup_method(self):
+        _clean_pending()
+
+    def teardown_method(self):
+        _clean_pending()
+
+    def test_process_extracts_all_extra_columns(self):
+        from plone.pgcatalog.pending import set_pending
+        from plone.pgcatalog.processor import CatalogStateProcessor
+        from psycopg.types.json import Json
+
+        idx = {
+            "Title": "Test",
+            "@meta": {"image_scales": {}},
+            "object_provides": ["IContentish"],
+            "allowedRolesAndUsers": ["Anonymous"],
+        }
+        set_pending(42, {"path": "/plone/test", "idx": idx, "searchable_text": None})
+
+        processor = CatalogStateProcessor()
+        result = processor.process(42, "mod", "Cls", {})
+
+        # Extra columns extracted
+        assert isinstance(result["meta"], Json)
+        assert result["meta"].obj == {"image_scales": {}}
+        assert result["object_provides"] == ["IContentish"]
+        assert result["allowed_roles"] == ["Anonymous"]
+
+        # Keys NOT in idx anymore
+        idx_result = result["idx"]
+        assert isinstance(idx_result, Json)
+        assert "@meta" not in idx_result.obj
+        assert "object_provides" not in idx_result.obj
+        assert "allowedRolesAndUsers" not in idx_result.obj
+        assert idx_result.obj["Title"] == "Test"
+
+
+class TestBrainMetaResolution:
+    """Tests for brain attribute resolution from meta column."""
+
+    def test_brain_reads_from_meta_column(self):
+        from plone.pgcatalog.brain import PGCatalogBrain
+        from plone.pgcatalog.columns import get_registry
+
+        registry = get_registry()
+        registry.add_metadata("image_scales")
+
+        row = {
+            "zoid": 1,
+            "path": "/plone/test",
+            "idx": {"Title": "Test"},
+            # meta column with JSON-native value (no codec needed)
+            "meta": {"image_scales": {"preview": {"w": 400}}},
+        }
+        brain = PGCatalogBrain(row)
+
+        # image_scales is JSON-native, accessible directly from meta
+        # (decode_meta would fail on non-codec data, but __contains__
+        # checks name in meta_col first — and it IS there)
+        assert "image_scales" in brain
+
+    def test_brain_falls_back_to_idx_meta(self):
+        from plone.pgcatalog.brain import PGCatalogBrain
+
+        row = {
+            "zoid": 2,
+            "path": "/plone/old",
+            "idx": {"Title": "Old"},
+            "meta": None,  # pre-migration: meta column not populated
+        }
+        brain = PGCatalogBrain(row)
+
+        # Title comes from top-level idx
+        assert brain.Title == "Old"
+
+    def test_contains_checks_meta_column(self):
+        from plone.pgcatalog.brain import PGCatalogBrain
+
+        row = {
+            "zoid": 3,
+            "path": "/plone/test",
+            "idx": {"Title": "Test"},
+            "meta": {"some_field": "value"},
+        }
+        brain = PGCatalogBrain(row)
+        assert "some_field" in brain
+        assert "Title" in brain
+        assert "nonexistent" not in brain
+
+
+class TestQueryRedirection:
+    """Tests for keyword query redirection to dedicated columns."""
+
+    def test_object_provides_uses_column(self):
+        from plone.pgcatalog.columns import get_registry
+        from plone.pgcatalog.columns import IndexType
+        from plone.pgcatalog.query import build_query
+
+        registry = get_registry()
+        if "object_provides" not in registry:
+            registry.register(
+                "object_provides",
+                IndexType.KEYWORD,
+                "object_provides",
+                ["object_provides"],
+            )
+
+        qr = build_query(
+            {"object_provides": {"query": ["IContentish"], "operator": "or"}}
+        )
+
+        assert "object_provides" in qr["where"]
+        assert "idx->'object_provides'" not in qr["where"]
+
+    def test_allowed_roles_uses_column(self):
+        from plone.pgcatalog.columns import get_registry
+        from plone.pgcatalog.columns import IndexType
+        from plone.pgcatalog.query import build_query
+
+        registry = get_registry()
+        if "allowedRolesAndUsers" not in registry:
+            registry.register(
+                "allowedRolesAndUsers",
+                IndexType.KEYWORD,
+                "allowedRolesAndUsers",
+                ["allowedRolesAndUsers"],
+            )
+
+        qr = build_query(
+            {"allowedRolesAndUsers": {"query": ["Anonymous"], "operator": "or"}}
+        )
+
+        assert "allowed_roles" in qr["where"]
+        assert "idx->'allowedRolesAndUsers'" not in qr["where"]
+
+
 class TestGetMainStorage:
     def test_returns_storage_directly(self):
         from plone.pgcatalog.startup import _get_main_storage


### PR DESCRIPTION
## Summary

Closes #98

- Introduces generic `ExtraIdxColumn` mechanism to declaratively extract heavy keys from the `idx` JSONB column into dedicated PG columns
- Extracts three keys: `@meta` → `meta JSONB`, `object_provides` → `object_provides TEXT[]`, `allowedRolesAndUsers` → `allowed_roles TEXT[]`
- Replaces all hardcoded `allowed_roles` handling with the generic mechanism
- Removes `_backfill_allowed_roles` startup function (superseded)
- Expected idx size reduction: ~85% (3.2 KB → ~400 B avg, below TOAST threshold)

### What changes

| File | Change |
|---|---|
| `columns.py` | `ExtraIdxColumn` dataclass + registry + 3 default registrations |
| `schema.py` | DDL for `meta JSONB` + `object_provides TEXT[]` + GIN index |
| `processor.py` | Generic extraction loop in `process()` + `get_extra_columns()` |
| `query.py` | Generic `get_extra_idx_column_for_key()` replaces hardcoded check |
| `brain.py` | `_resolve_from_idx()` checks `meta` column first, `idx["@meta"]` fallback |
| `search.py` | `meta` added to SELECT columns |
| `indexing.py` | `_extract_extra_columns()` replaces hardcoded `allowed_roles` extraction |
| `startup.py` | `_backfill_allowed_roles()` removed |

### Migration

- DDL uses `IF NOT EXISTS` — safe for rolling deploys
- Brain fallback handles pre-migration data transparently
- Run `clear_and_rebuild` after deployment to populate new columns

## Test plan

- [x] All 1202 existing tests pass (0 failures)
- [x] Processor uncatalog sentinel includes new columns
- [x] `get_extra_columns()` returns meta + object_provides + allowed_roles
- [x] Lazy batch load fetches meta column
- [ ] Integration test with PG: full write→query→read cycle
- [ ] Verify on staging/prod after `clear_and_rebuild`

🤖 Generated with [Claude Code](https://claude.com/claude-code)