### PR TITLE
Log all queries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.0b50
+
+### Changed
+
+- Add feature to log all queries for debugging purposes by setting the
+  environment variable `PGCATALOG_LOG_ALL_QUERIES=1`.
+
 ## 1.0.0b49
 
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,13 +1,22 @@
 # Changelog
 
-## 1.0.0b50
-
-### Changed
-
-- Add feature to log all queries for debugging purposes by setting the
-  environment variable `PGCATALOG_LOG_ALL_QUERIES=1`.
-
 ## 1.0.0b49
+
+### Added
+
+- Log all catalog queries for debugging via
+  `PGCATALOG_LOG_ALL_QUERIES=1` (also accepts `true`/`yes`).  Enabled
+  queries are logged at INFO level with duration, SQL, params, and
+  query keys.  Params are truncated at 2000 chars to bound log size.
+  The env var is re-checked on every query, so the setting can be
+  toggled at runtime without a restart.  See
+  `docs/how-to/debug-queries.md` for details and a production-safety
+  warning about logging user-supplied query values.
+
+- Slow-query log format changed slightly: the prefix is now
+  `Slow SQL catalog query (%.2f ms)` instead of
+  `Slow catalog query (%.1f ms)` — log-aggregation grep patterns may
+  need an update.
 
 ### Fixed
 

--- a/docs/sources/how-to/debug-queries.md
+++ b/docs/sources/how-to/debug-queries.md
@@ -1,0 +1,169 @@
+<!-- diataxis: how-to -->
+
+# Debug SQL queries
+
+## Overview
+
+PlonePGCatalog provides multiple ways to debug and monitor SQL queries generated from catalog searches. This is useful when troubleshooting performance issues or understanding how catalog queries are translated to PostgreSQL.
+
+## Environment variables
+
+### PGCATALOG_LOG_ALL_QUERIES
+
+Log all SQL queries to the Python logger at INFO level.
+
+**Usage:**
+```bash
+export PGCATALOG_LOG_ALL_QUERIES=1
+# or
+export PGCATALOG_LOG_ALL_QUERIES=true
+# or
+export PGCATALOG_LOG_ALL_QUERIES=yes
+```
+
+**Log output format:**
+```
+INFO plone.pgcatalog.search SQL catalog query (1.23 ms): SELECT zoid, path FROM object_state WHERE idx IS NOT NULL AND idx @> $1::jsonb | params: {'p_portal_type_1': {'portal_type': 'Document'}} | keys: ['portal_type']
+```
+
+**Performance impact:** Minimal when disabled (single environment variable check). When enabled, adds ~0.1ms per query for logging overhead.
+
+### PGCATALOG_SLOW_QUERY_MS
+
+Control the threshold for slow query logging (default: 10ms).
+
+**Usage:**
+```bash
+export PGCATALOG_SLOW_QUERY_MS=100  # Log queries > 100ms
+export PGCATALOG_SLOW_QUERY_MS=0.1  # Log all queries (via slow query system)
+```
+
+Slow queries are logged at WARNING level and stored in the `pgcatalog_slow_queries` table for analysis via the ZMI.
+
+## Debugging workflow
+
+### 1. Enable query logging
+
+For comprehensive debugging:
+```bash
+export PGCATALOG_LOG_ALL_QUERIES=1
+```
+
+For slow query analysis only:
+```bash
+export PGCATALOG_SLOW_QUERY_MS=50  # Adjust threshold as needed
+```
+
+### 2. Configure Python logging
+
+Enable INFO level logging for the search module:
+
+```python
+import logging
+logging.getLogger('plone.pgcatalog.search').setLevel(logging.INFO)
+```
+
+Or in your `zope.conf`:
+```xml
+<logger>
+  name plone.pgcatalog.search
+  level info
+</logger>
+```
+
+### 3. Run your problematic query
+
+Execute the catalog search that's causing issues:
+
+```python
+# In Python/debug console
+results = portal.portal_catalog.searchResults(
+    portal_type='Document',
+    review_state='published'
+)
+```
+
+### 4. Analyze the logged SQL
+
+The log output shows:
+- **Duration**: Query execution time in milliseconds
+- **SQL**: The actual PostgreSQL query
+- **Params**: Parameter values used in the query
+- **Keys**: Original catalog query keys
+
+Example log entry:
+```
+INFO plone.pgcatalog.search SQL catalog query (1.23 ms): SELECT zoid, path FROM object_state WHERE idx IS NOT NULL AND idx @> $1::jsonb AND idx @> $2::jsonb | params: {'p_portal_type_1': {'portal_type': 'Document'}, 'p_review_state_2': {'review_state': 'published'}} | keys: ['portal_type', 'review_state']
+```
+
+### 5. Test the query directly in PostgreSQL
+
+Copy the SQL and parameters to test directly:
+
+```sql
+-- Connect to your database
+psql "dbname=zodb host=localhost port=5432 user=zodb"
+
+-- Test the query with actual parameter values
+SELECT zoid, path
+FROM object_state
+WHERE idx IS NOT NULL
+  AND idx @> '{"portal_type": "Document"}'::jsonb
+  AND idx @> '{"review_state": "published"}'::jsonb;
+
+-- Analyze query performance
+EXPLAIN ANALYZE SELECT zoid, path
+FROM object_state
+WHERE idx IS NOT NULL
+  AND idx @> '{"portal_type": "Document"}'::jsonb
+  AND idx @> '{"review_state": "published"}'::jsonb;
+```
+
+## ZMI interface
+
+Access the **Slow Queries** tab at `/portal_catalog/manage_slowQueries` to:
+
+- View aggregated slow query statistics
+- Get index suggestions for common slow queries
+- Run EXPLAIN plans on recorded slow queries
+- Create suggested indexes to improve performance
+
+## Production considerations
+
+### Recommended settings for production
+
+```bash
+# Log only genuinely slow queries
+export PGCATALOG_SLOW_QUERY_MS=100
+
+# Disable comprehensive query logging in production
+# (omit PGCATALOG_LOG_ALL_QUERIES or set to 0/false)
+```
+
+### Debugging specific issues
+
+For temporary debugging in production:
+
+1. Enable query logging with a time limit:
+   ```bash
+   export PGCATALOG_LOG_ALL_QUERIES=1
+   # Restart application
+   # Reproduce the issue
+   # Disable logging and restart
+   ```
+
+2. Use PostgreSQL's built-in logging:
+   ```sql
+   -- Temporarily log all queries
+   ALTER SYSTEM SET log_statement = 'all';
+   SELECT pg_reload_conf();
+
+   -- Restore normal logging
+   ALTER SYSTEM RESET log_statement;
+   SELECT pg_reload_conf();
+   ```
+
+## See also
+
+- [Query raw SQL](query-raw-sql.md) - Direct PostgreSQL queries
+- [Deploy production](deploy-production.md) - Production configuration

--- a/docs/sources/how-to/debug-queries.md
+++ b/docs/sources/how-to/debug-queries.md
@@ -2,6 +2,18 @@
 
 # Debug SQL queries
 
+```{warning}
+Query parameters can contain user-supplied values, including search
+terms, UUIDs, or filter values that qualify as PII in some jurisdictions.
+Logging them at INFO level and shipping those logs to aggregators such
+as Elasticsearch or Loki creates a data-leak risk.
+
+Enable `PGCATALOG_LOG_ALL_QUERIES` only in development or for short-lived
+production debugging sessions, and review your log retention and
+aggregation policies before enabling it anywhere that logs leave the
+host.
+```
+
 ## Overview
 
 PlonePGCatalog provides multiple ways to debug and monitor SQL queries generated from catalog searches. This is useful when troubleshooting performance issues or understanding how catalog queries are translated to PostgreSQL.
@@ -27,6 +39,10 @@ INFO plone.pgcatalog.search SQL catalog query (1.23 ms): SELECT zoid, path FROM 
 ```
 
 **Performance impact:** Minimal when disabled (single environment variable check). When enabled, adds ~0.1ms per query for logging overhead.
+
+**Runtime toggle:** The setting is read on every query, not cached at import time. You can enable and disable logging without restarting the process, for example via `os.environ` in a debug console.
+
+**Parameter truncation:** The parameter string representation is truncated at 2000 characters with a `... (truncated)` suffix. This keeps log lines bounded when a query has huge values (for example, `path IN (...)` with thousands of entries).
 
 ### PGCATALOG_SLOW_QUERY_MS
 

--- a/src/plone/pgcatalog/search.py
+++ b/src/plone/pgcatalog/search.py
@@ -17,11 +17,37 @@ import time
 log = logging.getLogger(__name__)
 
 _SLOW_QUERY_MS = float(os.environ.get("PGCATALOG_SLOW_QUERY_MS", "10"))
-_LOG_ALL_QUERIES = os.environ.get("PGCATALOG_LOG_ALL_QUERIES", "").lower() in (
-    "1",
-    "true",
-    "yes",
-)
+
+# Max length of the params repr included in log lines.  Larger payloads
+# (e.g. 10k-entry path lists) are truncated to keep log output bounded.
+_LOG_PARAMS_MAX_LEN = 2000
+
+
+def _log_all_queries_enabled():
+    """Return True if PGCATALOG_LOG_ALL_QUERIES is set to a truthy value.
+
+    Checked on every query rather than cached at import time so the
+    setting can be toggled at runtime (e.g. temporarily for production
+    debugging) without a restart.  The overhead is a single dict lookup
+    per query, negligible compared to the PG round trip.
+    """
+    return os.environ.get("PGCATALOG_LOG_ALL_QUERIES", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def _truncate_params_repr(params):
+    """Return a bounded ``repr()`` of *params* for log output.
+
+    Guards against a single log line blowing up when a query uses huge
+    parameter values (e.g. ``path IN (...)`` with thousands of entries).
+    """
+    s = repr(params)
+    if len(s) > _LOG_PARAMS_MAX_LEN:
+        return s[:_LOG_PARAMS_MAX_LEN] + "... (truncated)"
+    return s
 
 
 def _record_slow_query(conn, query_keys, duration_ms, sql, params):
@@ -158,7 +184,8 @@ def _run_search(conn, query, catalog=None, lazy_conn=None):
     duration_ms = (time.monotonic() - t0) * 1000
 
     is_slow = duration_ms > _SLOW_QUERY_MS
-    if is_slow or _LOG_ALL_QUERIES:
+    log_all = _log_all_queries_enabled()
+    if is_slow or log_all:
         query_keys = sorted(query.keys())
         msg = "SQL catalog query (%.2f ms): %s | params: %s | keys: %s"
         msg = f"Slow {msg}" if is_slow else msg
@@ -168,7 +195,7 @@ def _run_search(conn, query, catalog=None, lazy_conn=None):
             msg,
             duration_ms,
             sql,
-            qr["params"],
+            _truncate_params_repr(qr["params"]),
             query_keys or [],
         )
         if is_slow:

--- a/src/plone/pgcatalog/search.py
+++ b/src/plone/pgcatalog/search.py
@@ -17,6 +17,11 @@ import time
 log = logging.getLogger(__name__)
 
 _SLOW_QUERY_MS = float(os.environ.get("PGCATALOG_SLOW_QUERY_MS", "10"))
+_LOG_ALL_QUERIES = os.environ.get("PGCATALOG_LOG_ALL_QUERIES", "").lower() in (
+    "1",
+    "true",
+    "yes",
+)
 
 
 def _record_slow_query(conn, query_keys, duration_ms, sql, params):
@@ -152,15 +157,22 @@ def _run_search(conn, query, catalog=None, lazy_conn=None):
         rows = cur.fetchall()
     duration_ms = (time.monotonic() - t0) * 1000
 
-    if duration_ms > _SLOW_QUERY_MS:
+    is_slow = duration_ms > _SLOW_QUERY_MS
+    if is_slow or _LOG_ALL_QUERIES:
         query_keys = sorted(query.keys())
-        log.warning(
-            "Slow catalog query (%.1f ms): keys=%s sql=%s",
+        msg = "SQL catalog query (%.2f ms): %s | params: %s | keys: %s"
+        msg = f"Slow {msg}" if is_slow else msg
+        logger = log.warning if is_slow else log.info
+
+        logger(
+            msg,
             duration_ms,
-            query_keys,
             sql,
+            qr["params"],
+            query_keys or [],
         )
-        _record_slow_query(conn, query_keys, duration_ms, sql, qr["params"])
+        if is_slow:
+            _record_slow_query(conn, query_keys, duration_ms, sql, qr["params"])
 
     actual_count = None
     if has_limit and rows:

--- a/tests/test_slow_queries.py
+++ b/tests/test_slow_queries.py
@@ -1,8 +1,9 @@
 """Tests for slow query logging."""
 
-from plone.pgcatalog.search import _LOG_ALL_QUERIES
+from plone.pgcatalog.search import _log_all_queries_enabled
 from plone.pgcatalog.search import _record_slow_query
 from plone.pgcatalog.search import _SLOW_QUERY_MS
+from plone.pgcatalog.search import _truncate_params_repr
 from unittest import mock
 
 import os
@@ -62,33 +63,49 @@ class TestRecordSlowQuery:
 class TestQueryLoggingConfiguration:
     """Test query logging configuration via environment variables."""
 
-    def test_default_log_all_queries(self):
-        """Test default value of LOG_ALL_QUERIES."""
-        # Should be boolean (actual value depends on environment)
-        assert isinstance(_LOG_ALL_QUERIES, bool)
+    def test_default_log_all_queries_disabled(self, monkeypatch):
+        """Without the env var, logging is disabled."""
+        monkeypatch.delenv("PGCATALOG_LOG_ALL_QUERIES", raising=False)
+        assert _log_all_queries_enabled() is False
 
-    def test_log_all_queries_env_override(self):
-        """Test LOG_ALL_QUERIES environment variable override."""
-        # Test with enabled
-        with mock.patch.dict(os.environ, {"PGCATALOG_LOG_ALL_QUERIES": "1"}):
-            from plone.pgcatalog import search
+    def test_log_all_queries_enabled_values(self, monkeypatch):
+        """Truthy values enable logging (case-insensitive)."""
+        for value in ("1", "true", "yes", "True", "YES", "TrUe"):
+            monkeypatch.setenv("PGCATALOG_LOG_ALL_QUERIES", value)
+            assert _log_all_queries_enabled() is True, f"{value!r} should enable"
 
-            import importlib
+    def test_log_all_queries_falsey_values(self, monkeypatch):
+        """Non-truthy values leave logging disabled."""
+        for value in ("", "0", "false", "no", "off", "disabled"):
+            monkeypatch.setenv("PGCATALOG_LOG_ALL_QUERIES", value)
+            assert _log_all_queries_enabled() is False, f"{value!r} should disable"
 
-            importlib.reload(search)
-            assert search._LOG_ALL_QUERIES is True
+    def test_log_all_queries_runtime_toggle(self, monkeypatch):
+        """Toggling the env var takes effect on the next call (no restart)."""
+        monkeypatch.delenv("PGCATALOG_LOG_ALL_QUERIES", raising=False)
+        assert _log_all_queries_enabled() is False
+        monkeypatch.setenv("PGCATALOG_LOG_ALL_QUERIES", "1")
+        assert _log_all_queries_enabled() is True
+        monkeypatch.setenv("PGCATALOG_LOG_ALL_QUERIES", "0")
+        assert _log_all_queries_enabled() is False
 
-        # Test with disabled
-        with mock.patch.dict(os.environ, {"PGCATALOG_LOG_ALL_QUERIES": "false"}):
-            importlib.reload(search)
-            assert search._LOG_ALL_QUERIES is False
 
-        # Test with different true values
-        for value in ["true", "yes", "True", "YES"]:
-            with mock.patch.dict(os.environ, {"PGCATALOG_LOG_ALL_QUERIES": value}):
-                importlib.reload(search)
-                assert search._LOG_ALL_QUERIES is True
+class TestTruncateParamsRepr:
+    """Test params truncation for log output."""
 
-        # Restore
-        os.environ.pop("PGCATALOG_LOG_ALL_QUERIES", None)
-        importlib.reload(search)
+    def test_short_params_unchanged(self):
+        assert _truncate_params_repr({"a": 1}) == "{'a': 1}"
+
+    def test_empty_params(self):
+        assert _truncate_params_repr({}) == "{}"
+
+    def test_long_params_truncated(self):
+        huge = {"paths": [f"/plone/page-{i}" for i in range(1000)]}
+        result = _truncate_params_repr(huge)
+        assert len(result) <= 2100  # 2000 + truncation marker
+        assert result.endswith("... (truncated)")
+
+    def test_short_list_unchanged(self):
+        # Small enough to fit under 2000 bytes
+        result = _truncate_params_repr({"paths": ["/a", "/b", "/c"]})
+        assert not result.endswith("(truncated)")

--- a/tests/test_slow_queries.py
+++ b/tests/test_slow_queries.py
@@ -1,5 +1,6 @@
 """Tests for slow query logging."""
 
+from plone.pgcatalog.search import _LOG_ALL_QUERIES
 from plone.pgcatalog.search import _record_slow_query
 from plone.pgcatalog.search import _SLOW_QUERY_MS
 from unittest import mock
@@ -56,3 +57,38 @@ class TestRecordSlowQuery:
         mock_conn.execute.assert_called_once()
         call_sql = mock_conn.execute.call_args[0][0]
         assert "pgcatalog_slow_queries" in call_sql
+
+
+class TestQueryLoggingConfiguration:
+    """Test query logging configuration via environment variables."""
+
+    def test_default_log_all_queries(self):
+        """Test default value of LOG_ALL_QUERIES."""
+        # Should be boolean (actual value depends on environment)
+        assert isinstance(_LOG_ALL_QUERIES, bool)
+
+    def test_log_all_queries_env_override(self):
+        """Test LOG_ALL_QUERIES environment variable override."""
+        # Test with enabled
+        with mock.patch.dict(os.environ, {"PGCATALOG_LOG_ALL_QUERIES": "1"}):
+            from plone.pgcatalog import search
+
+            import importlib
+
+            importlib.reload(search)
+            assert search._LOG_ALL_QUERIES is True
+
+        # Test with disabled
+        with mock.patch.dict(os.environ, {"PGCATALOG_LOG_ALL_QUERIES": "false"}):
+            importlib.reload(search)
+            assert search._LOG_ALL_QUERIES is False
+
+        # Test with different true values
+        for value in ["true", "yes", "True", "YES"]:
+            with mock.patch.dict(os.environ, {"PGCATALOG_LOG_ALL_QUERIES": value}):
+                importlib.reload(search)
+                assert search._LOG_ALL_QUERIES is True
+
+        # Restore
+        os.environ.pop("PGCATALOG_LOG_ALL_QUERIES", None)
+        importlib.reload(search)


### PR DESCRIPTION
- Add feature to log all queries for debugging purposes by setting the
  environment variable `PGCATALOG_LOG_ALL_QUERIES=1`.