### PR TITLE
fix: ZMI index suggestion error display (#104)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.0.0b49
+
+### Fixed
+
+- Gracefully handle missing `meta` column in `_load_idx_batch()` (#105).
+  Falls back to `SELECT zoid, idx` if the column does not exist yet,
+  preventing `UndefinedColumn` crash on first read after upgrade.
+  Root cause fix is in zodb-pgjsonb 1.10.4 (`poll_invalidations` now
+  applies deferred DDL before the read snapshot).
+
+- Show index creation errors in red instead of green in ZMI (#104).
+  `manage_apply_index` / `manage_drop_index` now redirect with
+  `index_error` param on failure, rendered as Bootstrap `alert-danger`.
+
 ## 1.0.0b48
 
 ### Fixed

--- a/src/plone/pgcatalog/brain.py
+++ b/src/plone/pgcatalog/brain.py
@@ -288,11 +288,23 @@ class CatalogSearchResults(Lazy):
         zoids = list(brain_map.keys())
 
         with self._conn.cursor() as cur:
-            cur.execute(
-                "SELECT zoid, idx, meta FROM object_state WHERE zoid = ANY(%(zoids)s)",
-                {"zoids": zoids},
-                prepare=True,
-            )
+            try:
+                cur.execute(
+                    "SELECT zoid, idx, meta FROM object_state"
+                    " WHERE zoid = ANY(%(zoids)s)",
+                    {"zoids": zoids},
+                    prepare=True,
+                )
+            except Exception:
+                # Column 'meta' may not exist yet if DDL was deferred and
+                # not yet applied (e.g. first read after upgrade).  Fall
+                # back to querying without it (#105).
+                self._conn.rollback()
+                cur.execute(
+                    "SELECT zoid, idx FROM object_state WHERE zoid = ANY(%(zoids)s)",
+                    {"zoids": zoids},
+                    prepare=True,
+                )
             for row in cur:
                 brain = brain_map.get(row["zoid"])
                 if brain is not None:

--- a/src/plone/pgcatalog/catalog.py
+++ b/src/plone/pgcatalog/catalog.py
@@ -1190,11 +1190,12 @@ class PlonePGCatalogTool(UniqueObject, Folder):
         from plone.pgcatalog.suggestions import apply_index
 
         msg = "No action taken"
+        success = False
         try:
             pool = get_pool(self)
             pg_conn = pool.getconn()
             try:
-                _success, msg, _duration = apply_index(pg_conn, ddl)
+                success, msg, _duration = apply_index(pg_conn, ddl)
             finally:
                 pool.putconn(pg_conn)
         except Exception as exc:
@@ -1203,10 +1204,15 @@ class PlonePGCatalogTool(UniqueObject, Folder):
         if REQUEST is not None:
             from urllib.parse import quote
 
-            REQUEST.RESPONSE.redirect(
-                f"{self.absolute_url()}/manage_slowQueries"
-                f"?manage_tabs_message={quote(msg)}"
-            )
+            if success:
+                REQUEST.RESPONSE.redirect(
+                    f"{self.absolute_url()}/manage_slowQueries"
+                    f"?manage_tabs_message={quote(msg)}"
+                )
+            else:
+                REQUEST.RESPONSE.redirect(
+                    f"{self.absolute_url()}/manage_slowQueries?index_error={quote(msg)}"
+                )
         return msg
 
     def manage_drop_index(self, index_name, REQUEST=None):  # pragma: no cover
@@ -1214,11 +1220,12 @@ class PlonePGCatalogTool(UniqueObject, Folder):
         from plone.pgcatalog.suggestions import drop_index
 
         msg = "No action taken"
+        success = False
         try:
             pool = get_pool(self)
             pg_conn = pool.getconn()
             try:
-                _success, msg, _duration = drop_index(pg_conn, index_name)
+                success, msg, _duration = drop_index(pg_conn, index_name)
             finally:
                 pool.putconn(pg_conn)
         except Exception as exc:
@@ -1227,10 +1234,15 @@ class PlonePGCatalogTool(UniqueObject, Folder):
         if REQUEST is not None:
             from urllib.parse import quote
 
-            REQUEST.RESPONSE.redirect(
-                f"{self.absolute_url()}/manage_slowQueries"
-                f"?manage_tabs_message={quote(msg)}"
-            )
+            if success:
+                REQUEST.RESPONSE.redirect(
+                    f"{self.absolute_url()}/manage_slowQueries"
+                    f"?manage_tabs_message={quote(msg)}"
+                )
+            else:
+                REQUEST.RESPONSE.redirect(
+                    f"{self.absolute_url()}/manage_slowQueries?index_error={quote(msg)}"
+                )
         return msg
 
     def manage_clear_slow_queries(self, REQUEST=None):

--- a/src/plone/pgcatalog/www/catalogSlowQueries.dtml
+++ b/src/plone/pgcatalog/www/catalogSlowQueries.dtml
@@ -3,6 +3,12 @@
 
 <main class="container-fluid">
 
+<dtml-if "REQUEST.get('index_error')">
+<div class="alert alert-danger mt-3" role="alert">
+  <dtml-var "REQUEST['index_error']" html_quote>
+</div>
+</dtml-if>
+
 <dtml-let stats="manage_get_slow_query_stats()">
 
 <div class="card mt-3 mb-3">

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -92,6 +92,30 @@ class TestSuggestIndexes:
         new = [s for s in result if s["status"] == "new"]
         assert any("((idx->>'is_folderish')::boolean)" in s["ddl"] for s in new)
 
+    def test_boolean_in_composite_has_outer_parens(self):
+        """Boolean cast in composite index must be wrapped in expression parens.
+
+        Without outer parens, PG parser sees (idx->>'field')::boolean and
+        interprets ')' as closing the index expression, leaving ::boolean
+        as an invalid token.  Regression test for #104.
+        """
+        registry = _reg(
+            portal_type=IndexType.FIELD,
+            exclude_from_nav=IndexType.BOOLEAN,
+        )
+        result = suggest_indexes(["portal_type", "exclude_from_nav"], registry, {})
+        composites = [
+            s for s in result if s["status"] == "new" and len(s["fields"]) > 1
+        ]
+        assert len(composites) == 1
+        ddl = composites[0]["ddl"]
+        # The boolean expression must have double parens so ::boolean is
+        # inside the CREATE INDEX expression grouping:
+        #   ... ((idx->>'exclude_from_nav')::boolean) ...
+        # NOT:
+        #   ... (idx->>'exclude_from_nav')::boolean ...
+        assert "((idx->>'exclude_from_nav')::boolean)" in ddl
+
     def test_uuid_uses_text_expression(self):
         registry = _reg(UID=IndexType.UUID)
         result = suggest_indexes(["UID"], registry, {})


### PR DESCRIPTION
## Summary

Fixes #104

- **Red error alerts**: `manage_apply_index` and `manage_drop_index` now distinguish success/failure using the `success` return flag. Errors redirect via `index_error` query param and display as a Bootstrap `alert-danger` (red) instead of `manage_tabs_message` (always green).
- **Regression test**: New test `test_boolean_in_composite_has_outer_parens` verifies that composite BOOLEAN index DDL wraps `::boolean` in proper expression parentheses — the root cause of the syntax error when pressing "Apply".

## Test plan

- [x] `test_suggestions.py` — all 24 tests pass (including new composite BOOLEAN test)
- [ ] Manual: trigger a slow query with a BOOLEAN field, verify Apply works and errors show in red

🤖 Generated with [Claude Code](https://claude.com/claude-code)