### PR TITLE
feat: use testcontainers fallback for test PostgreSQL

### DIFF
--- a/src/plone/pgcatalog/testing.py
+++ b/src/plone/pgcatalog/testing.py
@@ -24,7 +24,6 @@ from plone.testing import Layer
 from zope.configuration import xmlconfig
 
 import logging
-import os
 
 
 log = logging.getLogger(__name__)
@@ -100,14 +99,12 @@ class PGCatalogPGFixture(Layer):
     def setUp(self):
         from plone.pgcatalog.schema import install_catalog_schema
         from zodb_pgjsonb.storage import PGJsonbStorage
+        from zodb_pgjsonb.testing import get_test_dsn
         from zodb_pgjsonb.testing import PGTestDB
 
         import ZODB
 
-        dsn = os.environ.get(
-            "ZODB_TEST_DSN",
-            "dbname=zodb_test user=zodb password=zodb host=localhost port=5433",
-        )
+        dsn = get_test_dsn()
 
         # 1. Set up PG database with base + catalog schema
         self._test_db = PGTestDB(dsn)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from plone.pgcatalog.testing import PGCATALOG_INTEGRATION_TESTING
 from psycopg.rows import dict_row
 from psycopg.types.json import Json
 from zodb_pgjsonb.schema import HISTORY_FREE_SCHEMA
+from zodb_pgjsonb.testing import get_test_dsn
 from zope.pytestlayer import fixture
 
 import os
@@ -136,12 +137,8 @@ def populated_registry():
     return registry
 
 
-# Allow DSN override via environment variable for CI.
-# Default: local Docker on port 5433 (development setup).
-DSN = os.environ.get(
-    "ZODB_TEST_DSN",
-    "dbname=zodb_test user=zodb password=zodb host=localhost port=5433",
-)
+# Resolved once at import time (testcontainers auto-start if needed).
+DSN = get_test_dsn()
 
 # BM25 tests need vchord_bm25 + pg_tokenizer extensions.
 # Default: vchord-suite container on port 5434.


### PR DESCRIPTION
## Summary

- Use `get_test_dsn()` from `zodb_pgjsonb.testing` in `conftest.py` and `PGCatalogPGFixture` instead of hardcoded `os.environ.get()` DSN resolution
- Requires zodb-pgjsonb with testcontainers support (see bluedynamics/zodb-pgjsonb#14)

## Test plan

- [x] All 275 plone-pgcatalog tests pass with testcontainers fallback (1 pre-existing failure in `test_counter_with_pg`)
- [ ] Verify CI still works with `ZODB_TEST_DSN` env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)