### PR TITLE
fix: resolve computed IIndexer adapters in DateRecurringIndexTranslator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ docs/.vale/styles/Microsoft/
 docs/.vale/styles/write-good/
 uv.lock
 development/
+.worktrees/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 1.0.0b53
+
+### Fixed
+
+- `DateRecurringIndexTranslator.extract()` only looked at attributes on
+  the object, so computed Plone indexes — those registered through the
+  `plone.indexer` `@indexer` decorator as named `IIndexer` adapters —
+  were silently extracted as `None`.  Relying on the
+  `IIndexableObjectWrapper.__getattr__` delegation to route the call
+  turned out to be fragile in production component-registry setups.
+
+  The most visible symptom was `plone.app.event` / `bda.aaf.site`'s
+  `general_end` / `general_start` indexes: `idx->>'general_end'` was
+  `NULL` for every event, which broke any Collection using the
+  standard "Event ends in the future" criterion (`general_end` in the
+  query returned zero results even when plenty of future events
+  existed).  Pure persistent attributes like `end` / `start` were
+  unaffected, which is why the regression was easy to miss.
+
+  The translator now resolves the `IIndexer` adapter explicitly
+  (unwrapping the `plone.indexer` wrapper when present) and falls back
+  to attribute access only when no adapter is registered.  This
+  matches how standard ZCatalog resolves index values and fixes the
+  fallout for any `DateRecurringIndex` whose value comes from an
+  adapter.
+
+  Issue #126.
+
 ## 1.0.0b52
 
 ### Fixed

--- a/src/plone/pgcatalog/dri.py
+++ b/src/plone/pgcatalog/dri.py
@@ -51,6 +51,73 @@ def _safe_getattr(obj, name):
     return val
 
 
+def _resolve_via_indexer(obj, attr_name):
+    """Look up *attr_name* through the ``plone.indexer`` ``IIndexer`` chain.
+
+    Computed Plone indexes (``general_end``, ``general_start`` from
+    ``plone.app.event`` / ``bda.aaf.site``, etc.) are virtual attributes
+    registered as named ``IIndexer`` adapters — they never exist as
+    Python attributes on the content object.  Relying on
+    ``IIndexableObjectWrapper.__getattr__`` to trigger them is fragile
+    (the wrapper needs to be adapted correctly *and* the adapter needs
+    to be reachable via the current component registry), so the
+    translator resolves the adapter explicitly and falls back to
+    attribute access only if nothing is registered.
+
+    Returns ``None`` when plone.indexer is unavailable, when no catalog
+    can be determined, when no named ``IIndexer`` is registered, or
+    when the adapter call fails.
+    """
+    if not attr_name:
+        return None
+    try:
+        from plone.indexer.interfaces import IIndexableObjectWrapper
+        from plone.indexer.interfaces import IIndexer
+        from zope.component import queryMultiAdapter
+    except ImportError:
+        return None
+
+    raw = obj
+    catalog = None
+    if IIndexableObjectWrapper.providedBy(obj):
+        # Reach through the wrapper so the adapter sees the raw object,
+        # exactly like the ZCatalog indexing path.  Name-mangled attrs
+        # are a stable part of plone.indexer's ABI.
+        raw = getattr(obj, "_IndexableObjectWrapper__object", obj)
+        catalog = getattr(obj, "_IndexableObjectWrapper__catalog", None)
+    if catalog is None:
+        try:
+            from Products.CMFCore.utils import getToolByName
+
+            catalog = getToolByName(obj, "portal_catalog", None)
+        except Exception:
+            catalog = None
+    if catalog is None:
+        return None
+
+    indexer = queryMultiAdapter((raw, catalog), IIndexer, name=attr_name)
+    if indexer is None:
+        return None
+    try:
+        return indexer()
+    except Exception:
+        log.warning(
+            "IIndexer %r raised while extracting for %r",
+            attr_name,
+            raw,
+            exc_info=True,
+        )
+        return None
+
+
+def _extract_attr(obj, attr_name):
+    """Resolve *attr_name* via ``IIndexer`` first, then attribute access."""
+    val = _resolve_via_indexer(obj, attr_name)
+    if val is not None:
+        return val
+    return _safe_getattr(obj, attr_name)
+
+
 @implementer(IPGIndexTranslator)
 class DateRecurringIndexTranslator:
     """IPGIndexTranslator for Products.DateRecurringIndex.
@@ -72,13 +139,13 @@ class DateRecurringIndexTranslator:
 
     def extract(self, obj, index_name):
         """Extract base date and recurrence rule from obj."""
-        date_val = _safe_getattr(obj, self.date_attr)
+        date_val = _extract_attr(obj, self.date_attr)
         if date_val is None:
             return {}
 
         result = {index_name: convert_value(date_val)}
 
-        recurdef = _safe_getattr(obj, self.recurdef_attr)
+        recurdef = _extract_attr(obj, self.recurdef_attr)
         if recurdef:
             recurdef = str(recurdef)
             if len(recurdef) > _MAX_RRULE_LENGTH:

--- a/tests/test_dri.py
+++ b/tests/test_dri.py
@@ -109,6 +109,130 @@ class TestExtract:
 
 
 # ---------------------------------------------------------------------------
+# Unit tests: IIndexer adapter resolution (issue #126)
+# ---------------------------------------------------------------------------
+
+
+class TestIIndexerResolution:
+    """DRI translator resolves values via the plone.indexer IIndexer chain.
+
+    Regression coverage for issue #126: computed Plone indexes such as
+    ``general_end`` / ``general_start`` are virtual attributes — they only
+    exist as named ``IIndexer`` adapters, never as Python attributes on
+    the content object.  ``_safe_getattr`` alone silently returned
+    ``None`` for every event in the site, so ``idx->>'general_end'`` was
+    ``NULL`` across the catalog.
+    """
+
+    @pytest.fixture
+    def computed_catalog(self):
+        """Register an IIndexer for ``general_end`` that returns a fixed date.
+
+        Also registers the ``plone.indexer`` ``IIndexableObjectWrapper``
+        adapter factory so ``wrap_object`` produces a real wrapper — the
+        test then exercises both the wrapper unwrapping path and the
+        explicit adapter lookup added in the fix.
+        """
+        from plone.indexer.interfaces import IIndexableObject
+        from plone.indexer.interfaces import IIndexer
+        from plone.indexer.wrapper import IndexableObjectWrapper
+        from Products.ZCatalog.interfaces import IZCatalog
+        from zope.component import getGlobalSiteManager
+        from zope.interface import implementer
+        from zope.interface import Interface
+
+        @implementer(IZCatalog)
+        class _FakeCatalog:
+            pass
+
+        catalog = _FakeCatalog()
+
+        computed_value = datetime(2025, 6, 1, 18, 0, tzinfo=UTC)
+
+        @implementer(IIndexer)
+        class _FixedDateIndexer:
+            def __init__(self, context, catalog):
+                self.context = context
+                self.catalog = catalog
+
+            def __call__(self):
+                return computed_value
+
+        gsm = getGlobalSiteManager()
+        gsm.registerAdapter(
+            IndexableObjectWrapper,
+            (Interface, IZCatalog),
+            IIndexableObject,
+        )
+        gsm.registerAdapter(
+            _FixedDateIndexer,
+            (Interface, IZCatalog),
+            IIndexer,
+            name="general_end",
+        )
+        try:
+            yield catalog, computed_value
+        finally:
+            gsm.unregisterAdapter(
+                _FixedDateIndexer,
+                (Interface, IZCatalog),
+                IIndexer,
+                name="general_end",
+            )
+            gsm.unregisterAdapter(
+                IndexableObjectWrapper,
+                (Interface, IZCatalog),
+                IIndexableObject,
+            )
+
+    def test_extract_resolves_virtual_attr_via_indexer(self, computed_catalog):
+        """A computed index (no matching Python attribute) is resolved."""
+        from plone.pgcatalog.extraction import wrap_object
+
+        catalog, expected = computed_catalog
+        t = DateRecurringIndexTranslator("general_end", "recurrence")
+
+        # Bare object has no ``general_end`` attribute — only the adapter.
+        class _BareEvent:
+            pass
+
+        obj = _BareEvent()
+        wrapper = wrap_object(obj, catalog)
+
+        result = t.extract(wrapper, "general_end")
+
+        assert result == {"general_end": expected.isoformat()}
+
+    def test_extract_prefers_indexer_over_direct_attr(self, computed_catalog):
+        """When both an adapter and a real attribute exist, adapter wins.
+
+        The standard ZCatalog indexing path gives the adapter priority —
+        matching that keeps pgcatalog behavior-identical.
+        """
+        from plone.pgcatalog.extraction import wrap_object
+
+        catalog, expected = computed_catalog
+        t = DateRecurringIndexTranslator("general_end", "recurrence")
+
+        class _EventWithAttr:
+            general_end = datetime(2024, 1, 1, tzinfo=UTC)  # must be ignored
+
+        wrapper = wrap_object(_EventWithAttr(), catalog)
+        result = t.extract(wrapper, "general_end")
+
+        assert result == {"general_end": expected.isoformat()}
+
+    def test_extract_falls_back_to_attr_without_adapter(self):
+        """No IIndexer registered → existing attribute access still works."""
+        t = DateRecurringIndexTranslator("start", "recurrence")
+        obj = _FakeEvent(start=datetime(2025, 4, 1, 12, 0, tzinfo=UTC))
+
+        result = t.extract(obj, "start")
+
+        assert result == {"start": "2025-04-01T12:00:00+00:00"}
+
+
+# ---------------------------------------------------------------------------
 # Unit tests: query() SQL generation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #126.

## Problem

`DateRecurringIndexTranslator.extract()` pulls its value via plain attribute access (`_safe_getattr(obj, date_attr)`).  For DRIs whose value is a *computed* Plone index — registered through `plone.indexer`'s `@indexer` decorator as a named `IIndexer` adapter — there is no Python attribute to read.  In theory the `plone.indexer` `IIndexableObjectWrapper.__getattr__` delegation should find the adapter for us; in this production setup it empirically did not, and `idx->>'general_end'` came out `NULL` for **every event in the site** (13940 rows observed by @jensens).

Fallout: the standard Plone Collection criterion "Event end: in the future" (which uses `general_end` per `plone.app.querystring`) returns zero results site-wide.  Persistent attributes like `end` / `start` were unaffected, which is why the regression was easy to miss.

## Critical analysis

The user-reported root cause — `_safe_getattr` can't reach a virtual attribute — is accurate in effect.  The *why* the wrapper delegation doesn't fire in prod is a separate, deeper question (interface registration, wrapper adaptation, or registry scoping) that I did not chase down here because the translator shouldn't depend on that path anyway.  Standard ZCatalog resolves indexer values by explicitly querying the `IIndexer` adapter chain; the translator should do the same.

## Fix

`src/plone/pgcatalog/dri.py`:
- New `_resolve_via_indexer(obj, attr_name)` helper that queries `queryMultiAdapter((raw_obj, catalog), IIndexer, name=attr_name)`.  When `obj` is a `plone.indexer` `IIndexableObjectWrapper` it reaches through to the wrapped object and its catalog; when the helper is called with a raw (acquisition-wrapped) content object it falls back to `getToolByName(obj, 'portal_catalog')`.
- New `_extract_attr(obj, attr_name)` — tries the adapter first, falls back to `_safe_getattr` so existing attribute-based usage (and the full unit-test suite) stays untouched.
- `extract()` uses `_extract_attr` for both `date_attr` and `recurdef_attr`.

`driri.py` is unchanged — its `extract()` is a no-op.

## Tests

`tests/test_dri.py::TestIIndexerResolution` — three new tests that register a named `IIndexer` for `general_end` in the global site manager plus the `plone.indexer` wrapper factory, exercising:
- virtual attribute (bare object, no matching Python attr) resolved via adapter ✔
- adapter wins over a direct attribute on the object ✔
- no adapter registered → falls back to attribute access ✔

Full DRI/DRIRI unit suite: `41 passed, 7 deselected` (PG integration tests skipped — unrelated deadlock with concurrent runner on the test DB).

## Follow-up worth doing

Figure out *why* `IIndexableObjectWrapper.__getattr__` doesn't route to the `IIndexer` adapter in this production Plone setup.  It should, and if it does in most setups, there may be more than one DRI that silently mis-extracts elsewhere.  Not blocking this hotfix.

## Test plan

- [ ] Roll out to the affected production site, re-run `clearFindAndRebuild` (or targeted `reindexIndex('general_end')` / `general_start`), verify `SELECT count(*) FROM object_state WHERE idx->>'portal_type' = 'Event' AND idx->>'general_end' IS NOT NULL;` now returns 13940
- [ ] Re-check a Collection with "Event ends in the future"