### PR TITLE
Always cast Boolean values to JSON notation.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,14 @@
 
 ### Fixed
 
-- Always cast Boolean values to JSON notation.
-  This fixes problems with queries returning no results because they were using
-  Boolean values in Python notation
+- Stringify Boolean query values to JSON notation (`'true'`/`'false'`) so
+  queries against JSONB `->>` comparisons match.  Previously `str(True)`
+  produced `'True'` which never matched JSONB's lowercase form, causing
+  queries to return no results.  Fix applied in `query.py` (all field
+  handlers), `pgindex.py` (ZCatalog `_index.get()` compat),
+  `addons_compat/eeafacetednavigation.py` (faceted search dispatch),
+  and `backends.py` (text search backends).  Helper renamed from
+  `_to_json_string` to `_bool_to_lower_str` to match what it actually does.
 
 ## 1.0.0b49
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.0b50
+
+### Fixed
+
+- Always cast Boolean values to JSON notation.
+  This fixes problems with queries returning no results because they were using
+  Boolean values in Python notation
+
 ## 1.0.0b49
 
 ### Fixed

--- a/src/plone/pgcatalog/addons_compat/eeafacetednavigation.py
+++ b/src/plone/pgcatalog/addons_compat/eeafacetednavigation.py
@@ -14,6 +14,7 @@ from plone.pgcatalog.interfaces import IPGCatalogTool
 from plone.pgcatalog.interfaces import IPGIndexTranslator
 from plone.pgcatalog.pool import get_pool
 from plone.pgcatalog.pool import get_request_connection
+from plone.pgcatalog.query import _bool_to_lower_str
 from Products.CMFCore.utils import getToolByName
 from psycopg.types.json import Json
 from zope.component import queryUtility
@@ -67,7 +68,7 @@ def _dispatch_by_type(conn, idx_type, idx_key, value):
     """Run the appropriate SQL for the given IndexType."""
 
     if idx_type in (IndexType.FIELD, IndexType.GOPIP, IndexType.UUID):
-        return _query_jsonb_contains(conn, idx_key, str(value))
+        return _query_jsonb_contains(conn, idx_key, _bool_to_lower_str(value))
 
     if idx_type == IndexType.KEYWORD:
         return _query_keyword(conn, idx_key, value)
@@ -76,7 +77,7 @@ def _dispatch_by_type(conn, idx_type, idx_key, value):
         return _query_jsonb_contains(conn, idx_key, bool(value))
 
     if idx_type == IndexType.DATE:
-        return _query_jsonb_contains(conn, idx_key, str(value))
+        return _query_jsonb_contains(conn, idx_key, _bool_to_lower_str(value))
 
     # DATE_RANGE, TEXT, PATH -- not supported in faceted single-index apply
     return frozenset()

--- a/src/plone/pgcatalog/backends.py
+++ b/src/plone/pgcatalog/backends.py
@@ -11,6 +11,7 @@ segmenter).  A fallback column handles unconfigured languages.
 """
 
 from plone.pgcatalog.columns import validate_identifier
+from plone.pgcatalog.query import _bool_to_lower_str
 from psycopg import sql as pgsql
 
 import abc
@@ -248,8 +249,8 @@ class TsvectorBackend(SearchBackend):
         )
 
         params = {
-            p_text: str(query_val),
-            p_lang: str(lang_val) if lang_val else "",
+            p_text: _bool_to_lower_str(query_val),
+            p_lang: _bool_to_lower_str(lang_val) if lang_val else "",
         }
 
         return where, params, rank

--- a/src/plone/pgcatalog/catalog.py
+++ b/src/plone/pgcatalog/catalog.py
@@ -1346,7 +1346,7 @@ class PlonePGCatalogTool(UniqueObject, Folder):
             elif v is None:
                 display = ""
             elif isinstance(v, bool):
-                display = "True" if v else "False"
+                display = "true" if v else "false"
             else:
                 display = str(v)
             idx_items.append({"key": k, "value": display, "is_none": v is None})

--- a/src/plone/pgcatalog/pgindex.py
+++ b/src/plone/pgcatalog/pgindex.py
@@ -21,6 +21,7 @@ matching ``getpath()``/``getrid()`` on the catalog.
 
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from plone.pgcatalog.query import _bool_to_lower_str
 from Products.ZCatalog.ZCatalogIndexes import ZCatalogIndexes
 
 import logging
@@ -52,7 +53,7 @@ class _PGIndexMapping:
         with conn.cursor() as cur:
             cur.execute(
                 "SELECT zoid FROM object_state WHERE idx->>%(key)s = %(val)s LIMIT 1",
-                {"key": self._idx_key, "val": str(value)},
+                {"key": self._idx_key, "val": _bool_to_lower_str(value)},
             )
             row = cur.fetchone()
         return row["zoid"] if row else default

--- a/src/plone/pgcatalog/query.py
+++ b/src/plone/pgcatalog/query.py
@@ -63,11 +63,14 @@ def _lookup_translator(name):
         return None
 
 
-def _to_json_string(value):
-    """Convert a Python value to JSON-standard string representation.
+def _bool_to_lower_str(value):
+    """Stringify a value, lowercasing booleans to match JSONB ``->>`` output.
 
-    This ensures boolean values are converted to JSON format ('true'/'false')
-    instead of Python format ('True'/'False').
+    JSONB ``->>`` returns boolean values as lowercase ``'true'`` / ``'false'``,
+    but Python's ``str(True)`` returns ``'True'`` / ``'False'``.  Query
+    parameters must use the JSONB form or the comparison never matches.
+
+    Non-boolean values are passed through ``str()`` unchanged.
     """
     if isinstance(value, bool):
         return "true" if value else "false"
@@ -287,21 +290,21 @@ class _QueryBuilder:
             elif isinstance(query_val, (list, tuple)):
                 p = self._pname(name)
                 self.clauses.append(f"idx->>'{idx_key}' = ANY(%({p})s)")
-                self.params[p] = [_to_json_string(v) for v in query_val]
+                self.params[p] = [_bool_to_lower_str(v) for v in query_val]
             else:
                 p = self._pname(name)
                 self.clauses.append(f"idx->>'{idx_key}' = %({p})s")
-                self.params[p] = _to_json_string(query_val)
+                self.params[p] = _bool_to_lower_str(query_val)
 
         if not_val is not None:
             if isinstance(not_val, (list, tuple)):
                 p = self._pname(name + "_not")
                 self.clauses.append(f"NOT (idx->>'{idx_key}' = ANY(%({p})s))")
-                self.params[p] = [_to_json_string(v) for v in not_val]
+                self.params[p] = [_bool_to_lower_str(v) for v in not_val]
             else:
                 p = self._pname(name + "_not")
                 self.clauses.append(f"idx->>'{idx_key}' != %({p})s")
-                self.params[p] = _to_json_string(not_val)
+                self.params[p] = _bool_to_lower_str(not_val)
 
     def _field_range(self, idx_key, value, range_spec):
         if range_spec in ("min:max", "minmax") and isinstance(value, (list, tuple)):
@@ -311,16 +314,16 @@ class _QueryBuilder:
                 f"(idx->>'{idx_key}' >= %({p_min})s"
                 f" AND idx->>'{idx_key}' <= %({p_max})s)"
             )
-            self.params[p_min] = _to_json_string(value[0])
-            self.params[p_max] = _to_json_string(value[1])
+            self.params[p_min] = _bool_to_lower_str(value[0])
+            self.params[p_max] = _bool_to_lower_str(value[1])
         elif range_spec == "min":
             p = self._pname(idx_key)
             self.clauses.append(f"idx->>'{idx_key}' >= %({p})s")
-            self.params[p] = _to_json_string(value)
+            self.params[p] = _bool_to_lower_str(value)
         elif range_spec == "max":
             p = self._pname(idx_key)
             self.clauses.append(f"idx->>'{idx_key}' <= %({p})s")
-            self.params[p] = _to_json_string(value)
+            self.params[p] = _bool_to_lower_str(value)
 
     # -- KeywordIndex -------------------------------------------------------
 
@@ -441,7 +444,7 @@ class _QueryBuilder:
             return
         p = self._pname(name)
         self.clauses.append(f"idx->>'{idx_key}' = %({p})s")
-        self.params[p] = _to_json_string(query_val)
+        self.params[p] = _bool_to_lower_str(query_val)
 
     # -- ZCTextIndex (SearchableText / Title / Description) -----------------
 
@@ -461,7 +464,7 @@ class _QueryBuilder:
             lang_val = self._query.get("Language")
             if isinstance(lang_val, dict):
                 lang_val = lang_val.get("query", "")
-            lang_val = _to_json_string(lang_val) if lang_val else ""
+            lang_val = _bool_to_lower_str(lang_val) if lang_val else ""
 
             clause, params, rank_expr = get_backend().build_search_clause(
                 query_val, lang_val, self._pname
@@ -481,7 +484,7 @@ class _QueryBuilder:
                 f"COALESCE(idx->>'{idx_key}', '')) "
                 f"@@ plainto_tsquery('simple'::regconfig, %({p})s)"
             )
-            self.params[p] = _to_json_string(query_val)
+            self.params[p] = _bool_to_lower_str(query_val)
 
     # -- ExtendedPathIndex --------------------------------------------------
 

--- a/src/plone/pgcatalog/query.py
+++ b/src/plone/pgcatalog/query.py
@@ -63,6 +63,17 @@ def _lookup_translator(name):
         return None
 
 
+def _to_json_string(value):
+    """Convert a Python value to JSON-standard string representation.
+
+    This ensures boolean values are converted to JSON format ('true'/'false')
+    instead of Python format ('True'/'False').
+    """
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
 def build_query(query_dict):
     """Translate a ZCatalog query dict into SQL components.
 
@@ -276,21 +287,21 @@ class _QueryBuilder:
             elif isinstance(query_val, (list, tuple)):
                 p = self._pname(name)
                 self.clauses.append(f"idx->>'{idx_key}' = ANY(%({p})s)")
-                self.params[p] = [str(v) for v in query_val]
+                self.params[p] = [_to_json_string(v) for v in query_val]
             else:
                 p = self._pname(name)
                 self.clauses.append(f"idx->>'{idx_key}' = %({p})s")
-                self.params[p] = str(query_val)
+                self.params[p] = _to_json_string(query_val)
 
         if not_val is not None:
             if isinstance(not_val, (list, tuple)):
                 p = self._pname(name + "_not")
                 self.clauses.append(f"NOT (idx->>'{idx_key}' = ANY(%({p})s))")
-                self.params[p] = [str(v) for v in not_val]
+                self.params[p] = [_to_json_string(v) for v in not_val]
             else:
                 p = self._pname(name + "_not")
                 self.clauses.append(f"idx->>'{idx_key}' != %({p})s")
-                self.params[p] = str(not_val)
+                self.params[p] = _to_json_string(not_val)
 
     def _field_range(self, idx_key, value, range_spec):
         if range_spec in ("min:max", "minmax") and isinstance(value, (list, tuple)):
@@ -300,16 +311,16 @@ class _QueryBuilder:
                 f"(idx->>'{idx_key}' >= %({p_min})s"
                 f" AND idx->>'{idx_key}' <= %({p_max})s)"
             )
-            self.params[p_min] = str(value[0])
-            self.params[p_max] = str(value[1])
+            self.params[p_min] = _to_json_string(value[0])
+            self.params[p_max] = _to_json_string(value[1])
         elif range_spec == "min":
             p = self._pname(idx_key)
             self.clauses.append(f"idx->>'{idx_key}' >= %({p})s")
-            self.params[p] = str(value)
+            self.params[p] = _to_json_string(value)
         elif range_spec == "max":
             p = self._pname(idx_key)
             self.clauses.append(f"idx->>'{idx_key}' <= %({p})s")
-            self.params[p] = str(value)
+            self.params[p] = _to_json_string(value)
 
     # -- KeywordIndex -------------------------------------------------------
 
@@ -430,7 +441,7 @@ class _QueryBuilder:
             return
         p = self._pname(name)
         self.clauses.append(f"idx->>'{idx_key}' = %({p})s")
-        self.params[p] = str(query_val)
+        self.params[p] = _to_json_string(query_val)
 
     # -- ZCTextIndex (SearchableText / Title / Description) -----------------
 
@@ -450,7 +461,7 @@ class _QueryBuilder:
             lang_val = self._query.get("Language")
             if isinstance(lang_val, dict):
                 lang_val = lang_val.get("query", "")
-            lang_val = str(lang_val) if lang_val else ""
+            lang_val = _to_json_string(lang_val) if lang_val else ""
 
             clause, params, rank_expr = get_backend().build_search_clause(
                 query_val, lang_val, self._pname
@@ -470,7 +481,7 @@ class _QueryBuilder:
                 f"COALESCE(idx->>'{idx_key}', '')) "
                 f"@@ plainto_tsquery('simple'::regconfig, %({p})s)"
             )
-            self.params[p] = str(query_val)
+            self.params[p] = _to_json_string(query_val)
 
     # -- ExtendedPathIndex --------------------------------------------------
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 from datetime import UTC
+from plone.pgcatalog.query import _to_json_string
 from plone.pgcatalog.query import build_query
 from psycopg.types.json import Json
 from unittest import mock
@@ -505,6 +506,24 @@ class TestEdgeCases:
         assert "nonexistent_index" in qr["where"]
         assert len(qr["params"]) > 0
 
+    def test_unregistered_boolean_field_uses_json_format(self):
+        """Boolean values in unregistered fields should use JSON format ('true'/'false')."""
+        # Test True value
+        qr = build_query({"show_in_sidecalendar": True})
+        assert "show_in_sidecalendar" in qr["where"]
+        param_val = _find_str_param(qr["params"])
+        assert param_val == "true"  # JSON format, not Python "True"
+
+        # Test False value
+        qr = build_query({"show_in_sidecalendar": False})
+        param_val = _find_str_param(qr["params"])
+        assert param_val == "false"  # JSON format, not Python "False"
+
+        # Test boolean in list
+        qr = build_query({"some_boolean_field": [True, False]})
+        param_vals = _find_list_param(qr["params"])
+        assert set(param_vals) == {"true", "false"}
+
     def test_combined_query(self):
         qr = build_query(
             {
@@ -943,3 +962,35 @@ class TestIPGIndexTranslatorQuery:
             assert qr["order_by"] is None
         finally:
             sm.unregisterUtility(provided=IPGIndexTranslator, name="unsortable")
+
+
+# ---------------------------------------------------------------------------
+# Helper Function Tests
+# ---------------------------------------------------------------------------
+
+
+class TestToJsonString:
+    """Test the _to_json_string helper function."""
+
+    def test_boolean_true(self):
+        """Test True converts to 'true'."""
+        assert _to_json_string(True) == "true"
+
+    def test_boolean_false(self):
+        """Test False converts to 'false'."""
+        assert _to_json_string(False) == "false"
+
+    def test_string_passthrough(self):
+        """Test strings are passed through unchanged."""
+        assert _to_json_string("hello") == "hello"
+        assert _to_json_string("True") == "True"  # String "True" stays as-is
+        assert _to_json_string("false") == "false"
+
+    def test_number_conversion(self):
+        """Test numbers are converted to strings."""
+        assert _to_json_string(42) == "42"
+        assert _to_json_string(3.14) == "3.14"
+
+    def test_none_conversion(self):
+        """Test None converts to 'None'."""
+        assert _to_json_string(None) == "None"

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 from datetime import UTC
-from plone.pgcatalog.query import _to_json_string
+from plone.pgcatalog.query import _bool_to_lower_str
 from plone.pgcatalog.query import build_query
 from psycopg.types.json import Json
 from unittest import mock
@@ -969,28 +969,28 @@ class TestIPGIndexTranslatorQuery:
 # ---------------------------------------------------------------------------
 
 
-class TestToJsonString:
-    """Test the _to_json_string helper function."""
+class TestBoolToLowerStr:
+    """Test the _bool_to_lower_str helper function."""
 
     def test_boolean_true(self):
         """Test True converts to 'true'."""
-        assert _to_json_string(True) == "true"
+        assert _bool_to_lower_str(True) == "true"
 
     def test_boolean_false(self):
         """Test False converts to 'false'."""
-        assert _to_json_string(False) == "false"
+        assert _bool_to_lower_str(False) == "false"
 
     def test_string_passthrough(self):
         """Test strings are passed through unchanged."""
-        assert _to_json_string("hello") == "hello"
-        assert _to_json_string("True") == "True"  # String "True" stays as-is
-        assert _to_json_string("false") == "false"
+        assert _bool_to_lower_str("hello") == "hello"
+        assert _bool_to_lower_str("True") == "True"  # String "True" stays as-is
+        assert _bool_to_lower_str("false") == "false"
 
     def test_number_conversion(self):
         """Test numbers are converted to strings."""
-        assert _to_json_string(42) == "42"
-        assert _to_json_string(3.14) == "3.14"
+        assert _bool_to_lower_str(42) == "42"
+        assert _bool_to_lower_str(3.14) == "3.14"
 
     def test_none_conversion(self):
         """Test None converts to 'None'."""
-        assert _to_json_string(None) == "None"
+        assert _bool_to_lower_str(None) == "None"

--- a/tests/test_zmi_helpers.py
+++ b/tests/test_zmi_helpers.py
@@ -274,6 +274,7 @@ class TestManageGetObjectDetail:
         assert item["value"] == "python, zope"
 
     def test_bool_value_display(self, catalog_tool):
+        # Test True value displays as "true"
         row = {
             "path": "/x",
             "idx": {"is_folderish": True},
@@ -286,7 +287,23 @@ class TestManageGetObjectDetail:
             catalog_tool, "_get_pg_read_connection", return_value=mock_conn
         ):
             result = catalog_tool.manage_get_object_detail(zoid=1)
-        assert result["idx_items"][0]["value"] == "True"
+        assert result["idx_items"][0]["value"] == "true"
+
+    def test_bool_false_value_display(self, catalog_tool):
+        # Test False value displays as "false"
+        row = {
+            "path": "/x",
+            "idx": {"is_folderish": False},
+            "has_searchable_text": False,
+            "searchable_text_preview": None,
+        }
+        mock_conn = mock.MagicMock()
+        mock_conn.cursor().__enter__().fetchone.return_value = row
+        with mock.patch.object(
+            catalog_tool, "_get_pg_read_connection", return_value=mock_conn
+        ):
+            result = catalog_tool.manage_get_object_detail(zoid=1)
+        assert result["idx_items"][0]["value"] == "false"
 
     def test_not_found_returns_none(self, catalog_tool):
         mock_conn = mock.MagicMock()


### PR DESCRIPTION
This fixes problems with queries returning no results because they were using Boolean values in Python notation