### PR TITLE
fix: _handle_uuid accepts list/tuple queries (= ANY)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.0.0b50
+
+### Fixed
+
+- `_handle_uuid` now accepts list/tuple queries (uses `= ANY(...)`),
+  matching `_handle_field` semantics.  Previously a list query such as
+  `catalog.searchResults(UID=['f852...'])` was stringified as
+  `str(['f852...'])` → `"['f852...']"` and the JSONB `->>` comparison
+  never matched, so `@@getVocabulary?name=plone.app.vocabularies.Catalog`
+  with a `plone.app.querystring.operation.list.contains` criterion on
+  UID returned an empty vocabulary.
+
 ## 1.0.0b49
 
 ### Added

--- a/src/plone/pgcatalog/query.py
+++ b/src/plone/pgcatalog/query.py
@@ -443,8 +443,14 @@ class _QueryBuilder:
         if query_val is None:
             return
         p = self._pname(name)
-        self.clauses.append(f"idx->>'{idx_key}' = %({p})s")
-        self.params[p] = _bool_to_lower_str(query_val)
+        if isinstance(query_val, (list, tuple)):
+            # e.g. plone.app.querystring ``list.contains`` on UID —
+            # match any element in the list.
+            self.clauses.append(f"idx->>'{idx_key}' = ANY(%({p})s)")
+            self.params[p] = [_bool_to_lower_str(v) for v in query_val]
+        else:
+            self.clauses.append(f"idx->>'{idx_key}' = %({p})s")
+            self.params[p] = _bool_to_lower_str(query_val)
 
     # -- ZCTextIndex (SearchableText / Title / Description) -----------------
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -190,6 +190,29 @@ class TestUUIDIndex:
         param = _find_str_param(qr["params"])
         assert param == "abc123def456"
 
+    def test_list_uses_any(self):
+        """UID=list should use ``= ANY`` so plone.app.querystring
+        ``list.contains`` operator matches any element in the list.
+        Regression test for empty @@getVocabulary results.
+        """
+        qr = build_query({"UID": ["uid-a", "uid-b", "uid-c"]})
+        assert "idx->>'UID' = ANY(" in qr["where"]
+        vals = _find_list_param(qr["params"])
+        assert vals == ["uid-a", "uid-b", "uid-c"]
+
+    def test_tuple_uses_any(self):
+        qr = build_query({"UID": ("uid-a", "uid-b")})
+        assert "idx->>'UID' = ANY(" in qr["where"]
+        vals = _find_list_param(qr["params"])
+        assert vals == ["uid-a", "uid-b"]
+
+    def test_single_element_list(self):
+        """Single-element list still uses ANY (consistent with _handle_field)."""
+        qr = build_query({"UID": ["only-one"]})
+        assert "idx->>'UID' = ANY(" in qr["where"]
+        vals = _find_list_param(qr["params"])
+        assert vals == ["only-one"]
+
 
 # ---------------------------------------------------------------------------
 # SearchableText (ZCTextIndex)


### PR DESCRIPTION
## Problem

`@@getVocabulary?name=plone.app.vocabularies.Catalog&field=...&query={...\"i\":\"UID\",\"o\":\"plone.app.querystring.operation.list.contains\",\"v\":[\"f852...\"]...}&...` returns an empty vocabulary, even when matching objects exist.

## Root cause

`plone.app.querystring`'s `list.contains` operator passes the query value as a Python list:

```python
catalog.searchResults(UID=['f852e07c2eb14aeea6c7b9548f7c531d'])
```

`_handle_uuid` only handled single strings:

```python
self.clauses.append(f\"idx->>'{idx_key}' = %({p})s\")
self.params[p] = _bool_to_lower_str(query_val)
```

For a list, `_bool_to_lower_str(['f852...'])` returns `str(['f852...'])` = `\"['f852...']\"` — the Python **repr** as a single string.  The resulting SQL

```sql
idx->>'UID' = '[''f852...'']'
```

never matches any JSONB `->>` value, so the query returns zero brains and the vocabulary is empty.

## Fix

Accept list/tuple and use `= ANY(%s)`, matching `_handle_field` semantics:

```python
if isinstance(query_val, (list, tuple)):
    self.clauses.append(f\"idx->>'{idx_key}' = ANY(%({p})s)\")
    self.params[p] = [_bool_to_lower_str(v) for v in query_val]
else:
    self.clauses.append(f\"idx->>'{idx_key}' = %({p})s\")
    self.params[p] = _bool_to_lower_str(query_val)
```

## Test plan

Three new regression tests in `TestUUIDIndex`:

- `test_list_uses_any` — multi-element list produces `= ANY(...)`
- `test_tuple_uses_any` — tuples behave the same
- `test_single_element_list` — single-element list also uses ANY (consistent with _handle_field)

All 113 query tests pass.

## Related

Issue 2 (separate, not in this PR): `catalog._catalog.getIndex(name)` returns a raw ZCatalog index with empty BTrees, breaking `plone.app.vocabularies.Keywords` and other vocabularies that bypass `catalog.Indexes[name]`.  To be handled in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)