### PR TITLE
fix: restore DateRecurringIndex entries across catalog migration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,44 @@
 
 ## 1.0.0b53 (unreleased)
 
+### Fixed
+
+- Migration install handler silently dropped every
+  `DateRecurringIndex` (DRI) — e.g. `plone.app.event`'s / `bda.aaf.site`'s
+  `general_start` / `general_end` — when replacing a foreign
+  `portal_catalog` with `PlonePGCatalogTool`.  `_snapshot_catalog`
+  correctly captured the stored `attr_recurdef` / `attr_until`
+  attributes, but `_build_extra` had no DRI branch, so the restored
+  `extra` namespace lacked the `recurdef` / `until` keys that
+  `DateRecurringIndex.__init__` reads.  The constructor raised
+  `AttributeError`, the outer `try/except` in `_restore_from_snapshot`
+  swallowed it as a warning, and the index was never created — which
+  meant `extract_idx` never indexed those fields, the IndexRegistry
+  had no entry for them, and every site-wide Collection filtering on
+  `general_end` returned zero results.
+
+  Added the DRI translation in `_build_extra`, plus a roundtrip test
+  that actually instantiates `DateRecurringIndex` with the built extra
+  — the kind of assertion that would have caught this before it ever
+  shipped.  Issue #126.
+
+  Existing deployments that migrated on an affected build have to
+  re-add the missing indexes manually (the upgrade can't recover them
+  without the original catalog snapshot).  Run:
+
+  ```python
+  catalog = portal.portal_catalog
+  class _Extra: pass
+  extra = _Extra()
+  extra.recurdef = "recurrence"
+  extra.until = ""
+  for name in ("general_start", "general_end"):
+      if name not in catalog._catalog.indexes:
+          catalog.addIndex(name, "DateRecurringIndex", extra)
+  catalog.reindexIndex("general_start")
+  catalog.reindexIndex("general_end")
+  ```
+
 ### Added
 
 - Slow-query suggestions now produce covering composite indexes for the

--- a/src/plone/pgcatalog/setuphandlers.py
+++ b/src/plone/pgcatalog/setuphandlers.py
@@ -324,6 +324,10 @@ def _build_extra(entry):
     - FieldIndex/KeywordIndex/etc.: ``indexed_attrs``
     - DateRangeIndex: ``since_field``, ``until_field``
     - ZCTextIndex: ``lexicon_id``, ``index_type``, ``doc_attr``
+    - DateRecurringIndex: ``recurdef``, ``until`` (NOT ``attr_recurdef`` —
+      the index reads ``extra.recurdef`` in its constructor and stores it
+      on ``self.attr_recurdef``; the snapshot captures the stored attribute
+      so we have to translate the key back here).
     """
     extra = _Extra()
 
@@ -345,6 +349,16 @@ def _build_extra(entry):
     # ZCTextIndex: doc_attr from source_attrs
     if entry.get("meta_type") == "ZCTextIndex" and source_attrs:
         extra.doc_attr = source_attrs[0]
+
+    # DateRecurringIndex (plone.app.event / bda.aaf.site etc.):
+    # the constructor expects extra.recurdef / extra.until — without
+    # these, DateRecurringIndex.__init__ raises AttributeError and the
+    # index silently fails to restore.  Default to empty strings so the
+    # index creates even when the snapshot didn't capture one of them
+    # (rare but possible for hand-written catalog.xml imports).
+    if entry.get("meta_type") == "DateRecurringIndex":
+        extra.recurdef = entry.get("attr_recurdef", "")
+        extra.until = entry.get("attr_until", "")
 
     return extra
 

--- a/tests/test_setuphandlers.py
+++ b/tests/test_setuphandlers.py
@@ -244,6 +244,62 @@ class TestBuildExtra:
         extra = _build_extra(entry)
         assert not hasattr(extra, "indexed_attrs")
 
+    def test_date_recurring_index_extra(self):
+        """DRI needs extra.recurdef / extra.until — not attr_recurdef.
+
+        ``DateRecurringIndex.__init__`` reads ``extra.recurdef`` and
+        ``extra.until`` and stores them on ``self.attr_recurdef`` /
+        ``self.attr_until``.  The snapshot captures the *stored* form
+        (``attr_recurdef``), so ``_build_extra`` has to translate the
+        key back.  Missing this translation is how pre-fix migrations
+        silently lost every DRI in the site (issue #126).
+        """
+        entry = {
+            "meta_type": "DateRecurringIndex",
+            "source_attrs": ["general_end"],
+            "attr_recurdef": "recurrence",
+            "attr_until": "open_end",
+        }
+        extra = _build_extra(entry)
+        assert extra.recurdef == "recurrence"
+        assert extra.until == "open_end"
+
+    def test_date_recurring_index_extra_missing_attrs_defaults_to_empty(self):
+        """Snapshot captured a DRI but recurdef/until weren't set.
+
+        Still produce a usable extra — DateRecurringIndex tolerates
+        empty strings and falls back to no recurrence handling, which
+        is better than the index silently failing to restore.
+        """
+        entry = {
+            "meta_type": "DateRecurringIndex",
+            "source_attrs": ["general_start"],
+        }
+        extra = _build_extra(entry)
+        assert extra.recurdef == ""
+        assert extra.until == ""
+
+    def test_date_recurring_extra_is_accepted_by_dri_constructor(self):
+        """The extra object actually constructs a DateRecurringIndex.
+
+        The whole point of this translation: without ``extra.recurdef``
+        the constructor raises ``AttributeError`` and the index is
+        silently lost.  Instantiate the real class to prove our
+        ``extra`` satisfies its contract.
+        """
+        from Products.DateRecurringIndex.index import DateRecurringIndex
+
+        entry = {
+            "meta_type": "DateRecurringIndex",
+            "source_attrs": ["general_end"],
+            "attr_recurdef": "recurrence",
+            "attr_until": "",
+        }
+        extra = _build_extra(entry)
+        index = DateRecurringIndex("general_end", extra=extra)
+        assert index.attr_recurdef == "recurrence"
+        assert index.attr_until == ""
+
 
 # ===========================================================================
 # _replace_catalog


### PR DESCRIPTION
Fixes #126.

## Root cause

When the install handler replaces a foreign \`portal_catalog\` with \`PlonePGCatalogTool\`, it \`_snapshot_catalog\`s the old catalog's indexes and then \`_restore_from_snapshot\`s them on the new catalog via \`addIndex(name, meta_type, extra)\`. For DateRecurringIndex entries, the snapshot captured \`attr_recurdef\` / \`attr_until\` (the *stored* attribute names on the index object), but \`_build_extra\` only knew about FieldIndex, DateRangeIndex and ZCTextIndex. So the \`extra\` namespace passed to \`addIndex\` lacked \`recurdef\` / \`until\`.

\`DateRecurringIndex.__init__\` does:

\`\`\`python
self.attr_recurdef = extra.recurdef
self.attr_until = extra.until
\`\`\`

AttributeError. The outer \`try/except\` in \`_restore_from_snapshot\` swallowed it as a warning and moved on. The index was never created.

Downstream fallout on an affected site (investigated in #126):
- \`general_start\` / \`general_end\` missing from \`portal_catalog._catalog.indexes\`.
- No entry in \`plone.pgcatalog.columns.IndexRegistry\`.
- \`extract_idx\` therefore never iterated them — \`object_state.idx->>'general_end'\` stayed NULL for every event (13940 rows observed).
- Logs showed \`Unknown sort index 'general_start' — ignoring\` on every Collection query filtering on recurring-event end dates, returning zero results.

## Fix

\`_build_extra\` now handles \`DateRecurringIndex\`: translates \`attr_recurdef\` → \`extra.recurdef\` and \`attr_until\` → \`extra.until\`, defaulting to empty strings when the snapshot didn't capture them.

## Tests

Added to \`tests/test_setuphandlers.py::TestBuildExtra\`:
- \`test_date_recurring_index_extra\` — snapshot keys translated correctly.
- \`test_date_recurring_index_extra_missing_attrs_defaults_to_empty\` — robust when snapshot is incomplete.
- \`test_date_recurring_extra_is_accepted_by_dri_constructor\` — **instantiates real \`DateRecurringIndex\` with the built extra**. This is the test that would have caught the original bug.

All 47 tests in \`test_setuphandlers.py\` pass.

## Prod recovery (for already-migrated sites)

The fix stops the bleeding for future migrations but can't retroactively recreate indexes on an already-migrated site — the original snapshot is long gone. Operators have to re-add the missing DRI indexes by hand and reindex. The CHANGES.md entry documents the recipe:

\`\`\`python
catalog = portal.portal_catalog
class _Extra: pass
extra = _Extra()
extra.recurdef = \"recurrence\"
extra.until = \"\"
for name in (\"general_start\", \"general_end\"):
    if name not in catalog._catalog.indexes:
        catalog.addIndex(name, \"DateRecurringIndex\", extra)
catalog.reindexIndex(\"general_start\")
catalog.reindexIndex(\"general_end\")
\`\`\`

## Test plan

- [x] Unit + integration tests for \`_build_extra\` with DRI.
- [ ] On aaf-prod: run the recovery snippet above via zconsole, verify \`SELECT count(*) FROM object_state WHERE idx->>'portal_type'='Event' AND idx->>'general_end' IS NOT NULL\` returns 13940.
- [ ] Verify a Collection with \"Event ends in the future\" criterion now returns results.