### PR TITLE
Tika enqueue: resolve NamedBlobFile/Image wrapper OIDs (#115)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Tika enqueue: resolve Dexterity `NamedBlobFile` / `NamedBlobImage`
+  wrapper OIDs via a second-hop lookup through `object_state`, so the
+  queue receives jobs for modern Dexterity File/Image content.
+  Previously `_enqueue_tika_jobs()` only looked up the OIDs it found
+  in the content's state — which are the wrapper OIDs, not the inner
+  `ZODB.blob.Blob` OIDs.  The direct lookup returned zero rows and the
+  enqueue silently skipped.  Flat-state content (legacy/Archetypes-
+  style, where the content state carries a direct `ZODB.blob.Blob`
+  `@ref`) is unchanged.  Closes #115.
+
 ## 1.0.0b49
 
 ### Added

--- a/docs/superpowers/plans/2026-04-13-tika-wrapper-oid.md
+++ b/docs/superpowers/plans/2026-04-13-tika-wrapper-oid.md
@@ -1,0 +1,462 @@
+# Tika Enqueue: Resolve Wrapper OIDs — Implementation Plan
+
+**Goal:** Fix `_enqueue_tika_jobs()` to resolve Dexterity NamedBlobFile/Image wrapper OIDs via a one-level second hop through `object_state`, so Tika jobs are enqueued for the dominant modern-Plone content case.
+
+**Architecture:** In `_enqueue_tika_jobs()`, after the first `blob_state` lookup identifies refs without blob rows, fetch those wrapper OIDs' states from `object_state`, re-run `_collect_ref_oids()` over each wrapper state, and re-query `blob_state` with the derived inner OIDs. The queue row's `blob_zoid` becomes the inner Blob OID.
+
+**Tech Stack:** Python 3.12+, psycopg 3, pytest
+
+**Spec:** `docs/superpowers/specs/2026-04-13-tika-wrapper-oid-design.md`
+
+---
+
+## File Map
+
+- Modify: `src/plone/pgcatalog/processor.py` — `_enqueue_tika_jobs()`
+- Modify: `tests/test_tika_enqueue.py` — add regression + wrapper cases
+- Modify: `CHANGES.md` — changelog entry
+
+---
+
+### Task 1: Write failing integration test for wrapper resolution
+
+**Files:**
+- Modify: `tests/test_tika_enqueue.py` (add method to `TestEnqueueLogic`)
+
+- [ ] **Step 1: Add the test at the end of `TestEnqueueLogic`**
+
+Locate the last method of `TestEnqueueLogic` (`test_process_skips_candidate_without_refs` at ~line 300). Insert this new method **right after** `test_idempotent_enqueue` (~line 271) and before `test_process_accumulates_candidates_with_blob_refs`:
+
+```python
+    @pytest.mark.skipif(not TIKA_URL, reason="PGCATALOG_TIKA_URL not set")
+    def test_enqueue_resolves_wrapper_oid(self, pg_conn_with_queue):
+        """Dexterity NamedBlobFile wrapper: one-level hop to inner Blob.
+
+        Content state @ref points at wrapper (object_state), wrapper
+        state @ref points at Blob (blob_state).  Queue must store the
+        inner Blob OID, not the wrapper.
+        """
+        conn = pg_conn_with_queue
+        content_zoid, wrapper_zoid, blob_zoid, tid = 700, 701, 702, 1
+
+        # Content object has no direct blob entry; its ref points at the
+        # NamedBlobFile wrapper.
+        insert_object(conn, content_zoid, tid)
+        # The wrapper is a persistent object whose state carries the
+        # real Blob @ref.
+        wrapper_state = json.dumps(
+            {
+                "_blob": {
+                    "@ref": [f"{blob_zoid:016x}", "ZODB.blob.Blob"],
+                },
+                "filename": "sample.pdf",
+                "contentType": "application/pdf",
+            }
+        )
+        insert_object(
+            conn,
+            wrapper_zoid,
+            tid,
+            class_mod="plone.namedfile.file",
+            class_name="NamedBlobFile",
+            state=wrapper_state,
+        )
+        self._insert_blob(conn, blob_zoid, tid)
+
+        proc = CatalogStateProcessor()
+        proc._tika_candidates = [
+            {
+                "zoid": content_zoid,
+                "content_type": "application/pdf",
+                "blob_refs": [wrapper_zoid],  # wrapper only, no direct blob
+            }
+        ]
+
+        with conn.cursor(row_factory=tuple_row) as cur:
+            proc._enqueue_tika_jobs(cur)
+        conn.commit()
+
+        rows = self._get_queue(conn)
+        assert len(rows) == 1
+        assert rows[0]["zoid"] == content_zoid
+        assert rows[0]["blob_zoid"] == blob_zoid  # inner, NOT wrapper_zoid
+        assert rows[0]["tid"] == tid
+        assert rows[0]["content_type"] == "application/pdf"
+```
+
+Also at the top of the file, add the `insert_object` import to the existing conftest import block:
+
+```python
+from tests.conftest import insert_object
+```
+
+(Already imported at line 10 — verify it's there; if not, add it.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PGCATALOG_TIKA_URL=http://tika:9998 PYTHONPATH=src .venv/bin/pytest tests/test_tika_enqueue.py::TestEnqueueLogic::test_enqueue_resolves_wrapper_oid -v`
+
+Expected: FAIL — assertion on `len(rows) == 1` fails (0 rows) because current code doesn't resolve the wrapper hop.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add tests/test_tika_enqueue.py
+git commit -m "test: failing regression for NamedBlobFile wrapper OID resolution (#115)"
+```
+
+---
+
+### Task 2: Implement the wrapper resolution in `_enqueue_tika_jobs`
+
+**Files:**
+- Modify: `src/plone/pgcatalog/processor.py:327-373` (the `_enqueue_tika_jobs` method)
+
+- [ ] **Step 1: Replace `_enqueue_tika_jobs` body**
+
+Replace the entire existing method with:
+
+```python
+    def _enqueue_tika_jobs(self, cursor):
+        """Enqueue text extraction jobs for blobs committed in this txn.
+
+        Content objects (File/Image) reference blobs either directly
+        (legacy/Archetypes: content state carries a ``ZODB.blob.Blob``
+        ``@ref``) or via a wrapper (Dexterity NamedBlobFile/Image:
+        content state ``@ref`` points at the wrapper, whose own state
+        carries the ``ZODB.blob.Blob`` ``@ref``).
+
+        Resolution is two-step:
+        1. Look up all candidate refs in ``blob_state``.
+        2. For refs with no blob row, fetch their ``object_state`` row
+           (the wrapper), extract inner ``@ref`` OIDs, look those up in
+           ``blob_state``.
+
+        The queue row stores the *inner* Blob OID as ``blob_zoid`` —
+        the worker fetches blob data from ``blob_state`` using it.
+        """
+        candidates = self._tika_candidates
+        self._tika_candidates = []
+
+        # Collect all referenced oids across all candidates
+        all_refs = set()
+        for c in candidates:
+            all_refs.update(c["blob_refs"])
+        if not all_refs:
+            return
+
+        # Step 1: direct lookup in blob_state
+        cursor.execute(
+            "SELECT DISTINCT ON (zoid) zoid, tid FROM blob_state "
+            "WHERE zoid = ANY(%(zoids)s) ORDER BY zoid, tid DESC",
+            {"zoids": list(all_refs)},
+        )
+        blob_rows = {row[0]: row[1] for row in cursor.fetchall()}
+
+        # Step 2: resolve wrapper refs via object_state second hop
+        # (Dexterity NamedBlobFile/Image: content -> wrapper -> blob)
+        wrapper_to_inner = {}  # wrapper_oid -> list[inner_oid]
+        unresolved = all_refs - set(blob_rows)
+        if unresolved:
+            cursor.execute(
+                "SELECT DISTINCT ON (zoid) zoid, state FROM object_state "
+                "WHERE zoid = ANY(%(zoids)s) ORDER BY zoid, tid DESC",
+                {"zoids": list(unresolved)},
+            )
+            inner_refs = set()
+            for row in cursor.fetchall():
+                wrapper_oid, wrapper_state = row[0], row[1]
+                inner = _collect_ref_oids(wrapper_state)
+                if inner:
+                    wrapper_to_inner[wrapper_oid] = inner
+                    inner_refs.update(inner)
+
+            if inner_refs:
+                cursor.execute(
+                    "SELECT DISTINCT ON (zoid) zoid, tid FROM blob_state "
+                    "WHERE zoid = ANY(%(zoids)s) ORDER BY zoid, tid DESC",
+                    {"zoids": list(inner_refs)},
+                )
+                for row in cursor.fetchall():
+                    blob_rows[row[0]] = row[1]
+
+        if not blob_rows:
+            return
+
+        for c in candidates:
+            content_zoid = c["zoid"]
+            content_type = c.get("content_type")
+            for ref_zoid in c["blob_refs"]:
+                if ref_zoid in blob_rows:
+                    # Direct hit: content ref is a Blob OID
+                    self._insert_queue_row(
+                        cursor, content_zoid, ref_zoid,
+                        blob_rows[ref_zoid], content_type,
+                    )
+                elif ref_zoid in wrapper_to_inner:
+                    # Wrapper hit: content ref is a NamedBlob* wrapper;
+                    # enqueue for each resolvable inner Blob OID.
+                    for inner_zoid in wrapper_to_inner[ref_zoid]:
+                        if inner_zoid in blob_rows:
+                            self._insert_queue_row(
+                                cursor, content_zoid, inner_zoid,
+                                blob_rows[inner_zoid], content_type,
+                            )
+
+    def _insert_queue_row(self, cursor, zoid, blob_zoid, tid, content_type):
+        cursor.execute(
+            "INSERT INTO text_extraction_queue "
+            "  (zoid, blob_zoid, tid, content_type) "
+            "VALUES (%(zoid)s, %(blob_zoid)s, %(tid)s, %(ct)s) "
+            "ON CONFLICT (blob_zoid, tid) DO NOTHING",
+            {
+                "zoid": zoid,
+                "blob_zoid": blob_zoid,
+                "tid": tid,
+                "ct": content_type,
+            },
+        )
+```
+
+Note: the INSERT was extracted to a helper to avoid duplication between the two enqueue branches. Same SQL as before, unchanged semantics.
+
+- [ ] **Step 2: Run the previously-failing test**
+
+Run: `PGCATALOG_TIKA_URL=http://tika:9998 PYTHONPATH=src .venv/bin/pytest tests/test_tika_enqueue.py::TestEnqueueLogic::test_enqueue_resolves_wrapper_oid -v`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the entire tika enqueue test module**
+
+Run: `PGCATALOG_TIKA_URL=http://tika:9998 PYTHONPATH=src .venv/bin/pytest tests/test_tika_enqueue.py -v`
+
+Expected: all previously-passing tests still pass (no regressions); new test passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/plone/pgcatalog/processor.py
+git commit -m "fix(tika): resolve NamedBlobFile/Image wrapper OIDs via object_state hop (#115)"
+```
+
+---
+
+### Task 3: Add edge-case integration tests
+
+**Files:**
+- Modify: `tests/test_tika_enqueue.py` (add to `TestEnqueueLogic`)
+
+- [ ] **Step 1: Add three more tests**
+
+Append after `test_enqueue_resolves_wrapper_oid`:
+
+```python
+    @pytest.mark.skipif(not TIKA_URL, reason="PGCATALOG_TIKA_URL not set")
+    def test_enqueue_mixed_flat_and_wrapper(self, pg_conn_with_queue):
+        """Mix: one candidate has direct blob ref, another has wrapper ref.
+
+        Both should enqueue against the correct inner OID.
+        """
+        conn = pg_conn_with_queue
+
+        # Flat: content 800 -> blob 801 (direct)
+        flat_content, flat_blob, tid = 800, 801, 1
+        insert_object(conn, flat_content, tid)
+        self._insert_blob(conn, flat_blob, tid)
+
+        # Wrapped: content 810 -> wrapper 811 -> blob 812
+        wrap_content, wrap_oid, wrap_blob = 810, 811, 812
+        insert_object(conn, wrap_content, tid)
+        insert_object(
+            conn,
+            wrap_oid,
+            tid,
+            class_mod="plone.namedfile.file",
+            class_name="NamedBlobImage",
+            state=json.dumps(
+                {"_blob": {"@ref": [f"{wrap_blob:016x}", "ZODB.blob.Blob"]}}
+            ),
+        )
+        self._insert_blob(conn, wrap_blob, tid)
+
+        proc = CatalogStateProcessor()
+        proc._tika_candidates = [
+            {
+                "zoid": flat_content,
+                "content_type": "application/pdf",
+                "blob_refs": [flat_blob],
+            },
+            {
+                "zoid": wrap_content,
+                "content_type": "image/png",
+                "blob_refs": [wrap_oid],
+            },
+        ]
+
+        with conn.cursor(row_factory=tuple_row) as cur:
+            proc._enqueue_tika_jobs(cur)
+        conn.commit()
+
+        rows = {r["zoid"]: r for r in self._get_queue(conn)}
+        assert rows[flat_content]["blob_zoid"] == flat_blob
+        assert rows[wrap_content]["blob_zoid"] == wrap_blob
+        assert rows[wrap_content]["content_type"] == "image/png"
+
+    @pytest.mark.skipif(not TIKA_URL, reason="PGCATALOG_TIKA_URL not set")
+    def test_enqueue_wrapper_with_missing_inner_blob(self, pg_conn_with_queue):
+        """Wrapper exists in object_state but inner blob is missing."""
+        conn = pg_conn_with_queue
+        content_zoid, wrapper_zoid, tid = 820, 821, 1
+        missing_blob = 99999
+
+        insert_object(conn, content_zoid, tid)
+        insert_object(
+            conn,
+            wrapper_zoid,
+            tid,
+            class_mod="plone.namedfile.file",
+            class_name="NamedBlobFile",
+            state=json.dumps(
+                {"_blob": {"@ref": [f"{missing_blob:016x}", "ZODB.blob.Blob"]}}
+            ),
+        )
+        # no blob_state row for missing_blob
+
+        proc = CatalogStateProcessor()
+        proc._tika_candidates = [
+            {
+                "zoid": content_zoid,
+                "content_type": "application/pdf",
+                "blob_refs": [wrapper_zoid],
+            }
+        ]
+
+        with conn.cursor(row_factory=tuple_row) as cur:
+            proc._enqueue_tika_jobs(cur)
+        conn.commit()
+
+        assert self._get_queue(conn) == []
+
+    @pytest.mark.skipif(not TIKA_URL, reason="PGCATALOG_TIKA_URL not set")
+    def test_enqueue_ignores_unresolvable_refs(self, pg_conn_with_queue):
+        """Ref with neither blob_state nor object_state entry is a noop."""
+        conn = pg_conn_with_queue
+        content_zoid, tid = 830, 1
+        ghost_ref = 0xDEADBEEF
+
+        insert_object(conn, content_zoid, tid)
+
+        proc = CatalogStateProcessor()
+        proc._tika_candidates = [
+            {
+                "zoid": content_zoid,
+                "content_type": "application/pdf",
+                "blob_refs": [ghost_ref],
+            }
+        ]
+
+        with conn.cursor(row_factory=tuple_row) as cur:
+            proc._enqueue_tika_jobs(cur)
+        conn.commit()
+
+        assert self._get_queue(conn) == []
+```
+
+- [ ] **Step 2: Run the new tests**
+
+Run: `PGCATALOG_TIKA_URL=http://tika:9998 PYTHONPATH=src .venv/bin/pytest tests/test_tika_enqueue.py::TestEnqueueLogic -v`
+
+Expected: all `TestEnqueueLogic` tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_tika_enqueue.py
+git commit -m "test: edge cases for wrapper resolution (mixed, missing inner, unresolvable)"
+```
+
+---
+
+### Task 4: Full suite regression check + changelog
+
+**Files:**
+- Modify: `CHANGES.md`
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `PGCATALOG_TIKA_URL=http://tika:9998 PYTHONPATH=src .venv/bin/pytest -q`
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run again without TIKA_URL to verify skipped tests still skip, unaffected tests still pass**
+
+Run: `PYTHONPATH=src .venv/bin/pytest -q`
+
+Expected: Tika-gated tests skipped; all other tests pass.
+
+- [ ] **Step 3: Read and update CHANGES.md**
+
+Open `CHANGES.md`, identify the current unreleased/dev section (match existing format). Add an entry:
+
+```markdown
+- Tika enqueue: resolve Dexterity NamedBlobFile/NamedBlobImage wrapper
+  OIDs via a second-hop lookup through `object_state`, so the queue
+  receives jobs for modern Dexterity File/Image content. Previously
+  the enqueue path assumed a flat state with a direct
+  `ZODB.blob.Blob` `@ref`, which only held for Archetypes-style
+  content. Closes #115.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGES.md
+git commit -m "docs: changelog entry for wrapper OID resolution fix (#115)"
+```
+
+---
+
+### Task 5: Push branch and open PR
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin fix/tika-wrapper-oid`
+
+- [ ] **Step 2: Create the PR**
+
+Run (adjusting the body if additional context is discovered during implementation):
+
+```bash
+gh pr create --repo bluedynamics/plone-pgcatalog --base main --head fix/tika-wrapper-oid \
+  --title "Tika enqueue: resolve NamedBlobFile/Image wrapper OIDs (#115)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- `_enqueue_tika_jobs()` now resolves Dexterity `NamedBlobFile` /
+  `NamedBlobImage` wrapper OIDs via a one-hop lookup through
+  `object_state` before querying `blob_state`. Wrappers are the
+  standard Dexterity pattern, so previously the Tika queue stayed
+  empty for PDF/Office/image File/Image content.
+- Queue row's `blob_zoid` is the inner `ZODB.blob.Blob` OID
+  (matches what the worker needs).
+- Flat-state fast path unchanged: when the first `blob_state` lookup
+  resolves all refs, no second hop is performed.
+- 4 new integration tests: wrapper-resolve, mixed flat+wrapper,
+  wrapper with missing inner blob, unresolvable ref.
+
+Closes #115
+
+## Test plan
+
+- [x] Failing regression test (`test_enqueue_resolves_wrapper_oid`)
+  added first, implementation flipped it green
+- [x] Edge cases: mixed, missing inner blob, unresolvable ref
+- [x] Full suite still passes (with and without `PGCATALOG_TIKA_URL`)
+- [x] No schema change, no migration
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Report the PR URL.

--- a/docs/superpowers/specs/2026-04-13-tika-wrapper-oid-design.md
+++ b/docs/superpowers/specs/2026-04-13-tika-wrapper-oid-design.md
@@ -1,0 +1,167 @@
+# Tika Enqueue: Resolve Wrapper OIDs — Design Spec
+
+**Issue:** https://github.com/bluedynamics/plone-pgcatalog/issues/115
+**Date:** 2026-04-13
+
+## Problem
+
+With `PGCATALOG_TIKA_URL` configured, a `clearFindAndRebuild` over a
+Plone 6 site with PDF/Office/image content produces **zero** rows in
+`text_extraction_queue`. The cause: `_collect_ref_oids()` walks the
+content object's JSON state one level deep, but Dexterity wraps blob
+fields in `plone.namedfile.file.NamedBlobFile` /
+`NamedBlobImage`. The `@ref` in the content state points at the
+*wrapper*, not at the `ZODB.blob.Blob` sitting one persistent reference
+deeper.
+
+Reference chain for a Dexterity `File`:
+
+```
+Content File          (object_state)
+   .file.@ref ─► NamedBlobFile   (object_state)   ← _collect_ref_oids
+                  ._blob.@ref ─► ZODB.blob.Blob   (blob_state)        ← actual target
+```
+
+`_enqueue_tika_jobs()` queries `blob_state WHERE zoid = ANY(refs)` with
+the wrapper OIDs, gets zero rows, and silently returns. This affects
+every Dexterity File/Image — the dominant case in modern Plone.
+
+## Goal
+
+`_enqueue_tika_jobs()` must resolve wrapper OIDs to the actual blob
+OIDs before querying `blob_state`, so Tika jobs are enqueued for
+NamedBlobFile/Image content.
+
+## Why SQL, not a ZODB object load
+
+1. **Transaction context.** `_enqueue_tika_jobs` runs inside the active
+   `tpc_vote` / `finalize`, using the commit cursor. A second
+   `ZODB.DB.open()` would open a new PG connection with a new
+   REPEATABLE READ snapshot that *cannot* see our own not-yet-committed
+   `object_state` inserts. The cursor can.
+2. **No re-entry into the current ZODB Connection.** The active
+   Connection is mid-commit; re-entering it during commit is
+   semantically invalid and a deadlock risk.
+3. **Symmetry + speed.** The enqueue path already uses SQL to look up
+   `blob_state`. One extra query per transaction beats N pickle
+   decodes + persistent instantiations.
+4. **No class-name hardcoding.** A generic second-hop lookup works for
+   any wrapper type (NamedBlobFile, NamedBlobImage, future wrappers)
+   without maintaining a class whitelist.
+
+## Design
+
+### Approach: one-level second hop
+
+In `_enqueue_tika_jobs`, after the initial `blob_state` query returns
+matches for a subset of refs, fetch the `state` of the *unresolved*
+refs from `object_state`, run `_collect_ref_oids` over each wrapper
+state, and re-query `blob_state` with the derived OIDs.
+
+**One hop only** — no iteration. NamedBlobFile/Image embed the
+`ZODB.blob.Blob` directly; a doubly nested wrapper is not a current
+Plone pattern, and guessing at future ones is YAGNI. If it ever
+matters, the loop structure is an obvious extension.
+
+### Algorithm
+
+```
+all_refs = union of candidate.blob_refs
+blob_rows = SELECT DISTINCT ON (zoid) zoid, tid FROM blob_state WHERE zoid = ANY(all_refs)
+
+unresolved = all_refs - blob_rows.keys
+if unresolved:
+    wrappers = SELECT DISTINCT ON (zoid) zoid, state FROM object_state
+               WHERE zoid = ANY(unresolved)
+    wrapper_to_inner = {}          # wrapper_oid -> list of inner_oids
+    inner_refs = set()
+    for wrapper_oid, state in wrappers:
+        inner = _collect_ref_oids(state)
+        wrapper_to_inner[wrapper_oid] = inner
+        inner_refs.update(inner)
+    if inner_refs:
+        inner_blob_rows = SELECT DISTINCT ON (zoid) zoid, tid FROM blob_state
+                          WHERE zoid = ANY(inner_refs)
+        # Merge: candidate.ref → wrapper → inner blob → tid
+        for candidate c:
+            for ref_zoid in c.blob_refs:
+                if ref_zoid in blob_rows:
+                    enqueue(c.zoid, ref_zoid, blob_rows[ref_zoid])
+                elif ref_zoid in wrapper_to_inner:
+                    for inner_zoid in wrapper_to_inner[ref_zoid]:
+                        if inner_zoid in inner_blob_rows:
+                            enqueue(c.zoid, inner_zoid, inner_blob_rows[inner_zoid])
+```
+
+`DISTINCT ON (zoid) ... ORDER BY zoid, tid DESC` mirrors the existing
+blob lookup — returns the most recent TID per OID, correct in both
+history-free and history-preserving modes.
+
+### What lands in the queue
+
+The queue row stores `zoid` (content), `blob_zoid` (actual Blob OID),
+and `tid`. When resolved via a wrapper, `blob_zoid` is the *inner*
+Blob OID — which is exactly what the Tika worker needs to fetch from
+`blob_state`. The wrapper OID is intentionally discarded; the queue
+has no wrapper column and the worker has no need for it.
+
+### Cost
+
+- Fast path (flat-state content, Archetypes-style): unchanged — zero
+  extra queries when the first `blob_state` lookup resolves everything.
+- Wrapper path (Dexterity File/Image): +2 SQL round-trips per
+  transaction (one `object_state` fetch, one extra `blob_state`
+  fetch). Always batched: one query covers all unresolved refs across
+  all candidates.
+
+## Non-goals
+
+- Recursion beyond one hop. YAGNI.
+- Caching wrapper states across transactions. The unpickled JSON is
+  already cheap; caching invites invalidation bugs.
+- Detecting "this is a wrapper" by class name. The generic
+  unresolved-ref check works for any structure.
+
+## Testing
+
+### Unit tests (no PG)
+
+Extend `test_tika_enqueue.py`:
+
+- **State shape fixture** that mimics a real Dexterity File: content
+  state with `{"file": {"@ref": ["0000…wrapper", "...NamedBlobFile"]}}`,
+  wrapper state with `{"_blob": {"@ref": ["0000…blob", "ZODB.blob.Blob"]}}`.
+- Verify `_collect_ref_oids` on the content state returns only the
+  wrapper OID (documents today's behavior — no regression).
+- Verify `_collect_ref_oids` on the wrapper state returns the blob OID
+  (already covered implicitly, but explicit is better).
+
+### Integration tests (PG)
+
+Extend `TestEnqueueLogic` in `test_tika_enqueue.py`:
+
+- **`test_enqueue_resolves_wrapper_oid`**: seed `object_state` with a
+  wrapper row whose state points to a `blob_state` entry. Run
+  `_enqueue_tika_jobs` with a candidate whose `blob_refs` is the
+  wrapper OID. Assert the queue row has `blob_zoid = inner_blob_oid`,
+  not the wrapper OID.
+- **`test_enqueue_mixed_flat_and_wrapper`**: one candidate with a
+  direct blob ref (flat state), another with a wrapper ref. Both
+  should enqueue against the correct inner OIDs.
+- **`test_enqueue_wrapper_with_missing_inner_blob`**: wrapper exists
+  but the inner blob is absent from `blob_state`. No row enqueued, no
+  error.
+- **`test_enqueue_ignores_unresolvable_refs`**: ref OID has neither a
+  `blob_state` nor an `object_state` entry. Silent no-op, no error.
+
+### Regression coverage
+
+Existing `test_enqueue_blob_with_tika_url` stays green — its candidate
+directly references a blob that exists in `blob_state`, so the first
+query resolves it and the wrapper hop is skipped.
+
+## Rollout
+
+- Single file change: `src/plone/pgcatalog/processor.py`
+- No schema change, no migration
+- Backwards compatible: flat-state fast path is untouched

--- a/src/plone/pgcatalog/processor.py
+++ b/src/plone/pgcatalog/processor.py
@@ -327,12 +327,20 @@ class CatalogStateProcessor:
     def _enqueue_tika_jobs(self, cursor):
         """Enqueue text extraction jobs for blobs committed in this txn.
 
-        Content objects (File/Image) and their Blob sub-objects have
-        *different* ZODB oids.  ``process()`` extracts ``@ref`` oids
-        from the content state; we look those up in ``blob_state`` to
-        find the actual blob zoid + tid.  The queue stores both so the
-        worker can fetch blob data (blob_zoid) and update
-        searchable_text on the content (zoid).
+        Content objects (File/Image) reference blobs either directly
+        (legacy/Archetypes: content state carries a ``ZODB.blob.Blob``
+        ``@ref``) or via a wrapper (Dexterity NamedBlobFile/Image:
+        content state ``@ref`` points at the wrapper, whose own state
+        carries the ``ZODB.blob.Blob`` ``@ref``).
+
+        Resolution is two-step:
+        1. Look up all candidate refs in ``blob_state``.
+        2. For refs with no blob row, fetch their ``object_state`` row
+           (the wrapper), extract inner ``@ref`` OIDs, look those up in
+           ``blob_state``.
+
+        The queue row stores the *inner* Blob OID as ``blob_zoid`` —
+        the worker fetches blob data from ``blob_state`` using it.
         """
         candidates = self._tika_candidates
         self._tika_candidates = []
@@ -344,13 +352,41 @@ class CatalogStateProcessor:
         if not all_refs:
             return
 
-        # Find which referenced oids actually have blobs (latest tid per oid)
+        # Step 1: direct lookup in blob_state
         cursor.execute(
             "SELECT DISTINCT ON (zoid) zoid, tid FROM blob_state "
             "WHERE zoid = ANY(%(zoids)s) ORDER BY zoid, tid DESC",
             {"zoids": list(all_refs)},
         )
         blob_rows = {row[0]: row[1] for row in cursor.fetchall()}
+
+        # Step 2: resolve wrapper refs via object_state second hop
+        # (Dexterity NamedBlobFile/Image: content -> wrapper -> blob)
+        wrapper_to_inner = {}  # wrapper_oid -> list[inner_oid]
+        unresolved = all_refs - set(blob_rows)
+        if unresolved:
+            cursor.execute(
+                "SELECT DISTINCT ON (zoid) zoid, state FROM object_state "
+                "WHERE zoid = ANY(%(zoids)s) ORDER BY zoid, tid DESC",
+                {"zoids": list(unresolved)},
+            )
+            inner_refs = set()
+            for row in cursor.fetchall():
+                wrapper_oid, wrapper_state = row[0], row[1]
+                inner = _collect_ref_oids(wrapper_state)
+                if inner:
+                    wrapper_to_inner[wrapper_oid] = inner
+                    inner_refs.update(inner)
+
+            if inner_refs:
+                cursor.execute(
+                    "SELECT DISTINCT ON (zoid) zoid, tid FROM blob_state "
+                    "WHERE zoid = ANY(%(zoids)s) ORDER BY zoid, tid DESC",
+                    {"zoids": list(inner_refs)},
+                )
+                for row in cursor.fetchall():
+                    blob_rows[row[0]] = row[1]
+
         if not blob_rows:
             return
 
@@ -359,15 +395,37 @@ class CatalogStateProcessor:
             content_type = c.get("content_type")
             for ref_zoid in c["blob_refs"]:
                 if ref_zoid in blob_rows:
-                    cursor.execute(
-                        "INSERT INTO text_extraction_queue "
-                        "  (zoid, blob_zoid, tid, content_type) "
-                        "VALUES (%(zoid)s, %(blob_zoid)s, %(tid)s, %(ct)s) "
-                        "ON CONFLICT (blob_zoid, tid) DO NOTHING",
-                        {
-                            "zoid": content_zoid,
-                            "blob_zoid": ref_zoid,
-                            "tid": blob_rows[ref_zoid],
-                            "ct": content_type,
-                        },
+                    # Direct hit: content ref is a Blob OID
+                    self._insert_queue_row(
+                        cursor,
+                        content_zoid,
+                        ref_zoid,
+                        blob_rows[ref_zoid],
+                        content_type,
                     )
+                elif ref_zoid in wrapper_to_inner:
+                    # Wrapper hit: content ref is a NamedBlob* wrapper;
+                    # enqueue for each resolvable inner Blob OID.
+                    for inner_zoid in wrapper_to_inner[ref_zoid]:
+                        if inner_zoid in blob_rows:
+                            self._insert_queue_row(
+                                cursor,
+                                content_zoid,
+                                inner_zoid,
+                                blob_rows[inner_zoid],
+                                content_type,
+                            )
+
+    def _insert_queue_row(self, cursor, zoid, blob_zoid, tid, content_type):
+        cursor.execute(
+            "INSERT INTO text_extraction_queue "
+            "  (zoid, blob_zoid, tid, content_type) "
+            "VALUES (%(zoid)s, %(blob_zoid)s, %(tid)s, %(ct)s) "
+            "ON CONFLICT (blob_zoid, tid) DO NOTHING",
+            {
+                "zoid": zoid,
+                "blob_zoid": blob_zoid,
+                "tid": tid,
+                "ct": content_type,
+            },
+        )

--- a/tests/test_tika_enqueue.py
+++ b/tests/test_tika_enqueue.py
@@ -324,6 +324,116 @@ class TestEnqueueLogic:
         assert rows[0]["tid"] == tid
         assert rows[0]["content_type"] == "application/pdf"
 
+    @pytest.mark.skipif(not TIKA_URL, reason="PGCATALOG_TIKA_URL not set")
+    def test_enqueue_mixed_flat_and_wrapper(self, pg_conn_with_queue):
+        """Mix: one candidate has direct blob ref, another has wrapper ref.
+
+        Both should enqueue against the correct inner OID.
+        """
+        conn = pg_conn_with_queue
+
+        # Flat: content 800 -> blob 801 (direct)
+        flat_content, flat_blob, tid = 800, 801, 1
+        insert_object(conn, flat_content, tid)
+        self._insert_blob(conn, flat_blob, tid)
+
+        # Wrapped: content 810 -> wrapper 811 -> blob 812
+        wrap_content, wrap_oid, wrap_blob = 810, 811, 812
+        insert_object(conn, wrap_content, tid)
+        insert_object(
+            conn,
+            wrap_oid,
+            tid,
+            class_mod="plone.namedfile.file",
+            class_name="NamedBlobImage",
+            state=json.dumps(
+                {"_blob": {"@ref": [f"{wrap_blob:016x}", "ZODB.blob.Blob"]}}
+            ),
+        )
+        self._insert_blob(conn, wrap_blob, tid)
+
+        proc = CatalogStateProcessor()
+        proc._tika_candidates = [
+            {
+                "zoid": flat_content,
+                "content_type": "application/pdf",
+                "blob_refs": [flat_blob],
+            },
+            {
+                "zoid": wrap_content,
+                "content_type": "image/png",
+                "blob_refs": [wrap_oid],
+            },
+        ]
+
+        with conn.cursor(row_factory=tuple_row) as cur:
+            proc._enqueue_tika_jobs(cur)
+        conn.commit()
+
+        rows = {r["zoid"]: r for r in self._get_queue(conn)}
+        assert rows[flat_content]["blob_zoid"] == flat_blob
+        assert rows[wrap_content]["blob_zoid"] == wrap_blob
+        assert rows[wrap_content]["content_type"] == "image/png"
+
+    @pytest.mark.skipif(not TIKA_URL, reason="PGCATALOG_TIKA_URL not set")
+    def test_enqueue_wrapper_with_missing_inner_blob(self, pg_conn_with_queue):
+        """Wrapper exists in object_state but inner blob is missing."""
+        conn = pg_conn_with_queue
+        content_zoid, wrapper_zoid, tid = 820, 821, 1
+        missing_blob = 99999
+
+        insert_object(conn, content_zoid, tid)
+        insert_object(
+            conn,
+            wrapper_zoid,
+            tid,
+            class_mod="plone.namedfile.file",
+            class_name="NamedBlobFile",
+            state=json.dumps(
+                {"_blob": {"@ref": [f"{missing_blob:016x}", "ZODB.blob.Blob"]}}
+            ),
+        )
+        # no blob_state row for missing_blob
+
+        proc = CatalogStateProcessor()
+        proc._tika_candidates = [
+            {
+                "zoid": content_zoid,
+                "content_type": "application/pdf",
+                "blob_refs": [wrapper_zoid],
+            }
+        ]
+
+        with conn.cursor(row_factory=tuple_row) as cur:
+            proc._enqueue_tika_jobs(cur)
+        conn.commit()
+
+        assert self._get_queue(conn) == []
+
+    @pytest.mark.skipif(not TIKA_URL, reason="PGCATALOG_TIKA_URL not set")
+    def test_enqueue_ignores_unresolvable_refs(self, pg_conn_with_queue):
+        """Ref with neither blob_state nor object_state entry is a noop."""
+        conn = pg_conn_with_queue
+        content_zoid, tid = 830, 1
+        ghost_ref = 0xDEADBEEF
+
+        insert_object(conn, content_zoid, tid)
+
+        proc = CatalogStateProcessor()
+        proc._tika_candidates = [
+            {
+                "zoid": content_zoid,
+                "content_type": "application/pdf",
+                "blob_refs": [ghost_ref],
+            }
+        ]
+
+        with conn.cursor(row_factory=tuple_row) as cur:
+            proc._enqueue_tika_jobs(cur)
+        conn.commit()
+
+        assert self._get_queue(conn) == []
+
     def test_process_accumulates_candidates_with_blob_refs(self, pg_conn_with_queue):
         """process() accumulates tika candidates with blob_refs from state."""
         from plone.pgcatalog.pending import set_pending

--- a/tests/test_tika_enqueue.py
+++ b/tests/test_tika_enqueue.py
@@ -269,6 +269,61 @@ class TestEnqueueLogic:
         rows = self._get_queue(conn)
         assert len(rows) == 1
 
+    @pytest.mark.skipif(not TIKA_URL, reason="PGCATALOG_TIKA_URL not set")
+    def test_enqueue_resolves_wrapper_oid(self, pg_conn_with_queue):
+        """Dexterity NamedBlobFile wrapper: one-level hop to inner Blob.
+
+        Content state @ref points at wrapper (object_state), wrapper
+        state @ref points at Blob (blob_state).  Queue must store the
+        inner Blob OID, not the wrapper.
+        """
+        conn = pg_conn_with_queue
+        content_zoid, wrapper_zoid, blob_zoid, tid = 700, 701, 702, 1
+
+        # Content object has no direct blob entry; its ref points at the
+        # NamedBlobFile wrapper.
+        insert_object(conn, content_zoid, tid)
+        # The wrapper is a persistent object whose state carries the
+        # real Blob @ref.
+        wrapper_state = json.dumps(
+            {
+                "_blob": {
+                    "@ref": [f"{blob_zoid:016x}", "ZODB.blob.Blob"],
+                },
+                "filename": "sample.pdf",
+                "contentType": "application/pdf",
+            }
+        )
+        insert_object(
+            conn,
+            wrapper_zoid,
+            tid,
+            class_mod="plone.namedfile.file",
+            class_name="NamedBlobFile",
+            state=wrapper_state,
+        )
+        self._insert_blob(conn, blob_zoid, tid)
+
+        proc = CatalogStateProcessor()
+        proc._tika_candidates = [
+            {
+                "zoid": content_zoid,
+                "content_type": "application/pdf",
+                "blob_refs": [wrapper_zoid],  # wrapper only, no direct blob
+            }
+        ]
+
+        with conn.cursor(row_factory=tuple_row) as cur:
+            proc._enqueue_tika_jobs(cur)
+        conn.commit()
+
+        rows = self._get_queue(conn)
+        assert len(rows) == 1
+        assert rows[0]["zoid"] == content_zoid
+        assert rows[0]["blob_zoid"] == blob_zoid  # inner, NOT wrapper_zoid
+        assert rows[0]["tid"] == tid
+        assert rows[0]["content_type"] == "application/pdf"
+
     def test_process_accumulates_candidates_with_blob_refs(self, pg_conn_with_queue):
         """process() accumulates tika candidates with blob_refs from state."""
         from plone.pgcatalog.pending import set_pending

--- a/tests/test_tika_enqueue.py
+++ b/tests/test_tika_enqueue.py
@@ -488,6 +488,147 @@ class TestEnqueueLogic:
         assert len(proc._tika_candidates) == 0
 
 
+class TestEnqueueUnit:
+    """Unit tests for _enqueue_tika_jobs + _insert_queue_row — mocked cursor, no DB, no TIKA_URL gate.
+
+    These tests run unconditionally so the wrapper-resolution code
+    path is exercised in environments (e.g. CI) where
+    PGCATALOG_TIKA_URL is not configured.
+    """
+
+    def _make_cursor(self, responses):
+        """Return a MagicMock cursor whose consecutive fetchall() calls
+        return the rows in *responses* (a list of row-lists).
+        """
+        cur = mock.MagicMock()
+        cur.fetchall.side_effect = responses
+        return cur
+
+    def test_empty_candidates_is_noop(self):
+        proc = CatalogStateProcessor()
+        proc._tika_candidates = []
+        cur = mock.MagicMock()
+        proc._enqueue_tika_jobs(cur)
+        cur.execute.assert_not_called()
+
+    def test_direct_blob_ref_inserts_row(self):
+        proc = CatalogStateProcessor()
+        proc._tika_candidates = [
+            {"zoid": 100, "content_type": "application/pdf", "blob_refs": [999]}
+        ]
+        # First fetchall: direct blob_state lookup returns (999, 1)
+        cur = self._make_cursor([[(999, 1)]])
+
+        proc._enqueue_tika_jobs(cur)
+
+        # Exactly 2 execute calls: 1 SELECT (direct lookup) + 1 INSERT
+        assert cur.execute.call_count == 2
+        insert_sql = cur.execute.call_args_list[1].args[0]
+        insert_params = cur.execute.call_args_list[1].args[1]
+        assert "INSERT INTO text_extraction_queue" in insert_sql
+        assert insert_params == {
+            "zoid": 100,
+            "blob_zoid": 999,
+            "tid": 1,
+            "ct": "application/pdf",
+        }
+
+    def test_wrapper_oid_hops_through_object_state(self):
+        """Wrapper ref -> object_state -> inner blob ref -> blob_state.
+
+        Content ref is a wrapper OID with no direct blob_state entry.
+        Second-hop fetch returns the wrapper's state (JSON string with
+        @ref to inner Blob).  Third fetch returns the inner blob row.
+        """
+        proc = CatalogStateProcessor()
+        wrapper_oid = 701
+        inner_blob_oid = 702
+        proc._tika_candidates = [
+            {
+                "zoid": 700,
+                "content_type": "application/pdf",
+                "blob_refs": [wrapper_oid],
+            }
+        ]
+        wrapper_state = json.dumps(
+            {"_blob": {"@ref": [f"{inner_blob_oid:016x}", "ZODB.blob.Blob"]}}
+        )
+        cur = self._make_cursor(
+            [
+                [],  # 1st SELECT: no direct blob_state row for wrapper_oid
+                [(wrapper_oid, wrapper_state)],  # 2nd SELECT: wrapper's state
+                [(inner_blob_oid, 1)],  # 3rd SELECT: blob for inner oid
+            ]
+        )
+
+        proc._enqueue_tika_jobs(cur)
+
+        # 3 SELECT + 1 INSERT = 4 execute calls
+        assert cur.execute.call_count == 4
+        insert_params = cur.execute.call_args_list[3].args[1]
+        assert insert_params["zoid"] == 700
+        assert insert_params["blob_zoid"] == inner_blob_oid  # NOT wrapper
+        assert insert_params["tid"] == 1
+
+    def test_unresolved_ref_without_wrapper_state_is_silent_skip(self):
+        """Ref has neither blob_state nor object_state row — no INSERT, no error."""
+        proc = CatalogStateProcessor()
+        proc._tika_candidates = [
+            {"zoid": 800, "content_type": "application/pdf", "blob_refs": [9999]}
+        ]
+        cur = self._make_cursor(
+            [
+                [],  # 1st SELECT: blob_state empty
+                [],  # 2nd SELECT: object_state empty (no wrapper state)
+            ]
+        )
+
+        proc._enqueue_tika_jobs(cur)
+
+        # 2 SELECTs, 0 INSERTs
+        assert cur.execute.call_count == 2
+        # No INSERT call
+        for call in cur.execute.call_args_list:
+            assert "INSERT" not in call.args[0]
+
+    def test_wrapper_state_without_inner_refs_is_silent_skip(self):
+        """Wrapper exists in object_state but its state has no @ref."""
+        proc = CatalogStateProcessor()
+        proc._tika_candidates = [
+            {"zoid": 810, "content_type": "application/pdf", "blob_refs": [811]}
+        ]
+        # Wrapper state has no @ref — defensive path
+        cur = self._make_cursor(
+            [
+                [],  # no direct blob row
+                [(811, json.dumps({"filename": "empty.pdf"}))],  # no @ref inside
+            ]
+        )
+
+        proc._enqueue_tika_jobs(cur)
+
+        # Only 2 SELECTs (no 3rd because inner_refs is empty), no INSERT
+        assert cur.execute.call_count == 2
+
+    def test_insert_queue_row_uses_correct_sql_and_params(self):
+        proc = CatalogStateProcessor()
+        cur = mock.MagicMock()
+        proc._insert_queue_row(
+            cur, zoid=42, blob_zoid=43, tid=7, content_type="image/png"
+        )
+
+        cur.execute.assert_called_once()
+        sql, params = cur.execute.call_args.args
+        assert "INSERT INTO text_extraction_queue" in sql
+        assert "ON CONFLICT (blob_zoid, tid) DO NOTHING" in sql
+        assert params == {
+            "zoid": 42,
+            "blob_zoid": 43,
+            "tid": 7,
+            "ct": "image/png",
+        }
+
+
 class TestQueueSchema:
     """Test the queue table schema."""
 


### PR DESCRIPTION
## Summary

- `_enqueue_tika_jobs()` now resolves Dexterity `NamedBlobFile` / `NamedBlobImage` wrapper OIDs via a one-hop lookup through `object_state` before querying `blob_state`.  Wrappers are the standard Dexterity pattern, so previously the Tika queue stayed empty for PDF/Office/image File/Image content.
- Queue row's `blob_zoid` is the inner `ZODB.blob.Blob` OID (matches what the worker needs).
- Flat-state fast path unchanged: when the first `blob_state` lookup resolves all refs, no second hop is performed.
- 4 new integration tests: wrapper resolution, mixed flat+wrapper, wrapper with missing inner blob, unresolvable ref.

Closes #115

## Reference chain

```
Content File (zoid 59246625)
   .file.@ref ─► NamedBlobFile  (zoid 59246633)  [object_state]
                 ._blob.@ref ─► ZODB.blob.Blob   (zoid 59246634)  [blob_state]
```

The ref in the content's state points at the wrapper; the actual `ZODB.blob.Blob` sits one persistent reference deeper.  Resolution is two-step:
1. Direct lookup in `blob_state` for all candidate refs.
2. For unresolved refs, fetch their `object_state` row, extract inner `@ref` OIDs, re-query `blob_state`.

## Test plan

- [x] Failing regression test (`test_enqueue_resolves_wrapper_oid`) added first, implementation flipped it green
- [x] Edge cases: mixed flat+wrapper, wrapper with missing inner blob, ref with neither object_state nor blob_state entry
- [x] All 21 tests in \`test_tika_enqueue.py\` pass
- [x] No schema change, no migration
- [x] No class-name hardcoding — generic unresolved-ref check works for any wrapper structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)