### PR TITLE
Suggestions engine PR 2: field split + covering composites (#122)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ docs/.vale/styles/Microsoft/
 docs/.vale/styles/write-good/
 uv.lock
 development/
+.worktrees/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.0.0b53 (unreleased)
+
+### Added
+
+- Slow-query suggestions now produce covering composite indexes for the
+  common `portal_type + effectiveRange + sort_on=effective` pattern
+  (issue #122).  The suggestion engine splits the legacy
+  `_NON_IDX_FIELDS` into purpose-specific constants, expands
+  `effectiveRange` to its `effective` date contributor, and appends the
+  query's `sort_on` field as a trailing btree composite column so the
+  planner can skip the ORDER BY sort step.
+
 ## 1.0.0b52
 
 ### Fixed

--- a/src/plone/pgcatalog/catalog.py
+++ b/src/plone/pgcatalog/catalog.py
@@ -1212,7 +1212,7 @@ class PlonePGCatalogTool(UniqueObject, Folder):
                     "avg_ms": float(row["avg_ms"]),
                     "max_ms": float(row["max_ms"]),
                     "last_seen": str(row["last_seen"])[:19],
-                    "suggestions": suggest_indexes(keys, registry, existing),
+                    "suggestions": suggest_indexes(keys, None, registry, existing),
                 }
             )
         return result

--- a/src/plone/pgcatalog/catalog.py
+++ b/src/plone/pgcatalog/catalog.py
@@ -1186,15 +1186,31 @@ class PlonePGCatalogTool(UniqueObject, Folder):
 
                 with pg_conn.cursor() as cur:
                     cur.execute(
-                        "SELECT query_keys, "
-                        "  COUNT(*) AS cnt, "
-                        "  ROUND(AVG(duration_ms)::numeric, 1) AS avg_ms, "
-                        "  ROUND(MAX(duration_ms)::numeric, 1) AS max_ms, "
-                        "  MAX(created_at) AS last_seen "
-                        "FROM pgcatalog_slow_queries "
-                        "GROUP BY query_keys "
-                        "ORDER BY max_ms DESC "
-                        "LIMIT 50"
+                        "SELECT grp.query_keys, "
+                        "  grp.cnt, "
+                        "  grp.avg_ms, "
+                        "  grp.max_ms, "
+                        "  grp.last_seen, "
+                        "  slowest.params AS representative_params "
+                        "FROM ( "
+                        "  SELECT query_keys, "
+                        "    COUNT(*) AS cnt, "
+                        "    ROUND(AVG(duration_ms)::numeric, 1) AS avg_ms, "
+                        "    ROUND(MAX(duration_ms)::numeric, 1) AS max_ms, "
+                        "    MAX(created_at) AS last_seen "
+                        "  FROM pgcatalog_slow_queries "
+                        "  GROUP BY query_keys "
+                        "  ORDER BY max_ms DESC "
+                        "  LIMIT 50 "
+                        ") grp "
+                        "LEFT JOIN LATERAL ( "
+                        "  SELECT params "
+                        "  FROM pgcatalog_slow_queries s "
+                        "  WHERE s.query_keys = grp.query_keys "
+                        "  ORDER BY s.duration_ms DESC "
+                        "  LIMIT 1 "
+                        ") slowest ON TRUE "
+                        "ORDER BY grp.max_ms DESC"
                     )
                     rows = cur.fetchall()
             finally:
@@ -1205,6 +1221,7 @@ class PlonePGCatalogTool(UniqueObject, Folder):
         result = []
         for row in rows:
             keys = row["query_keys"]
+            params = row["representative_params"]
             result.append(
                 {
                     "query_keys": ", ".join(keys),
@@ -1212,7 +1229,7 @@ class PlonePGCatalogTool(UniqueObject, Folder):
                     "avg_ms": float(row["avg_ms"]),
                     "max_ms": float(row["max_ms"]),
                     "last_seen": str(row["last_seen"])[:19],
-                    "suggestions": suggest_indexes(keys, None, registry, existing),
+                    "suggestions": suggest_indexes(keys, params, registry, existing),
                 }
             )
         return result

--- a/src/plone/pgcatalog/suggestions.py
+++ b/src/plone/pgcatalog/suggestions.py
@@ -179,6 +179,40 @@ def suggest_indexes(query_keys, params, registry, existing_indexes):
     return suggestions
 
 
+def _extract_sort_field(params, registry):
+    """Return ``(field_name, IndexType)`` for a composite-eligible sort
+    column, or ``None``.
+
+    Plone emits the sort key under various param names — plain
+    ``sort_on`` for direct catalog searches, ``p_sort_on_1`` for
+    restapi-generated queries, etc.  Substring matching on
+    ``"sort_on"`` is the pragmatic fit.
+
+    Only btree-composite-eligible types are returned — KEYWORD, TEXT,
+    GOPIP, and DATE_RANGE cannot be trailing columns of a btree index.
+    """
+    if not params:
+        return None
+
+    sort_value = None
+    for param_name, value in params.items():
+        if "sort_on" in param_name:
+            sort_value = value
+            break
+    if not sort_value:
+        return None
+
+    # Registry lookup.  items() returns name -> (IndexType, idx_key, source_attrs).
+    for name, (idx_type, _idx_key, _source_attrs) in registry.items():
+        if name == sort_value:
+            if idx_type in _NON_COMPOSITE_TYPES:
+                return None
+            if idx_type in _SKIP_TYPES:
+                return None
+            return (name, idx_type)
+    return None
+
+
 def _add_standalone_suggestion(field, idx_type, existing_indexes, suggestions):
     """Add a standalone GIN/tsvector suggestion for KEYWORD or TEXT field."""
     if idx_type == IndexType.KEYWORD:

--- a/src/plone/pgcatalog/suggestions.py
+++ b/src/plone/pgcatalog/suggestions.py
@@ -89,13 +89,17 @@ def _gin_expr(field):
 # ── Core suggestion engine ───────────────────────────────────────────────
 
 
-def suggest_indexes(query_keys, registry, existing_indexes):
+def suggest_indexes(query_keys, params, registry, existing_indexes):
     """Generate index suggestions for a set of slow-query field keys.
 
     Pure function — no DB access.
 
     Args:
         query_keys: list of catalog query field names
+        params: dict of representative query params (value of the
+            slowest observed invocation of this query-key group), or
+            None when no representative is available.  Used to extract
+            a sort_on value for covering-composite suggestions.
         registry: IndexRegistry instance (has .items() returning
             name -> (IndexType, idx_key, source_attrs))
         existing_indexes: dict {index_name: index_def_sql} from

--- a/src/plone/pgcatalog/suggestions.py
+++ b/src/plone/pgcatalog/suggestions.py
@@ -26,18 +26,26 @@ log = logging.getLogger(__name__)
 
 # ── Constants ────────────────────────────────────────────────────────────
 
-# Query-meta keys that are not index fields
-_NON_IDX_FIELDS = frozenset(
-    {
-        "SearchableText",
-        "path",
-        "effectiveRange",
-        "sort_on",
-        "sort_order",
-        "b_size",
-        "b_start",
-    }
-)
+# Pagination meta — ignored everywhere in the suggestion engine.
+_PAGINATION_META = frozenset({"b_size", "b_start"})
+
+# Sort meta keys — not a filter.  The VALUE of sort_on drives
+# covering-composite construction (see _extract_sort_field).
+_SORT_META = frozenset({"sort_on", "sort_order"})
+
+# Virtual filter keys that expand to real idx columns for composite
+# suggestions.  Each entry maps virtual_key -> list of (real_field,
+# IndexType) tuples.  The real fields then participate in
+# _add_btree_suggestions as if the query had named them directly.
+_FILTER_VIRTUAL = {
+    "effectiveRange": [("effective", IndexType.DATE)],
+}
+
+# Fields we deliberately skip in PR 2 — path suggestions are deferred
+# to PR 3 (EXPLAIN-driven coverage); SearchableText already has a
+# dedicated tsvector column and is additionally handled via
+# _DEDICATED_FIELDS for the reason-string.
+_SKIP_FIELDS = frozenset({"path", "SearchableText"})
 
 # Fields with dedicated PG columns or indexes — always "already_covered"
 _DEDICATED_FIELDS = {
@@ -119,10 +127,20 @@ def suggest_indexes(query_keys, params, registry, existing_indexes):
     btree_fields = []  # (field, idx_type) tuples for composite candidate
 
     for key in query_keys:
-        if key in _NON_IDX_FIELDS:
+        # Pagination/sort meta keys are never filter columns.
+        if key in _PAGINATION_META or key in _SORT_META:
             continue
 
-        # Dedicated column check
+        # Virtual filter fields (e.g. effectiveRange) expand to their
+        # real date/text contributors.  The expansion participates in the
+        # btree composite the same way a direct key would.
+        if key in _FILTER_VIRTUAL:
+            for real_field, real_type in _FILTER_VIRTUAL[key]:
+                btree_fields.append((real_field, real_type))
+            continue
+
+        # Dedicated column check comes BEFORE the skip set so SearchableText
+        # emits its "dedicated column" reason rather than silently vanishing.
         if key in _DEDICATED_FIELDS:
             suggestions.append(
                 {
@@ -135,6 +153,10 @@ def suggest_indexes(query_keys, params, registry, existing_indexes):
                     "reason": f"Dedicated column: {_DEDICATED_FIELDS[key]}",
                 }
             )
+            continue
+
+        # Explicitly skipped fields (path — deferred to PR 3).
+        if key in _SKIP_FIELDS:
             continue
 
         idx_type = reg_lookup.get(key)

--- a/src/plone/pgcatalog/suggestions.py
+++ b/src/plone/pgcatalog/suggestions.py
@@ -70,6 +70,11 @@ _SELECTIVITY_ORDER = {
     IndexType.PATH: 4,
 }
 
+# Hard cap on columns in a composite btree suggestion — beyond three
+# the write-amplification cost outweighs read savings in real Plone
+# catalogs.  Sort covering column counts against this cap.
+_MAX_COMPOSITE_COLUMNS = 3
+
 # Safe index name pattern
 _SAFE_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
@@ -172,9 +177,14 @@ def suggest_indexes(query_keys, params, registry, existing_indexes):
         else:
             btree_fields.append((key, idx_type))
 
-    # Build composite from btree-eligible fields
+    # Extract sort field for covering trailing column (if any).
+    sort_field = _extract_sort_field(params, registry)
+
+    # Build composite from btree-eligible fields plus optional sort cover.
+    # No sort-only suggestion — a btree on sort alone does not
+    # accelerate a filter-less query in a meaningful way.
     if btree_fields:
-        _add_btree_suggestions(btree_fields, existing_indexes, suggestions)
+        _add_btree_suggestions(btree_fields, sort_field, existing_indexes, suggestions)
 
     return suggestions
 
@@ -246,16 +256,51 @@ def _add_standalone_suggestion(field, idx_type, existing_indexes, suggestions):
     )
 
 
-def _add_btree_suggestions(btree_fields, existing_indexes, suggestions):
-    """Add btree suggestions — single or composite (max 3 fields)."""
-    # Sort by selectivity
-    btree_fields.sort(key=lambda ft: _SELECTIVITY_ORDER.get(ft[1], 99))
+def _add_btree_suggestions(btree_fields, sort_field, existing_indexes, suggestions):
+    """Add a btree suggestion — single column or composite.
 
-    # Limit to max 3
-    fields_limited = btree_fields[:3]
+    Args:
+        btree_fields: list of ``(field_name, IndexType)`` tuples for
+            filter columns discovered in the query.  Order is the
+            traversal order of query_keys — this function sorts by
+            selectivity.
+        sort_field: ``(field_name, IndexType)`` for a trailing covering
+            column, or None.  Makes the planner skip the ORDER BY sort
+            step when the leading filter columns have equality predicates.
+        existing_indexes: dict {name: indexdef} from get_existing_indexes.
+        suggestions: output list to append the resulting dict to.
+    """
+    # Sort filters by selectivity (most selective first).
+    btree_fields = sorted(
+        btree_fields, key=lambda ft: _SELECTIVITY_ORDER.get(ft[1], 99)
+    )
 
-    if len(fields_limited) == 1:
-        field, idx_type = fields_limited[0]
+    # Reserve one slot for sort_field if present.  Cap stays 3 total.
+    filter_cap = (
+        _MAX_COMPOSITE_COLUMNS - 1 if sort_field is not None else _MAX_COMPOSITE_COLUMNS
+    )
+    fields_limited = btree_fields[:filter_cap]
+
+    # Build the ordered column list: filters first, sort trailing.
+    # Dedupe: if sort_field's name is already a filter column, don't
+    # repeat it — the leading position already satisfies ORDER BY when
+    # the remaining columns have equality predicates.
+    ordered = list(fields_limited)
+    sort_covering = False
+    if sort_field is not None:
+        existing_names = {f for f, _t in ordered}
+        if sort_field[0] not in existing_names:
+            ordered.append(sort_field)
+            sort_covering = True
+
+    # Empty after dedupe (shouldn't happen — caller gates on truthy
+    # btree_fields — but guard anyway).
+    if not ordered:
+        return
+
+    field_names = [f for f, _t in ordered]
+    if len(ordered) == 1:
+        field, idx_type = ordered[0]
         expr = _btree_expr(field, idx_type)
         name = f"idx_os_sug_{field}"
         ddl = (
@@ -264,22 +309,23 @@ def _add_btree_suggestions(btree_fields, existing_indexes, suggestions):
         )
         reason = f"Btree index for {idx_type.name} field '{field}'"
     else:
-        exprs = [_btree_expr(f, t) for f, t in fields_limited]
-        field_names = [f for f, _t in fields_limited]
+        exprs = [_btree_expr(f, t) for f, t in ordered]
         name = "idx_os_sug_" + "_".join(field_names)
         cols = ", ".join(exprs)
         ddl = (
             f"CREATE INDEX CONCURRENTLY {name} "
             f"ON object_state ({cols}) WHERE idx IS NOT NULL"
         )
-        types_str = " + ".join(t.name for _f, t in fields_limited)
-        reason = f"Composite btree ({types_str}) for {len(fields_limited)} fields"
+        types_str = " + ".join(t.name for _f, t in ordered)
+        reason = f"Composite btree ({types_str}) for {len(ordered)} fields"
+    if sort_covering:
+        reason += f"; last column covers ORDER BY {sort_field[0]}"
 
     status = _check_covered(ddl, existing_indexes)
     suggestions.append(
         {
-            "fields": [f for f, _t in fields_limited],
-            "field_types": [t.name for _f, t in fields_limited],
+            "fields": field_names,
+            "field_types": [t.name for _f, t in ordered],
             "ddl": ddl,
             "status": status,
             "reason": reason if status == "new" else f"Already covered: {reason}",

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -146,6 +146,26 @@ class TestSuggestIndexes:
             assert "sort_on" not in s["fields"]
             assert "b_size" not in s["fields"]
 
+    def test_pagination_meta_dropped(self):
+        """b_size / b_start are pagination-meta — never appear in suggestions."""
+        registry = _reg(portal_type=IndexType.FIELD)
+        result = suggest_indexes(
+            ["portal_type", "b_size", "b_start"], None, registry, {}
+        )
+        for s in result:
+            assert "b_size" not in s["fields"]
+            assert "b_start" not in s["fields"]
+
+    def test_sort_meta_keys_dropped(self):
+        """sort_on / sort_order keys (as raw keys) are dropped from the filter list."""
+        registry = _reg(portal_type=IndexType.FIELD)
+        result = suggest_indexes(
+            ["portal_type", "sort_on", "sort_order"], None, registry, {}
+        )
+        for s in result:
+            assert "sort_on" not in s["fields"]
+            assert "sort_order" not in s["fields"]
+
     def test_unknown_field_skipped(self):
         registry = _reg(portal_type=IndexType.FIELD)
         result = suggest_indexes(["portal_type", "unknown_field"], None, registry, {})

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -455,3 +455,55 @@ class TestApplyIndexPreflight:
         # No DROP, just CREATE
         assert not any("DROP INDEX CONCURRENTLY IF EXISTS" in s for s in executed_sqls)
         assert any("CREATE INDEX CONCURRENTLY" in s for s in executed_sqls)
+
+
+class TestExtractSortField:
+    """Unit tests for _extract_sort_field helper."""
+
+    def test_returns_none_when_params_is_none(self):
+        from plone.pgcatalog.suggestions import _extract_sort_field
+
+        assert _extract_sort_field(None, _reg()) is None
+
+    def test_returns_none_when_params_empty(self):
+        from plone.pgcatalog.suggestions import _extract_sort_field
+
+        assert _extract_sort_field({}, _reg()) is None
+
+    def test_plain_sort_on_extracted(self):
+        from plone.pgcatalog.suggestions import _extract_sort_field
+
+        registry = _reg(effective=IndexType.DATE)
+        result = _extract_sort_field({"sort_on": "effective"}, registry)
+        assert result == ("effective", IndexType.DATE)
+
+    def test_plone_aliased_sort_on_extracted(self):
+        """Plone generates p_sort_on_1 etc. — substring match wins."""
+        from plone.pgcatalog.suggestions import _extract_sort_field
+
+        registry = _reg(effective=IndexType.DATE)
+        result = _extract_sort_field({"p_sort_on_1": "effective"}, registry)
+        assert result == ("effective", IndexType.DATE)
+
+    def test_returns_none_for_unknown_field(self):
+        """Sort value not in registry → None (no crash)."""
+        from plone.pgcatalog.suggestions import _extract_sort_field
+
+        registry = _reg(effective=IndexType.DATE)
+        assert _extract_sort_field({"sort_on": "bogus"}, registry) is None
+
+    def test_returns_none_for_non_composite_type(self):
+        """Sort on a KEYWORD/TEXT field → None (cannot be a trailing btree column)."""
+        from plone.pgcatalog.suggestions import _extract_sort_field
+
+        registry = _reg(Subject=IndexType.KEYWORD)
+        assert _extract_sort_field({"sort_on": "Subject"}, registry) is None
+
+    def test_returns_none_for_skip_type(self):
+        """GOPIP / DATE_RANGE cannot be a trailing btree column either."""
+        from plone.pgcatalog.suggestions import _extract_sort_field
+
+        registry = _reg(getObjPositionInParent=IndexType.GOPIP)
+        assert (
+            _extract_sort_field({"sort_on": "getObjPositionInParent"}, registry) is None
+        )

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -249,11 +249,29 @@ class TestSuggestIndexes:
             assert "idx_os_sug_" in s["ddl"]
 
     def test_date_range_excluded(self):
-        """DATE_RANGE (effectiveRange) should be filtered by _NON_IDX_FIELDS."""
+        """The effectiveRange virtual key never appears verbatim in outputs."""
         registry = _reg(portal_type=IndexType.FIELD)
         result = suggest_indexes(["portal_type", "effectiveRange"], None, registry, {})
         for s in result:
             assert "effectiveRange" not in s["fields"]
+
+    def test_effective_range_expands_to_effective(self):
+        """effectiveRange in query keys yields a composite mentioning effective."""
+        registry = _reg(portal_type=IndexType.FIELD)
+        result = suggest_indexes(["portal_type", "effectiveRange"], None, registry, {})
+        new = [s for s in result if s["status"] == "new"]
+        assert len(new) == 1
+        assert "portal_type" in new[0]["fields"]
+        assert "effective" in new[0]["fields"]
+        assert "pgcatalog_to_timestamptz(idx->>'effective')" in new[0]["ddl"]
+
+    def test_effective_range_narrow_no_expires(self):
+        """Narrow expansion — expires is NOT added to the composite."""
+        registry = _reg(portal_type=IndexType.FIELD)
+        result = suggest_indexes(["portal_type", "effectiveRange"], None, registry, {})
+        for s in result:
+            assert "expires" not in s["fields"]
+            assert "'expires'" not in s["ddl"]
 
     def test_gopip_skipped(self):
         """GopipIndex fields are skipped (no meaningful PG index type)."""

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -298,6 +298,118 @@ class TestSuggestIndexes:
         result = suggest_indexes(["Language"], None, registry, existing)
         assert all(s["status"] == "already_covered" for s in result)
 
+    def test_sort_on_appends_trailing_column(self):
+        """sort_on in params appends the sort field as the last composite column."""
+        registry = _reg(
+            portal_type=IndexType.FIELD,
+            effective=IndexType.DATE,
+        )
+        result = suggest_indexes(
+            ["portal_type"],
+            {"sort_on": "effective"},
+            registry,
+            {},
+        )
+        new = [s for s in result if s["status"] == "new"]
+        assert len(new) == 1
+        assert new[0]["fields"] == ["portal_type", "effective"]
+        ddl = new[0]["ddl"]
+        assert ddl.index("pgcatalog_to_timestamptz(idx->>'effective')") > ddl.index(
+            "(idx->>'portal_type')"
+        )
+        assert "ORDER BY effective" in new[0]["reason"]
+
+    def test_sort_on_deduped_when_already_leading(self):
+        """Sort field already present as filter column — not appended twice."""
+        registry = _reg(
+            portal_type=IndexType.FIELD,
+            effective=IndexType.DATE,
+        )
+        result = suggest_indexes(
+            ["portal_type", "effectiveRange"],
+            {"sort_on": "effective"},
+            registry,
+            {},
+        )
+        new = [s for s in result if s["status"] == "new"]
+        assert len(new) == 1
+        assert new[0]["fields"].count("effective") == 1
+
+    def test_sort_on_ignored_for_non_composite_type(self):
+        """Sort on a TEXT field does not add a trailing column."""
+        registry = _reg(
+            portal_type=IndexType.FIELD,
+            Title=IndexType.TEXT,
+        )
+        result = suggest_indexes(
+            ["portal_type"],
+            {"sort_on": "Title"},
+            registry,
+            {},
+        )
+        new = [
+            s for s in result if s["status"] == "new" and "portal_type" in s["fields"]
+        ]
+        assert all("Title" not in s["fields"] for s in new)
+
+    def test_sort_on_unknown_field_ignored(self):
+        """Sort on an unregistered field produces no covering column, no crash."""
+        registry = _reg(portal_type=IndexType.FIELD)
+        result = suggest_indexes(
+            ["portal_type"],
+            {"sort_on": "not_in_registry"},
+            registry,
+            {},
+        )
+        new = [s for s in result if s["status"] == "new"]
+        assert len(new) == 1
+        assert new[0]["fields"] == ["portal_type"]
+
+    def test_composite_cap_includes_sort(self):
+        """Three filter fields + sort → filter list truncated to 2, sort appended."""
+        registry = _reg(
+            a=IndexType.FIELD,
+            b=IndexType.FIELD,
+            c=IndexType.FIELD,
+            effective=IndexType.DATE,
+        )
+        result = suggest_indexes(
+            ["a", "b", "c"],
+            {"sort_on": "effective"},
+            registry,
+            {},
+        )
+        new = [s for s in result if s["status"] == "new"]
+        assert len(new) == 1
+        assert len(new[0]["fields"]) == 3
+        assert new[0]["fields"][-1] == "effective"
+
+    def test_issue_122_pattern(self):
+        """Regression for #122: portal_type + effectiveRange + sort_on=effective."""
+        registry = _reg(
+            portal_type=IndexType.FIELD,
+            effective=IndexType.DATE,
+        )
+        result = suggest_indexes(
+            ["portal_type", "effectiveRange"],
+            {"sort_on": "effective"},
+            registry,
+            {},
+        )
+        new = [s for s in result if s["status"] == "new"]
+        assert len(new) == 1
+        assert new[0]["fields"] == ["portal_type", "effective"]
+        ddl = new[0]["ddl"]
+        assert "(idx->>'portal_type')" in ddl
+        assert "pgcatalog_to_timestamptz(idx->>'effective')" in ddl
+
+    def test_params_none_behaves_as_before(self):
+        """Passing params=None is equivalent to the pre-PR-2 behavior."""
+        registry = _reg(portal_type=IndexType.FIELD)
+        r_none = suggest_indexes(["portal_type"], None, registry, {})
+        r_empty = suggest_indexes(["portal_type"], {}, registry, {})
+        assert [s["ddl"] for s in r_none] == [s["ddl"] for s in r_empty]
+
     def test_composite_already_covered_by_pg_normalized_indexdef(self):
         """Composite suggestion detects equivalent PG-stored indexdef.
 

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -29,7 +29,7 @@ class TestSuggestIndexes:
 
     def test_single_field_returns_single_btree(self):
         registry = _reg(portal_type=IndexType.FIELD)
-        result = suggest_indexes(["portal_type"], registry, {})
+        result = suggest_indexes(["portal_type"], None, registry, {})
         assert len(result) == 1
         assert result[0]["status"] == "new"
         assert "(idx->>'portal_type')" in result[0]["ddl"]
@@ -40,7 +40,7 @@ class TestSuggestIndexes:
             portal_type=IndexType.FIELD,
             Creator=IndexType.FIELD,
         )
-        result = suggest_indexes(["portal_type", "Creator"], registry, {})
+        result = suggest_indexes(["portal_type", "Creator"], None, registry, {})
         new = [s for s in result if s["status"] == "new"]
         assert len(new) == 1
         assert "portal_type" in new[0]["ddl"]
@@ -53,7 +53,7 @@ class TestSuggestIndexes:
             c=IndexType.FIELD,
             d=IndexType.FIELD,
         )
-        result = suggest_indexes(["a", "b", "c", "d"], registry, {})
+        result = suggest_indexes(["a", "b", "c", "d"], None, registry, {})
         new = [s for s in result if s["status"] == "new"]
         # Composite should have max 3 fields
         for s in new:
@@ -64,7 +64,7 @@ class TestSuggestIndexes:
             portal_type=IndexType.FIELD,
             Subject=IndexType.KEYWORD,
         )
-        result = suggest_indexes(["portal_type", "Subject"], registry, {})
+        result = suggest_indexes(["portal_type", "Subject"], None, registry, {})
         # KEYWORD gets its own suggestion, not mixed into composite
         for s in result:
             if "Subject" in s["fields"] and len(s["fields"]) > 1:
@@ -75,20 +75,20 @@ class TestSuggestIndexes:
             portal_type=IndexType.FIELD,
             Title=IndexType.TEXT,
         )
-        result = suggest_indexes(["portal_type", "Title"], registry, {})
+        result = suggest_indexes(["portal_type", "Title"], None, registry, {})
         for s in result:
             if "Title" in s["fields"] and len(s["fields"]) > 1:
                 pytest.fail("TEXT should not be in a composite")
 
     def test_date_uses_timestamptz(self):
         registry = _reg(modified=IndexType.DATE)
-        result = suggest_indexes(["modified"], registry, {})
+        result = suggest_indexes(["modified"], None, registry, {})
         new = [s for s in result if s["status"] == "new"]
         assert any("pgcatalog_to_timestamptz" in s["ddl"] for s in new)
 
     def test_boolean_uses_cast(self):
         registry = _reg(is_folderish=IndexType.BOOLEAN)
-        result = suggest_indexes(["is_folderish"], registry, {})
+        result = suggest_indexes(["is_folderish"], None, registry, {})
         new = [s for s in result if s["status"] == "new"]
         assert any("((idx->>'is_folderish')::boolean)" in s["ddl"] for s in new)
 
@@ -103,7 +103,9 @@ class TestSuggestIndexes:
             portal_type=IndexType.FIELD,
             exclude_from_nav=IndexType.BOOLEAN,
         )
-        result = suggest_indexes(["portal_type", "exclude_from_nav"], registry, {})
+        result = suggest_indexes(
+            ["portal_type", "exclude_from_nav"], None, registry, {}
+        )
         composites = [
             s for s in result if s["status"] == "new" and len(s["fields"]) > 1
         ]
@@ -118,33 +120,35 @@ class TestSuggestIndexes:
 
     def test_uuid_uses_text_expression(self):
         registry = _reg(UID=IndexType.UUID)
-        result = suggest_indexes(["UID"], registry, {})
+        result = suggest_indexes(["UID"], None, registry, {})
         new = [s for s in result if s["status"] == "new"]
         assert any("(idx->>'UID')" in s["ddl"] for s in new)
 
     def test_path_uses_text_pattern_ops(self):
         registry = _reg(tgpath=IndexType.PATH)
-        result = suggest_indexes(["tgpath"], registry, {})
+        result = suggest_indexes(["tgpath"], None, registry, {})
         new = [s for s in result if s["status"] == "new"]
         assert any("text_pattern_ops" in s["ddl"] for s in new)
 
     def test_keyword_gets_own_gin(self):
         """Unknown KEYWORD fields (not in _DEDICATED_FIELDS) get a GIN suggestion."""
         registry = _reg(custom_tags=IndexType.KEYWORD)
-        result = suggest_indexes(["custom_tags"], registry, {})
+        result = suggest_indexes(["custom_tags"], None, registry, {})
         new = [s for s in result if s["status"] == "new"]
         assert any("GIN" in s["ddl"].upper() or "gin" in s["ddl"] for s in new)
 
     def test_non_idx_fields_filtered(self):
         registry = _reg(portal_type=IndexType.FIELD)
-        result = suggest_indexes(["portal_type", "sort_on", "b_size"], registry, {})
+        result = suggest_indexes(
+            ["portal_type", "sort_on", "b_size"], None, registry, {}
+        )
         for s in result:
             assert "sort_on" not in s["fields"]
             assert "b_size" not in s["fields"]
 
     def test_unknown_field_skipped(self):
         registry = _reg(portal_type=IndexType.FIELD)
-        result = suggest_indexes(["portal_type", "unknown_field"], registry, {})
+        result = suggest_indexes(["portal_type", "unknown_field"], None, registry, {})
         for s in result:
             assert "unknown_field" not in s["fields"]
 
@@ -156,7 +160,7 @@ class TestSuggestIndexes:
                 "((idx->>'portal_type')) WHERE idx IS NOT NULL"
             )
         }
-        result = suggest_indexes(["portal_type"], registry, existing)
+        result = suggest_indexes(["portal_type"], None, registry, existing)
         assert all(s["status"] == "already_covered" for s in result)
 
     def test_already_covered_by_sug_name(self):
@@ -169,14 +173,14 @@ class TestSuggestIndexes:
                 "WHERE (idx IS NOT NULL)"
             )
         }
-        result = suggest_indexes(["portal_type"], registry, existing)
+        result = suggest_indexes(["portal_type"], None, registry, existing)
         assert all(s["status"] == "already_covered" for s in result)
 
     def test_dedicated_field_already_covered(self):
         registry = _reg(
             allowedRolesAndUsers=IndexType.KEYWORD,
         )
-        result = suggest_indexes(["allowedRolesAndUsers"], registry, {})
+        result = suggest_indexes(["allowedRolesAndUsers"], None, registry, {})
         covered = [s for s in result if s["status"] == "already_covered"]
         assert len(covered) == 1
         assert "dedicated" in covered[0]["reason"].lower()
@@ -184,25 +188,25 @@ class TestSuggestIndexes:
     def test_object_provides_already_covered(self):
         """object_provides has a dedicated GIN index — always covered."""
         registry = _reg(object_provides=IndexType.KEYWORD)
-        result = suggest_indexes(["object_provides"], registry, {})
+        result = suggest_indexes(["object_provides"], None, registry, {})
         covered = [s for s in result if s["status"] == "already_covered"]
         assert len(covered) == 1
 
     def test_subject_already_covered(self):
         """Subject has a dedicated GIN index — always covered."""
         registry = _reg(Subject=IndexType.KEYWORD)
-        result = suggest_indexes(["Subject"], registry, {})
+        result = suggest_indexes(["Subject"], None, registry, {})
         covered = [s for s in result if s["status"] == "already_covered"]
         assert len(covered) == 1
 
     def test_empty_keys_returns_empty(self):
         registry = _reg()
-        result = suggest_indexes([], registry, {})
+        result = suggest_indexes([], None, registry, {})
         assert result == []
 
     def test_all_filtered_keys_returns_empty(self):
         registry = _reg()
-        result = suggest_indexes(["sort_on", "b_size"], registry, {})
+        result = suggest_indexes(["sort_on", "b_size"], None, registry, {})
         assert result == []
 
     def test_selectivity_ordering(self):
@@ -211,7 +215,7 @@ class TestSuggestIndexes:
             review_state=IndexType.FIELD,
             UID=IndexType.UUID,
         )
-        result = suggest_indexes(["review_state", "UID"], registry, {})
+        result = suggest_indexes(["review_state", "UID"], None, registry, {})
         composites = [s for s in result if len(s["fields"]) > 1]
         if composites:
             assert composites[0]["fields"][0] == "UID"
@@ -219,7 +223,7 @@ class TestSuggestIndexes:
     def test_naming_convention(self):
         """Generated index names use idx_os_sug_ prefix."""
         registry = _reg(portal_type=IndexType.FIELD)
-        result = suggest_indexes(["portal_type"], registry, {})
+        result = suggest_indexes(["portal_type"], None, registry, {})
         new = [s for s in result if s["status"] == "new"]
         for s in new:
             assert "idx_os_sug_" in s["ddl"]
@@ -227,14 +231,14 @@ class TestSuggestIndexes:
     def test_date_range_excluded(self):
         """DATE_RANGE (effectiveRange) should be filtered by _NON_IDX_FIELDS."""
         registry = _reg(portal_type=IndexType.FIELD)
-        result = suggest_indexes(["portal_type", "effectiveRange"], registry, {})
+        result = suggest_indexes(["portal_type", "effectiveRange"], None, registry, {})
         for s in result:
             assert "effectiveRange" not in s["fields"]
 
     def test_gopip_skipped(self):
         """GopipIndex fields are skipped (no meaningful PG index type)."""
         registry = _reg(getObjPositionInParent=IndexType.GOPIP)
-        result = suggest_indexes(["getObjPositionInParent"], registry, {})
+        result = suggest_indexes(["getObjPositionInParent"], None, registry, {})
         assert result == []
 
     def test_mixed_case_name_already_covered(self):
@@ -253,7 +257,7 @@ class TestSuggestIndexes:
                 "WHERE (idx IS NOT NULL)"
             )
         }
-        result = suggest_indexes(["Language"], registry, existing)
+        result = suggest_indexes(["Language"], None, registry, existing)
         assert all(s["status"] == "already_covered" for s in result)
 
     def test_composite_already_covered_by_pg_normalized_indexdef(self):
@@ -281,7 +285,9 @@ class TestSuggestIndexes:
                 ") WHERE (idx IS NOT NULL)"
             )
         }
-        result = suggest_indexes(["Language", "portal_type", "end"], registry, existing)
+        result = suggest_indexes(
+            ["Language", "portal_type", "end"], None, registry, existing
+        )
         assert all(s["status"] == "already_covered" for s in result)
 
 


### PR DESCRIPTION
## Summary

Closes the slow-query suggestion gap for the canonical Plone pattern from [issue #122](https://github.com/bluedynamics/plone-pgcatalog/issues/122) — `portal_type + effectiveRange + sort_on=effective` previously produced no suggestion because every key landed in the vague `_NON_IDX_FIELDS` catch-all.

- Splits `_NON_IDX_FIELDS` into `_PAGINATION_META`, `_SORT_META`, `_FILTER_VIRTUAL`, `_SKIP_FIELDS` — each with a single clear purpose.
- Expands `effectiveRange` → `('effective', DATE)` so published-content queries participate in composite suggestions (narrow expansion: no `expires`).
- Appends the query's `sort_on` field as a trailing covering column when btree-composite-eligible. Composite cap stays 3 total columns; sort eats one slot when present; dedupes when the sort field is already a filter column.
- Plumbs the representative params blob through `manage_get_slow_query_stats` via `LEFT JOIN LATERAL` so the engine sees a real `sort_on` value per query-key group.

No DDL changes, no schema migration, no ZMI template changes — safe to roll out mid-fleet.

Spec: [`docs/superpowers/specs/2026-04-13-suggestions-engine-pr2-design.md`](docs/superpowers/specs/2026-04-13-suggestions-engine-pr2-design.md)
Plan: [`docs/plans/2026-04-14-suggestions-engine-pr2-plan.md`](docs/plans/2026-04-14-suggestions-engine-pr2-plan.md)

## Test plan

- [x] Full pytest suite green (1328 passed, 39 skipped)
- [x] 16 new tests in \`tests/test_suggestions.py\` covering each design decision (Q1-Q6), including \`test_issue_122_pattern\` regression guard
- [x] \`ruff check\` clean on modified files
- [ ] Manual smoke in a live instance: trigger \`portal_type + effectiveRange + sort_on=effective\` and confirm Slow Queries tab now shows a covering composite suggestion with \`pgcatalog_to_timestamptz(idx->>'effective')\` as the trailing column

Refs #122. Follow-up PR 3 (EXPLAIN-driven coverage + DTML→JSON UI) already scoped in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)