### PR TITLE
fix: startup DDL self-deadlock (#100)

### DIFF
--- a/src/plone/pgcatalog/startup.py
+++ b/src/plone/pgcatalog/startup.py
@@ -126,8 +126,22 @@ def register_catalog_processor(event):
         storage.register_state_processor(processor)
         log.info("Registered CatalogStateProcessor on %s", storage)
         _sync_registry_from_db(db)
-        _ensure_text_indexes(storage)
-        _ensure_field_indexes(storage)
+        # Defer index creation to first write transaction (#100).
+        # At this point a ZODB Connection holds an open REPEATABLE READ
+        # snapshot (ACCESS SHARE), which would block CREATE INDEX (needs
+        # ACCESS EXCLUSIVE).  defer_startup_action() queues the work for
+        # tpc_begin() when the read snapshot has been committed.
+        if hasattr(storage, "defer_startup_action"):
+            storage.defer_startup_action(
+                _make_ensure_text_indexes_action(), "ensure_text_indexes"
+            )
+            storage.defer_startup_action(
+                _make_ensure_field_indexes_action(), "ensure_field_indexes"
+            )
+        else:
+            # Fallback for older zodb-pgjsonb without defer_startup_action
+            _ensure_text_indexes(storage)
+            _ensure_field_indexes(storage)
         _backfill_allowed_roles(storage)
 
         # Enable refs prefetch for cataloged content objects only.
@@ -150,6 +164,116 @@ def register_catalog_processor(event):
             _start_inprocess_worker(dsn, tika_url, storage)
     else:
         log.debug("Storage %s does not support state processors", storage)
+
+
+def _make_ensure_text_indexes_action():
+    """Return a callable(dsn) that creates text indexes when invoked.
+
+    Captures the current IndexRegistry state.  The callable is passed
+    to ``storage.defer_startup_action()`` and executed during the first
+    write transaction when REPEATABLE READ locks are released.
+    """
+    registry = get_registry()
+    text_indexes = [
+        (name, idx_key)
+        for name, (idx_type, idx_key, _) in registry.items()
+        if idx_type == IndexType.TEXT and idx_key is not None
+    ]
+    if not text_indexes:
+        return lambda dsn: None
+
+    def _action(dsn):  # pragma: no cover
+        try:
+            from psycopg import sql as pgsql
+
+            with psycopg.connect(dsn, autocommit=True) as conn:
+                conn.execute("SET lock_timeout = '30s'")
+                for name, idx_key in text_indexes:
+                    validate_identifier(idx_key)
+                    idx_name = f"idx_os_cat_{idx_key.lower()}_tsv"
+                    stmt = pgsql.SQL(
+                        "CREATE INDEX IF NOT EXISTS {idx_name} "
+                        "ON object_state USING gin ("
+                        "to_tsvector('simple'::regconfig, "
+                        "COALESCE(idx->>{idx_key}, ''))) "
+                        "WHERE idx IS NOT NULL"
+                    ).format(
+                        idx_name=pgsql.Identifier(idx_name),
+                        idx_key=pgsql.Literal(idx_key),
+                    )
+                    conn.execute(stmt)
+                    log.info("Ensured GIN text index %s for %s", idx_name, name)
+        except Exception:
+            log.warning(
+                "Failed to create text expression indexes "
+                "(lock timeout or other error) — "
+                "text field queries may be slow until indexes are created. "
+                "Indexes will be retried on next startup.",
+                exc_info=True,
+            )
+
+    return _action
+
+
+def _make_ensure_field_indexes_action():
+    """Return a callable(dsn) that creates field indexes when invoked.
+
+    Captures the current IndexRegistry state.  The callable is passed
+    to ``storage.defer_startup_action()`` and executed during the first
+    write transaction when REPEATABLE READ locks are released.
+    """
+    registry = get_registry()
+    candidates = [
+        (name, idx_type, idx_key)
+        for name, (idx_type, idx_key, _) in registry.items()
+        if idx_type in _BTREE_INDEX_TYPES
+        and idx_key is not None
+        and idx_key not in _HARDCODED_IDX_KEYS
+    ]
+    if not candidates:
+        return lambda dsn: None
+
+    def _action(dsn):  # pragma: no cover
+        try:
+            from psycopg import sql as pgsql
+
+            with psycopg.connect(dsn, autocommit=True) as conn:
+                conn.execute("SET lock_timeout = '30s'")
+                for name, idx_type, idx_key in candidates:
+                    validate_identifier(idx_key)
+                    idx_name = f"idx_os_cat_{idx_key.lower()}"
+
+                    if idx_type == IndexType.DATE:
+                        expr = pgsql.SQL(
+                            "pgcatalog_to_timestamptz(idx->>{key})"
+                        ).format(key=pgsql.Literal(idx_key))
+                    else:
+                        expr = pgsql.SQL("(idx->>{key})").format(
+                            key=pgsql.Literal(idx_key)
+                        )
+
+                    stmt = pgsql.SQL(
+                        "CREATE INDEX IF NOT EXISTS {idx_name} "
+                        "ON object_state ({expr}) "
+                        "WHERE idx IS NOT NULL"
+                    ).format(idx_name=pgsql.Identifier(idx_name), expr=expr)
+                    conn.execute(stmt)
+                    log.info(
+                        "Ensured btree index %s for %s (%s)",
+                        idx_name,
+                        name,
+                        idx_type.value,
+                    )
+        except Exception:
+            log.warning(
+                "Failed to create field expression indexes "
+                "(lock timeout or other error) — "
+                "custom field queries may be slow until indexes are created. "
+                "Indexes will be retried on next startup.",
+                exc_info=True,
+            )
+
+    return _action
 
 
 def _ensure_text_indexes(storage):  # pragma: no cover

--- a/src/plone/pgcatalog/suggestions.py
+++ b/src/plone/pgcatalog/suggestions.py
@@ -346,9 +346,15 @@ def apply_index(conn, ddl, timeout=_DEFAULT_INDEX_TIMEOUT):  # pragma: no cover
     if "OBJECT_STATE" not in ddl_upper:
         return (False, "DDL must target object_state table", 0.0)
 
-    # Extract index name for logging
+    # Extract and validate index name
     m = re.search(r"(?:CREATE INDEX\s+(?:CONCURRENTLY\s+)?)(\S+)", ddl, re.I)
     idx_name = m.group(1) if m else "unknown"
+    if not _SAFE_NAME_RE.match(idx_name):
+        return (False, f"Invalid index name: {idx_name!r}", 0.0)
+
+    # Validate timeout format (e.g. "5min", "300s", "300000ms")
+    if not re.match(r"^\d+\s*(ms|s|min|h)?$", timeout):
+        return (False, f"Invalid timeout format: {timeout!r}", 0.0)
 
     old_autocommit = conn.autocommit
     try:
@@ -356,7 +362,7 @@ def apply_index(conn, ddl, timeout=_DEFAULT_INDEX_TIMEOUT):  # pragma: no cover
 
         # Drop INVALID index from a previously aborted CONCURRENTLY build.
         # An INVALID index blocks new CREATE INDEX on the same name and
-        # wastes disk space.
+        # wastes disk space.  idx_name is validated above.
         with conn.cursor() as cur:
             cur.execute(
                 "SELECT 1 FROM pg_index i "

--- a/src/plone/pgcatalog/suggestions.py
+++ b/src/plone/pgcatalog/suggestions.py
@@ -7,6 +7,7 @@ the IndexRegistry and existing indexes as input and returns suggestions.
 
 from plone.pgcatalog.columns import IndexType
 
+import contextlib
 import logging
 import re
 import time
@@ -313,15 +314,27 @@ def explain_query(conn, sql, params):  # pragma: no cover
         return {"error": str(exc)}
 
 
-def apply_index(conn, ddl):  # pragma: no cover
+_DEFAULT_INDEX_TIMEOUT = "5min"
+
+
+def apply_index(conn, ddl, timeout=_DEFAULT_INDEX_TIMEOUT):  # pragma: no cover
     """Create an index using CREATE INDEX CONCURRENTLY.
 
     The connection must support autocommit (CONCURRENTLY cannot run
     inside a transaction block).
 
+    Before building, checks for and drops any INVALID index with the
+    same name (left behind by a previously aborted CONCURRENTLY build).
+
+    Sets ``statement_timeout`` to prevent indefinite hangs when other
+    sessions hold long-running REPEATABLE READ transactions (#100).
+    The default timeout is 5 minutes; if exceeded, the build is aborted
+    and can be retried later.
+
     Args:
         conn: psycopg connection
         ddl: full CREATE INDEX CONCURRENTLY statement
+        timeout: PG interval string for statement_timeout (default 5min)
 
     Returns:
         tuple (success: bool, message: str, duration_seconds: float)
@@ -340,7 +353,26 @@ def apply_index(conn, ddl):  # pragma: no cover
     old_autocommit = conn.autocommit
     try:
         conn.autocommit = True
-        log.info("Creating index: %s", ddl)
+
+        # Drop INVALID index from a previously aborted CONCURRENTLY build.
+        # An INVALID index blocks new CREATE INDEX on the same name and
+        # wastes disk space.
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM pg_index i "
+                "JOIN pg_class c ON c.oid = i.indexrelid "
+                "WHERE c.relname = %s AND NOT i.indisvalid",
+                (idx_name,),
+            )
+            if cur.fetchone():
+                log.warning(
+                    "Dropping INVALID index %s (aborted previous build)",
+                    idx_name,
+                )
+                conn.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {idx_name}")
+
+        conn.execute(f"SET statement_timeout = '{timeout}'")
+        log.info("Creating index (timeout=%s): %s", timeout, ddl)
         t0 = time.monotonic()
         conn.execute(ddl)
         duration = time.monotonic() - t0
@@ -354,6 +386,8 @@ def apply_index(conn, ddl):  # pragma: no cover
         log.error("Index creation failed: %s — %s", idx_name, exc)
         return (False, f"Index creation failed: {exc}", 0.0)
     finally:
+        with contextlib.suppress(Exception):
+            conn.execute("SET statement_timeout = 0")
         conn.autocommit = old_autocommit
 
 


### PR DESCRIPTION
## Summary

Fixes #100 — self-deadlock where `CREATE INDEX` / `ALTER TABLE` during startup blocks against the same process's own REPEATABLE READ snapshot.

**Three commits addressing two related problems:**

### Problem 1: Startup DDL blocked by own read transaction

At `IDatabaseOpenedWithRoot` time, a ZODB Connection holds an open REPEATABLE READ snapshot (ACCESS SHARE on `object_state`). DDL statements (ALTER TABLE, CREATE INDEX) need ACCESS EXCLUSIVE → self-deadlock.

**Fix (commit 1):** `_ensure_text_indexes` and `_ensure_field_indexes` now defer via `storage.defer_startup_action()` (new API in zodb-pgjsonb) instead of running immediately. The deferred actions execute during `tpc_begin()` when the read snapshot has been committed. Falls back to direct execution for older zodb-pgjsonb.

**Companion PR:** [bluedynamics/zodb-pgjsonb `fix/startup-ddl-deadlock-100`](https://github.com/bluedynamics/zodb-pgjsonb/compare/fix/startup-ddl-deadlock-100) — `_apply_processor_ddl()` always defers + new `defer_startup_action()` API.

### Problem 2: `CREATE INDEX CONCURRENTLY` hangs indefinitely

`CREATE INDEX CONCURRENTLY` ignores `lock_timeout` — it's a 3-phase operation that must wait for ALL running transactions to finish. On multi-pod deployments this can hang forever.

**Fix (commit 2):**
- `apply_index()` sets `statement_timeout = '5min'` before the CONCURRENTLY build. If exceeded, the build aborts cleanly.
- Before building, detects and drops INVALID indexes left by previously aborted builds (they block new builds on the same name).

## Test plan

- [ ] Deploy to staging with new indexes not yet created
- [ ] Verify pods start without hanging
- [ ] Verify `CREATE INDEX CONCURRENTLY` via ZMI "Apply" button works
- [ ] Verify timeout aborts cleanly after 5min
- [ ] Verify INVALID index cleanup works (abort a build, retry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)