### PR TITLE
Strip path/parent_path/path_depth from idx JSONB

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 1.0.0b54
+
+### Changed
+
+- Stop duplicating `path`, `path_parent`, and `path_depth` between the typed
+  columns on `object_state` and the `idx` JSONB.  These three fields now live
+  exclusively in their typed columns (`path`, `parent_path`, `path_depth`) —
+  previously identical values were stored in both places, wasting ~10 % of
+  JSONB storage and (more importantly) blocking the planner from collecting
+  selectivity statistics on path-subtree filters.  Indexes and extended
+  statistics on these fields have been migrated to reference the typed columns
+  directly.  Custom `PATH`-type indexes (e.g. `tgpath`) are unaffected and
+  continue to store their data in `idx`.
+
+  **Migration:** Schema and writer changes are picked up automatically on
+  startup (the eight affected indexes and three extended-statistics objects
+  are reissued with idempotent `DROP … IF EXISTS` / `CREATE … IF NOT EXISTS`
+  pairs).  To strip the obsolete keys from existing JSONB on large catalogs,
+  run:
+
+  ```python
+  from plone.pgcatalog.migrations.strip_path_keys import run
+  run(conn, batch_size=5000)
+  ```
+
+  Safe to run online, idempotent, batched.  Issue #132.
+
 ## 1.0.0b53
 
 ### Fixed

--- a/docs/plans/2026-04-15-strip-path-from-idx-jsonb.md
+++ b/docs/plans/2026-04-15-strip-path-from-idx-jsonb.md
@@ -1,0 +1,1094 @@
+# Strip `path`/`path_parent`/`path_depth` from `idx` JSONB — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop duplicating `path`, `path_parent`, and `path_depth` between typed columns and the `idx` JSONB on `object_state`. Migrate index DDL, extended-statistics DDL, the query builder, and existing data to use the typed columns exclusively.
+
+**Architecture:** This is a 4-axis change — writers, schema (indexes + stats), query builder, and a one-shot data migration — all converging on a single invariant: *the typed columns `path`, `parent_path`, `path_depth` are the only source of truth; `idx` JSONB never carries these three keys for the built-in `path` index.* Custom path indexes (e.g. `tgpath`) keep their JSONB layout. Each axis is testable in isolation; they ship together because the writers and queries assume the same shape.
+
+**Tech Stack:** Python 3.13, psycopg3, PostgreSQL 18, pytest, ZODB/Plone catalog API, zodb-pgjsonb state-processor plugin model.
+
+**Tracking issue:** [bluedynamics/plone-pgcatalog#132](https://github.com/bluedynamics/plone-pgcatalog/issues/132)
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `src/plone/pgcatalog/query.py` | SQL fragment generation for path queries | **Modify** lines 517–522: dispatch built-in path index to typed columns |
+| `src/plone/pgcatalog/indexing.py` | Direct catalog write path (`catalog_object()`) | **Modify** lines 43–46: stop adding path keys to `idx` |
+| `src/plone/pgcatalog/catalog.py` | Plone catalog tool, sets pending annotation | **Modify** lines 501–504: stop adding path keys to `idx` |
+| `src/plone/pgcatalog/processor.py` | State processor — read pending → typed cols + run bulk move | **Modify** lines 232–234 (read source), 287–294 (bulk move SQL) |
+| `src/plone/pgcatalog/schema.py` | DDL constants for indexes + extended statistics | **Modify**: replace 7 indexes + 3 statistics objects to use typed columns. **Add**: idempotent `DROP INDEX IF EXISTS` for the obsolete JSONB versions |
+| `src/plone/pgcatalog/migrations/__init__.py` | New migrations sub-package | **Create**: house migration helpers |
+| `src/plone/pgcatalog/migrations/strip_path_keys.py` | One-shot UPDATE to remove keys from existing rows | **Create**: batched, idempotent, safe to re-run |
+| `tests/test_strip_path_from_idx.py` | Test suite for this whole change | **Create**: write/read parity, query builder dispatch, schema state, migration |
+| `CHANGES.md` | Changelog | **Modify**: top-of-file entry |
+
+**Out of scope (separate follow-ups):**
+- `id`/`getId` JSONB duplication (also 100% identical, ~4.5 MB) — different code path, different question (which key is canonical for catalog readers?). File as separate issue.
+- The `overview_image` JSONB key (16 MB total) — needs investigation; not a duplication, just large.
+- `idx_os_cat_events_upcoming` (0 scans ever) — separate cleanup, listed in #131.
+
+---
+
+## Pre-flight (one-time)
+
+- [ ] **Step 0: Decide on worktree**
+
+This change spans 4+ files in `sources/plone-pgcatalog/`. Use the `superpowers:using-git-worktrees` skill to create an isolated worktree if not already in one. Branch suggestion: `feat/strip-path-from-idx`.
+
+```bash
+cd /home/jensens/ws/cdev/z3blobs/sources/plone-pgcatalog
+git checkout -b feat/strip-path-from-idx
+```
+
+- [ ] **Step 0.1: Confirm test environment**
+
+```bash
+cd /home/jensens/ws/cdev/z3blobs/sources/plone-pgcatalog
+.venv/bin/pytest tests/test_indexing.py -x --tb=short 2>&1 | tail -20
+```
+
+Expected: tests pass on current main. If they don't, stop and investigate.
+
+---
+
+## Task 1: Test scaffold for the whole change (TDD start)
+
+**Files:**
+- Create: `tests/test_strip_path_from_idx.py`
+
+- [ ] **Step 1.1: Create the failing test file**
+
+This is one big test module that covers all four axes of the change. Each test should fail on current main; together they prove the cleanup is complete when they all pass.
+
+```python
+"""Tests for stripping path/parent_path/path_depth from idx JSONB.
+
+See: docs/plans/2026-04-15-strip-path-from-idx-jsonb.md
+Issue: bluedynamics/plone-pgcatalog#132
+"""
+
+import pytest
+
+from plone.pgcatalog.query import QueryBuilder
+
+
+PATH_KEYS_IN_IDX = ("path", "path_parent", "path_depth")
+
+
+# ── 1. Writer side: idx must not contain the path keys ────────────────────
+
+class TestWriterDoesNotDuplicatePath:
+    """After the cleanup, writers must NOT put path/path_parent/path_depth
+    into idx JSONB.  Typed columns carry these values.
+    """
+
+    def test_catalog_object_strips_path_keys(self, pg_conn, sample_zoid):
+        """plone.pgcatalog.indexing.catalog_object must not write path keys."""
+        from plone.pgcatalog.indexing import catalog_object
+
+        idx_in = {"portal_type": "Document", "Title": "T"}
+        catalog_object(pg_conn, sample_zoid, "/Plone/doc", idx_in)
+
+        row = pg_conn.execute(
+            "SELECT path, parent_path, path_depth, idx FROM object_state "
+            "WHERE zoid = %s",
+            (sample_zoid,),
+        ).fetchone()
+
+        assert row.path == "/Plone/doc"
+        assert row.parent_path == "/Plone"
+        assert row.path_depth == 2
+        for key in PATH_KEYS_IN_IDX:
+            assert key not in row.idx, (
+                f"{key!r} must not be written to idx JSONB after cleanup"
+            )
+
+    def test_pgcatalog_tool_set_pg_annotation_strips_path_keys(self, pg_conn, plone_obj):
+        """PlonePGCatalogTool._set_pg_annotation must not write path keys to idx."""
+        from plone.pgcatalog.catalog import PlonePGCatalogTool, ANNOTATION_KEY
+
+        tool = PlonePGCatalogTool()
+        tool._set_pg_annotation(plone_obj, "/Plone/doc")
+
+        pending = plone_obj.__dict__[ANNOTATION_KEY]
+        for key in PATH_KEYS_IN_IDX:
+            assert key not in pending["idx"], (
+                f"{key!r} must not be in pending idx after cleanup"
+            )
+
+    def test_processor_reads_typed_cols_not_idx(self, pg_conn, sample_pending):
+        """CatalogStateProcessor.process must source parent_path/path_depth
+        from compute_path_info(path), not from idx."""
+        from plone.pgcatalog.processor import CatalogStateProcessor
+
+        # pending["path"] = "/a/b/c" → parent_path="/a/b", depth=3
+        # idx must NOT carry path_parent/path_depth (test isolation)
+        processor = CatalogStateProcessor()
+        result = processor.process(sample_pending, "fake_state_dict")
+
+        assert result["path"] == "/a/b/c"
+        assert result["parent_path"] == "/a/b"
+        assert result["path_depth"] == 3
+
+
+# ── 2. Bulk move (rename of subtree) keeps typed cols in sync, leaves idx alone ──
+
+class TestBulkMoveDoesNotTouchIdxPathKeys:
+    def test_bulk_move_updates_typed_only(self, pg_conn, two_objects_at):
+        """After bulk move SQL, typed cols reflect new path; idx still has no path keys."""
+        # two_objects_at fixture: pre-creates /Plone/old/a and /Plone/old/b
+        from plone.pgcatalog.processor import CatalogStateProcessor
+
+        processor = CatalogStateProcessor()
+        # Register a move /Plone/old → /Plone/new
+        from plone.pgcatalog.move import register_move
+        register_move("/Plone/old", "/Plone/new", depth_delta=0)
+
+        cursor = pg_conn.cursor()
+        processor.finalize(cursor)
+        pg_conn.commit()
+
+        for old_path in ("/Plone/old/a", "/Plone/old/b"):
+            row = pg_conn.execute(
+                "SELECT path, parent_path, idx FROM object_state WHERE path = %s",
+                (old_path.replace("/old/", "/new/"),),
+            ).fetchone()
+            assert row is not None, f"row not found at new path"
+            assert row.parent_path == "/Plone/new"
+            for key in PATH_KEYS_IN_IDX:
+                assert key not in row.idx
+
+
+# ── 3. Query builder: built-in path index → typed cols, custom → JSONB ──
+
+class TestQueryBuilderDispatchesPathToTypedColumns:
+    def _build(self, query):
+        qb = QueryBuilder(query, language="simple")
+        qb.build()
+        return qb.sql, qb.params
+
+    def test_builtin_path_index_uses_typed_columns(self):
+        sql, params = self._build({"path": {"query": "/Plone/x", "depth": -1}})
+        # Must NOT use idx->>'path' for the built-in path index
+        assert "idx->>'path'" not in sql
+        assert "(idx->>'path_depth')::integer" not in sql
+        # MUST use typed columns
+        assert " path " in sql or "path " in sql or " path)" in sql
+
+    def test_builtin_path_navtree_uses_typed_parent_path(self):
+        sql, params = self._build(
+            {"path": {"query": "/Plone/a/b", "navtree": True, "depth": 1}}
+        )
+        assert "idx->>'path_parent'" not in sql
+        assert "parent_path" in sql
+
+    def test_builtin_path_depth_uses_typed_path_depth(self):
+        sql, params = self._build({"path": {"query": "/Plone", "depth": 2}})
+        assert "(idx->>'path_depth')::integer" not in sql
+        assert "path_depth" in sql
+
+    def test_custom_path_index_keeps_jsonb_keys(self):
+        # tgpath (or any non-builtin path index): idx_key="tgpath", uses JSONB
+        sql, params = self._build(
+            {"tgpath": {"query": "/Plone/x", "depth": -1}}
+        )
+        assert "idx->>'tgpath'" in sql
+
+
+# ── 4. Schema state: indexes + statistics on typed cols, JSONB versions gone ──
+
+class TestSchemaUsesTypedColumns:
+    """Verify the resulting schema after migrations."""
+
+    EXPECTED_TYPED_COL_INDEXES = {
+        "idx_os_cat_path",          # → btree(path)
+        "idx_os_cat_path_pattern",  # → btree(path text_pattern_ops)
+        "idx_os_cat_path_parent",   # → btree(parent_path)
+        "idx_os_cat_path_depth",    # → btree(path_depth)
+        "idx_os_cat_parent_type",   # → btree(parent_path, idx->>'portal_type')
+        "idx_os_cat_path_type",     # → btree(path text_pattern_ops, idx->>'portal_type')
+        "idx_os_cat_path_depth_type",
+        "idx_os_cat_nav_visible",
+    }
+
+    def test_path_indexes_reference_typed_columns(self, pg_conn):
+        rows = pg_conn.execute("""
+            SELECT indexname, indexdef
+            FROM pg_indexes
+            WHERE tablename = 'object_state'
+              AND indexname = ANY(%s)
+        """, (list(self.EXPECTED_TYPED_COL_INDEXES),)).fetchall()
+        for r in rows:
+            # The path expression in any of these indexes must be the typed column,
+            # not the JSONB extract.
+            assert "idx ->> 'path'" not in r.indexdef, (
+                f"{r.indexname}: still uses idx->>'path' — migration incomplete"
+            )
+            assert "idx ->> 'path_parent'" not in r.indexdef
+            assert "idx ->> 'path_depth'" not in r.indexdef
+
+    def test_extended_statistics_reference_typed_columns(self, pg_conn):
+        rows = pg_conn.execute("""
+            SELECT stxname, pg_get_statisticsobjdef(oid) AS stxdef
+            FROM pg_statistic_ext
+            WHERE stxname IN (
+                'stts_os_parent_type',
+                'stts_os_path_type',
+                'stts_os_path_depth_type'
+            )
+        """).fetchall()
+        for r in rows:
+            assert "idx ->> 'path'" not in r.stxdef
+            assert "idx ->> 'path_parent'" not in r.stxdef
+            assert "idx ->> 'path_depth'" not in r.stxdef
+
+
+# ── 5. Migration: existing rows get their path keys stripped, idempotently ──
+
+class TestMigrationStripsPathKeys:
+    def test_strip_removes_keys_idempotently(self, pg_conn, dirty_rows):
+        """dirty_rows fixture inserts 5 rows with path/path_parent/path_depth
+        present in idx — simulating pre-migration state."""
+        from plone.pgcatalog.migrations.strip_path_keys import run
+
+        run(pg_conn, batch_size=2)  # forces multiple batches
+
+        rows = pg_conn.execute(
+            "SELECT idx FROM object_state WHERE zoid = ANY(%s)",
+            (dirty_rows,),
+        ).fetchall()
+        for r in rows:
+            for key in PATH_KEYS_IN_IDX:
+                assert key not in r.idx
+
+    def test_strip_is_idempotent(self, pg_conn, dirty_rows):
+        from plone.pgcatalog.migrations.strip_path_keys import run
+
+        run(pg_conn)
+        # Second run must be a no-op (zero rows updated)
+        result = run(pg_conn)
+        assert result["rows_updated"] == 0
+```
+
+- [ ] **Step 1.2: Run the new tests; they must all fail**
+
+```bash
+cd /home/jensens/ws/cdev/z3blobs/sources/plone-pgcatalog
+.venv/bin/pytest tests/test_strip_path_from_idx.py -v 2>&1 | tail -50
+```
+
+Expected: every test fails (most likely import errors or fixture errors first; that's fine — we'll define fixtures as we go).
+
+- [ ] **Step 1.3: Sketch fixtures** (do not implement — just identify gaps)
+
+Look at `tests/conftest.py` to find existing fixtures (`pg_conn`, etc.). Likely missing fixtures we'll need:
+- `sample_zoid` — a zoid pre-created in `object_state`
+- `plone_obj` — a Plone content stub with `getPhysicalPath()`
+- `sample_pending` — a pending dict shaped like `_pgcatalog_pending`
+- `two_objects_at` — pre-creates 2 catalog rows under a path
+- `dirty_rows` — pre-creates rows with the path keys still in `idx`
+
+Add minimal versions of these to `tests/conftest.py` as needed. Don't over-engineer — only add what each test consumes.
+
+- [ ] **Step 1.4: Commit the failing tests**
+
+```bash
+git add tests/test_strip_path_from_idx.py tests/conftest.py
+git commit -m "test: failing test scaffold for stripping path keys from idx (#132)"
+```
+
+---
+
+## Task 2: Query builder — dispatch built-in `path` to typed columns
+
+**Files:**
+- Modify: `src/plone/pgcatalog/query.py:517-522`
+
+- [ ] **Step 2.1: Confirm exactly which path tests fail**
+
+```bash
+.venv/bin/pytest tests/test_strip_path_from_idx.py::TestQueryBuilderDispatchesPathToTypedColumns -v 2>&1 | tail -30
+```
+
+Expected: 3 failures (`test_builtin_path_*`); 1 pass (`test_custom_path_index_keeps_jsonb_keys` — current code already uses JSONB).
+
+- [ ] **Step 2.2: Modify `_handle_path` to dispatch on the built-in path index**
+
+Open `src/plone/pgcatalog/query.py`. Replace lines 517–522 with:
+
+```python
+        # Dispatch: the built-in "path" index lives in typed columns
+        # (path, parent_path, path_depth).  Custom path indexes
+        # (e.g. "tgpath") still store their data in idx JSONB.
+        # See: docs/plans/2026-04-15-strip-path-from-idx-jsonb.md
+        if idx_key is None and name == "path":
+            expr_path = "path"
+            expr_parent = "parent_path"
+            expr_depth = "path_depth"
+        else:
+            key = name if idx_key is None else idx_key
+            expr_path = f"idx->>'{key}'"
+            expr_parent = f"idx->>'{key}_parent'"
+            expr_depth = f"(idx->>'{key}_depth')::integer"
+```
+
+- [ ] **Step 2.3: Run the QB tests**
+
+```bash
+.venv/bin/pytest tests/test_strip_path_from_idx.py::TestQueryBuilderDispatchesPathToTypedColumns -v
+```
+
+Expected: all 4 pass.
+
+- [ ] **Step 2.4: Run the broader path test suite to catch regressions**
+
+```bash
+.venv/bin/pytest tests/test_path.py tests/test_query.py tests/test_query_integration.py -v 2>&1 | tail -40
+```
+
+Expected: all pass. If any fail because they assert on `idx->>'path'` literally (rather than behavior), update them — they were testing implementation, not contract.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add src/plone/pgcatalog/query.py tests/test_path.py tests/test_query.py
+git commit -m "feat(query): use typed path columns for built-in path index (#132)"
+```
+
+---
+
+## Task 3: Writer — `indexing.catalog_object` stops adding path keys to `idx`
+
+**Files:**
+- Modify: `src/plone/pgcatalog/indexing.py:43-46`
+
+- [ ] **Step 3.1: Run the relevant test, confirm failure**
+
+```bash
+.venv/bin/pytest tests/test_strip_path_from_idx.py::TestWriterDoesNotDuplicatePath::test_catalog_object_strips_path_keys -v
+```
+
+Expected: FAIL — `'path' must not be written to idx JSONB after cleanup`.
+
+- [ ] **Step 3.2: Remove the three `setdefault` calls**
+
+In `src/plone/pgcatalog/indexing.py`, replace lines 43–46:
+
+```python
+    parent_path, path_depth = compute_path_info(path)
+
+    # Store path data in idx JSONB for unified path queries
+    idx.setdefault("path", path)
+    idx.setdefault("path_parent", parent_path)
+    idx.setdefault("path_depth", path_depth)
+```
+
+with:
+
+```python
+    parent_path, path_depth = compute_path_info(path)
+
+    # Path data lives in typed columns only (path, parent_path, path_depth).
+    # See: docs/plans/2026-04-15-strip-path-from-idx-jsonb.md
+```
+
+- [ ] **Step 3.3: Run, confirm pass**
+
+```bash
+.venv/bin/pytest tests/test_strip_path_from_idx.py::TestWriterDoesNotDuplicatePath::test_catalog_object_strips_path_keys -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 3.4: Run the full indexing tests for regressions**
+
+```bash
+.venv/bin/pytest tests/test_indexing.py -v 2>&1 | tail -30
+```
+
+Expected: all pass.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add src/plone/pgcatalog/indexing.py
+git commit -m "feat(indexing): stop dual-writing path keys to idx JSONB (#132)"
+```
+
+---
+
+## Task 4: Writer — `catalog._set_pg_annotation` stops adding path keys
+
+**Files:**
+- Modify: `src/plone/pgcatalog/catalog.py:501-504`
+
+- [ ] **Step 4.1: Run the test, confirm failure**
+
+```bash
+.venv/bin/pytest tests/test_strip_path_from_idx.py::TestWriterDoesNotDuplicatePath::test_pgcatalog_tool_set_pg_annotation_strips_path_keys -v
+```
+
+Expected: FAIL.
+
+- [ ] **Step 4.2: Remove the three assignments**
+
+In `src/plone/pgcatalog/catalog.py`, replace lines 499–510:
+
+```python
+        zoid = self._obj_to_zoid(obj)
+
+        wrapper = self._wrap_object(obj)
+        idx = self._extract_idx(wrapper)
+        searchable_text = self._extract_searchable_text(wrapper)
+        parent_path, path_depth = compute_path_info(uid)
+
+        # Store built-in path data in idx JSONB for unified path queries
+        idx["path"] = uid
+        idx["path_parent"] = parent_path
+        idx["path_depth"] = path_depth
+
+        pending_data = {
+            "path": uid,
+            "idx": idx,
+            "searchable_text": searchable_text,
+        }
+```
+
+with:
+
+```python
+        zoid = self._obj_to_zoid(obj)
+
+        wrapper = self._wrap_object(obj)
+        idx = self._extract_idx(wrapper)
+        searchable_text = self._extract_searchable_text(wrapper)
+
+        # Path data lives in typed columns only (path, parent_path, path_depth).
+        # The processor computes parent/depth from `path` via compute_path_info.
+        # See: docs/plans/2026-04-15-strip-path-from-idx-jsonb.md
+        pending_data = {
+            "path": uid,
+            "idx": idx,
+            "searchable_text": searchable_text,
+        }
+```
+
+(The `compute_path_info` import on the previous lines is no longer needed in this function — leave it if other functions in the file use it; otherwise remove.)
+
+- [ ] **Step 4.3: Verify import cleanup**
+
+```bash
+.venv/bin/python -c "import ast; tree = ast.parse(open('src/plone/pgcatalog/catalog.py').read()); print('OK')"
+```
+
+If `compute_path_info` becomes unused, remove its import. Run pyflakes if available:
+
+```bash
+.venv/bin/python -m pyflakes src/plone/pgcatalog/catalog.py
+```
+
+- [ ] **Step 4.4: Run the test**
+
+```bash
+.venv/bin/pytest tests/test_strip_path_from_idx.py::TestWriterDoesNotDuplicatePath::test_pgcatalog_tool_set_pg_annotation_strips_path_keys -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 4.5: Run broader catalog tool tests**
+
+```bash
+.venv/bin/pytest tests/test_catalog_plone.py tests/test_indexing.py -v 2>&1 | tail -30
+```
+
+Expected: all pass.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add src/plone/pgcatalog/catalog.py
+git commit -m "feat(catalog): stop dual-writing path keys to idx JSONB (#132)"
+```
+
+---
+
+## Task 5: Processor — read parent/depth from `path`, not `idx`
+
+**Files:**
+- Modify: `src/plone/pgcatalog/processor.py:227-238`
+
+- [ ] **Step 5.1: Run the test, confirm failure**
+
+```bash
+.venv/bin/pytest tests/test_strip_path_from_idx.py::TestWriterDoesNotDuplicatePath::test_processor_reads_typed_cols_not_idx -v
+```
+
+Expected: FAIL — current code reads `idx.get("path_parent")` and `idx.get("path_depth")`, which after Task 3 + 4 are now `None`.
+
+- [ ] **Step 5.2: Replace the source of `parent_path` and `path_depth`**
+
+In `src/plone/pgcatalog/processor.py`, replace lines 227–240:
+
+```python
+        # Normal catalog: extract registered extra idx columns
+        idx = pending.get("idx")
+        extra_values = extract_extra_idx_columns(idx)
+
+        result = {
+            "path": pending.get("path"),
+            "parent_path": idx.get("path_parent") if idx else None,
+            "path_depth": idx.get("path_depth") if idx else None,
+            "idx": Json(idx) if idx else None,
+            "searchable_text": pending.get("searchable_text"),
+            **extra_values,
+        }
+        result.update(get_backend().process_search_data(pending))
+        return result
+```
+
+with:
+
+```python
+        # Normal catalog: extract registered extra idx columns
+        idx = pending.get("idx")
+        extra_values = extract_extra_idx_columns(idx)
+
+        # Path data lives in typed columns only.  Compute parent/depth
+        # from the canonical `path` field — not from idx.
+        # See: docs/plans/2026-04-15-strip-path-from-idx-jsonb.md
+        path = pending.get("path")
+        if path:
+            from plone.pgcatalog.columns import compute_path_info
+            parent_path, path_depth = compute_path_info(path)
+        else:
+            parent_path, path_depth = None, None
+
+        result = {
+            "path": path,
+            "parent_path": parent_path,
+            "path_depth": path_depth,
+            "idx": Json(idx) if idx else None,
+            "searchable_text": pending.get("searchable_text"),
+            **extra_values,
+        }
+        result.update(get_backend().process_search_data(pending))
+        return result
+```
+
+(If `compute_path_info` is already imported at module level, drop the local import.)
+
+- [ ] **Step 5.3: Run the test**
+
+```bash
+.venv/bin/pytest tests/test_strip_path_from_idx.py::TestWriterDoesNotDuplicatePath::test_processor_reads_typed_cols_not_idx -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git add src/plone/pgcatalog/processor.py
+git commit -m "feat(processor): derive parent_path/path_depth from path, not idx (#132)"
+```
+
+---
+
+## Task 6: Processor — bulk move SQL stops touching `idx` for path keys
+
+**Files:**
+- Modify: `src/plone/pgcatalog/processor.py:281-303`
+
+- [ ] **Step 6.1: Run the test, confirm failure**
+
+```bash
+.venv/bin/pytest tests/test_strip_path_from_idx.py::TestBulkMoveDoesNotTouchIdxPathKeys -v
+```
+
+Expected: FAIL — current bulk move SQL writes the three keys back into idx.
+
+- [ ] **Step 6.2: Simplify the bulk move SQL**
+
+In `src/plone/pgcatalog/processor.py`, replace lines 281–304:
+
+```python
+        # Execute bulk path moves (one SQL per moved subtree)
+        moves = pop_all_pending_moves()
+        for old_prefix, new_prefix, depth_delta in moves:
+            cursor.execute(
+                """
+                UPDATE object_state SET
+                    path = %(new)s || substring(path FROM length(%(old)s) + 1),
+                    parent_path = %(new)s || substring(parent_path FROM length(%(old)s) + 1),
+                    path_depth = path_depth + %(dd)s,
+                    idx = idx || jsonb_build_object(
+                        'path',
+                        %(new)s || substring(idx->>'path' FROM length(%(old)s) + 1),
+                        'path_parent',
+                        %(new)s || substring(idx->>'path_parent' FROM length(%(old)s) + 1),
+                        'path_depth',
+                        (idx->>'path_depth')::int + %(dd)s
+                    )
+                WHERE path LIKE %(like)s
+                  AND idx IS NOT NULL
+                """,
+                {
+                    "old": old_prefix,
+                    "new": new_prefix,
+                    "dd": depth_delta,
+                    "like": old_prefix + "/%",
+                },
+            )
+```
+
+with:
+
+```python
+        # Execute bulk path moves (one SQL per moved subtree).
+        # Touches typed columns only — idx no longer carries path keys.
+        # See: docs/plans/2026-04-15-strip-path-from-idx-jsonb.md
+        moves = pop_all_pending_moves()
+        for old_prefix, new_prefix, depth_delta in moves:
+            cursor.execute(
+                """
+                UPDATE object_state SET
+                    path = %(new)s || substring(path FROM length(%(old)s) + 1),
+                    parent_path = %(new)s || substring(parent_path FROM length(%(old)s) + 1),
+                    path_depth = path_depth + %(dd)s
+                WHERE path LIKE %(like)s
+                """,
+                {
+                    "old": old_prefix,
+                    "new": new_prefix,
+                    "dd": depth_delta,
+                    "like": old_prefix + "/%",
+                },
+            )
+```
+
+(The `AND idx IS NOT NULL` is no longer needed — the move now updates only typed columns, and rows with a `path` value have catalog data by definition.)
+
+- [ ] **Step 6.3: Run the test + integration tests**
+
+```bash
+.venv/bin/pytest tests/test_strip_path_from_idx.py::TestBulkMoveDoesNotTouchIdxPathKeys tests/test_move_integration.py -v 2>&1 | tail -30
+```
+
+Expected: all pass.
+
+- [ ] **Step 6.4: Commit**
+
+```bash
+git add src/plone/pgcatalog/processor.py
+git commit -m "feat(processor): bulk move updates typed columns only (#132)"
+```
+
+---
+
+## Task 7: Schema — replace JSONB-extract indexes with typed-column indexes
+
+**Files:**
+- Modify: `src/plone/pgcatalog/schema.py` (DDL constants for `CATALOG_INDEXES` and `CATALOG_STATISTICS`)
+
+This task replaces 7 indexes and 3 extended-statistics objects. The strategy: explicit `DROP INDEX IF EXISTS` followed by `CREATE INDEX IF NOT EXISTS` so the swap is idempotent and self-healing on next startup.
+
+- [ ] **Step 7.1: Run the schema test, confirm failure**
+
+```bash
+.venv/bin/pytest tests/test_strip_path_from_idx.py::TestSchemaUsesTypedColumns -v
+```
+
+Expected: FAIL — current schema definitions still use `idx->>'path'`.
+
+- [ ] **Step 7.2: Replace the path-related indexes in `schema.py`**
+
+In `src/plone/pgcatalog/schema.py`, locate the `CATALOG_INDEXES` constant.
+
+For each of the 7 indexes below, **replace** the existing `CREATE INDEX IF NOT EXISTS …` block with a `DROP INDEX IF EXISTS …; CREATE INDEX IF NOT EXISTS …` pair using the typed columns:
+
+```sql
+-- Replace idx_os_cat_path (was: btree on idx->>'path')
+DROP INDEX IF EXISTS idx_os_cat_path;
+CREATE INDEX IF NOT EXISTS idx_os_cat_path
+    ON object_state (path) WHERE path IS NOT NULL;
+
+-- Replace idx_os_cat_path_pattern
+DROP INDEX IF EXISTS idx_os_cat_path_pattern;
+CREATE INDEX IF NOT EXISTS idx_os_cat_path_pattern
+    ON object_state USING btree (path text_pattern_ops) WHERE path IS NOT NULL;
+
+-- Replace idx_os_cat_path_parent
+DROP INDEX IF EXISTS idx_os_cat_path_parent;
+CREATE INDEX IF NOT EXISTS idx_os_cat_path_parent
+    ON object_state (parent_path) WHERE parent_path IS NOT NULL;
+
+-- Replace idx_os_cat_path_depth
+DROP INDEX IF EXISTS idx_os_cat_path_depth;
+CREATE INDEX IF NOT EXISTS idx_os_cat_path_depth
+    ON object_state (path_depth) WHERE path_depth IS NOT NULL;
+
+-- Replace idx_os_cat_parent_type
+DROP INDEX IF EXISTS idx_os_cat_parent_type;
+CREATE INDEX IF NOT EXISTS idx_os_cat_parent_type
+    ON object_state (parent_path, (idx->>'portal_type'))
+    WHERE parent_path IS NOT NULL;
+
+-- Replace idx_os_cat_path_type
+DROP INDEX IF EXISTS idx_os_cat_path_type;
+CREATE INDEX IF NOT EXISTS idx_os_cat_path_type
+    ON object_state (path text_pattern_ops, (idx->>'portal_type'))
+    WHERE path IS NOT NULL;
+
+-- Replace idx_os_cat_path_depth_type
+DROP INDEX IF EXISTS idx_os_cat_path_depth_type;
+CREATE INDEX IF NOT EXISTS idx_os_cat_path_depth_type
+    ON object_state (path text_pattern_ops, path_depth, (idx->>'portal_type'))
+    WHERE path IS NOT NULL;
+
+-- Replace idx_os_cat_nav_visible
+DROP INDEX IF EXISTS idx_os_cat_nav_visible;
+CREATE INDEX IF NOT EXISTS idx_os_cat_nav_visible
+    ON object_state (path text_pattern_ops, (idx->>'portal_type'))
+    WHERE path IS NOT NULL AND (idx->>'exclude_from_nav')::boolean = false;
+```
+
+- [ ] **Step 7.3: Replace the extended statistics in `schema.py`**
+
+In the same file, locate the `CATALOG_STATISTICS` (or equivalent) constant and replace the three path-related statistics objects:
+
+```sql
+-- Replace stts_os_parent_type
+DROP STATISTICS IF EXISTS stts_os_parent_type;
+CREATE STATISTICS IF NOT EXISTS stts_os_parent_type
+    (mcv, dependencies)
+    ON parent_path, (idx->>'portal_type')
+    FROM object_state;
+
+-- Replace stts_os_path_type
+DROP STATISTICS IF EXISTS stts_os_path_type;
+CREATE STATISTICS IF NOT EXISTS stts_os_path_type
+    (dependencies)
+    ON path, (idx->>'portal_type')
+    FROM object_state;
+
+-- Replace stts_os_path_depth_type
+DROP STATISTICS IF EXISTS stts_os_path_depth_type;
+CREATE STATISTICS IF NOT EXISTS stts_os_path_depth_type
+    (dependencies)
+    ON path, path_depth, (idx->>'portal_type')
+    FROM object_state;
+```
+
+- [ ] **Step 7.4: Verify the schema applies cleanly to a fresh test DB**
+
+```bash
+.venv/bin/pytest tests/test_schema.py -v 2>&1 | tail -20
+```
+
+Expected: pass. If a test asserts on the *old* index definitions, update it (those tests were locking down the obsolete shape).
+
+- [ ] **Step 7.5: Run the schema invariant tests**
+
+```bash
+.venv/bin/pytest tests/test_strip_path_from_idx.py::TestSchemaUsesTypedColumns -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7.6: Commit**
+
+```bash
+git add src/plone/pgcatalog/schema.py tests/test_schema.py
+git commit -m "feat(schema): index path/parent_path/path_depth on typed columns (#132)"
+```
+
+---
+
+## Task 8: Migration helper — strip keys from existing rows
+
+**Files:**
+- Create: `src/plone/pgcatalog/migrations/__init__.py`
+- Create: `src/plone/pgcatalog/migrations/strip_path_keys.py`
+
+- [ ] **Step 8.1: Run the migration test, confirm failure**
+
+```bash
+.venv/bin/pytest tests/test_strip_path_from_idx.py::TestMigrationStripsPathKeys -v
+```
+
+Expected: FAIL with `ImportError`.
+
+- [ ] **Step 8.2: Create the migrations package**
+
+```bash
+mkdir -p src/plone/pgcatalog/migrations
+touch src/plone/pgcatalog/migrations/__init__.py
+```
+
+- [ ] **Step 8.3: Implement the migration**
+
+Create `src/plone/pgcatalog/migrations/strip_path_keys.py`:
+
+```python
+"""One-shot migration: remove path/path_parent/path_depth from idx JSONB.
+
+After issue #132, these three keys live exclusively in typed columns
+(path, parent_path, path_depth).  This script removes them from existing
+rows that were written before the cleanup.
+
+Idempotent and batched.  Safe to re-run; safe to interrupt.
+
+Usage (from a shell with a configured psycopg connection):
+
+    from plone.pgcatalog.migrations.strip_path_keys import run
+    result = run(conn, batch_size=5000)
+    print(result)  # {"batches": N, "rows_updated": M}
+"""
+
+import logging
+
+
+log = logging.getLogger(__name__)
+
+# Rows that still have any of the three keys present in idx
+_DIRTY_PREDICATE = "idx ?| ARRAY['path', 'path_parent', 'path_depth']"
+
+_BATCH_SQL = f"""
+    WITH batch AS (
+        SELECT zoid
+        FROM object_state
+        WHERE zoid > %(after_zoid)s
+          AND idx IS NOT NULL
+          AND {_DIRTY_PREDICATE}
+        ORDER BY zoid
+        LIMIT %(batch_size)s
+    )
+    UPDATE object_state os
+       SET idx = idx - 'path' - 'path_parent' - 'path_depth'
+      FROM batch
+     WHERE os.zoid = batch.zoid
+    RETURNING os.zoid
+"""
+
+
+def run(conn, batch_size: int = 5000) -> dict:
+    """Strip path keys from idx in batches.
+
+    Args:
+        conn: psycopg connection (autocommit will be enabled per batch
+              by issuing COMMIT after each batch — caller-managed
+              transaction is committed first).
+        batch_size: rows per batch.  Default 5000 keeps each UPDATE under
+                    ~10 MB WAL and ~1 s on a typical pod.
+
+    Returns: {"batches": int, "rows_updated": int}
+    """
+    if not conn.autocommit:
+        # Ensure each batch commits independently — avoids a multi-GB
+        # single transaction and lets autovacuum reclaim space mid-run.
+        conn.commit()
+        conn.autocommit = True
+
+    after_zoid = -1
+    batches = 0
+    total = 0
+
+    while True:
+        with conn.cursor() as cur:
+            cur.execute(_BATCH_SQL, {
+                "after_zoid": after_zoid,
+                "batch_size": batch_size,
+            })
+            zoids = [r[0] for r in cur.fetchall()]
+
+        if not zoids:
+            break
+
+        batches += 1
+        total += len(zoids)
+        after_zoid = max(zoids)
+        log.info(
+            "strip_path_keys: batch %d, %d rows, last zoid=%d, total=%d",
+            batches, len(zoids), after_zoid, total,
+        )
+
+    log.info("strip_path_keys: done. %d batches, %d rows updated.", batches, total)
+    return {"batches": batches, "rows_updated": total}
+```
+
+- [ ] **Step 8.4: Run the migration tests**
+
+```bash
+.venv/bin/pytest tests/test_strip_path_from_idx.py::TestMigrationStripsPathKeys -v
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add src/plone/pgcatalog/migrations/__init__.py src/plone/pgcatalog/migrations/strip_path_keys.py
+git commit -m "feat(migrations): strip_path_keys removes obsolete idx duplicates (#132)"
+```
+
+---
+
+## Task 9: Run the full test suite
+
+- [ ] **Step 9.1: Run everything**
+
+```bash
+.venv/bin/pytest tests/ -v 2>&1 | tail -60
+```
+
+Expected: all 700-ish tests pass. Pay special attention to:
+- `test_path.py`, `test_query.py`, `test_query_integration.py`
+- `test_indexing.py`, `test_catalog_plone.py`
+- `test_move_integration.py`
+- `test_schema.py`
+- `test_strip_path_from_idx.py` (the new module — every test in it must pass)
+
+If anything fails, investigate. Common cases:
+- A test asserted on `idx->>'path'` in a generated SQL string — update the assertion to check the *behavior*, not the implementation.
+- A fixture seeded `idx` with the path keys explicitly — remove that seeding.
+
+- [ ] **Step 9.2: Lint pass**
+
+```bash
+.venv/bin/python -m pyflakes src/plone/pgcatalog/ 2>&1
+```
+
+Expected: no warnings about unused imports introduced by the cleanup.
+
+- [ ] **Step 9.3: Commit any test fixups**
+
+```bash
+git add tests/
+git commit -m "test: align assertions with typed-column path storage (#132)"
+```
+
+---
+
+## Task 10: CHANGES.md
+
+**Files:**
+- Modify: `CHANGES.md`
+
+- [ ] **Step 10.1: Add changelog entry**
+
+Open `CHANGES.md`. Under the next-release header (or add one if needed — check `gh release list -L 5` first per user preference, do NOT infer the version from CHANGES.md alone), insert:
+
+```markdown
+### Changed
+
+- Stop duplicating `path`, `path_parent`, and `path_depth` keys in the `idx`
+  JSONB column. These three fields now live exclusively in their typed columns
+  on `object_state`. Previously identical values were stored in both places,
+  wasting ~10% of JSONB storage and blocking the planner from getting accurate
+  selectivity stats on path-subtree filters. Indexes and extended statistics
+  on these fields have been migrated to reference the typed columns directly.
+  Custom `PATH`-type indexes (e.g. `tgpath`) are unaffected.
+
+  **Migration:** Schema and writer changes are picked up automatically on
+  startup (idempotent `DROP/CREATE` of affected indexes). To strip the
+  obsolete keys from existing JSONB on large catalogs, run:
+
+  ```python
+  from plone.pgcatalog.migrations.strip_path_keys import run
+  run(conn, batch_size=5000)
+  ```
+
+  Safe to run online and idempotent.
+
+  See: bluedynamics/plone-pgcatalog#132.
+```
+
+- [ ] **Step 10.2: Commit**
+
+```bash
+git add CHANGES.md
+git commit -m "docs: changelog entry for #132 path JSONB dedup"
+```
+
+---
+
+## Task 11: Manual smoke verification (optional, before opening PR)
+
+These are quick sanity checks against a local test DB to confirm the pipeline works end-to-end. Skip if CI covers this and you trust it.
+
+- [ ] **Step 11.1: Spin up a fresh test DB and verify schema bootstraps clean**
+
+```bash
+docker exec -it zodb-pgjsonb-dev psql -U zodb -d zodb_test -c "DROP TABLE IF EXISTS object_state CASCADE;"
+.venv/bin/pytest tests/test_indexing.py::test_first_object -v
+```
+
+Then:
+
+```bash
+docker exec -it zodb-pgjsonb-dev psql -U zodb -d zodb_test \
+    -c "\d object_state" | grep -E "(path|parent|depth)"
+```
+
+Expected: typed columns present; indexes named `idx_os_cat_path*` and `idx_os_cat_parent_type` reference `path`/`parent_path`/`path_depth` columns directly (not `idx ->> 'path'`).
+
+- [ ] **Step 11.2: Verify a write does not produce path keys in idx**
+
+```bash
+docker exec -it zodb-pgjsonb-dev psql -U zodb -d zodb_test \
+    -c "SELECT zoid, path, idx ? 'path' AS has_path_key FROM object_state LIMIT 5;"
+```
+
+Expected: `has_path_key = f` for every row written by the new code.
+
+---
+
+## Task 12: PR
+
+- [ ] **Step 12.1: Push the branch**
+
+```bash
+git push -u origin feat/strip-path-from-idx
+```
+
+- [ ] **Step 12.2: Open the PR**
+
+Use `gh pr create`. PR body should:
+- Reference issue #132 (`Closes #132`)
+- Summarize the four axes of the change
+- Note the migration step (mention the `strip_path_keys.run()` helper)
+- Link to this plan
+- Mention the prod numbers measured during diagnosis (~21 MB JSONB freed, ~140 MB index storage freed if the duplicate `idx_os_path` is also dropped — though that drop is *not* in this PR; it's existing schema)
+
+---
+
+## Self-Review
+
+Done after writing the plan above. Findings:
+
+1. **Spec coverage:** Issue #132 lists three phases (writer, queries/indexes, bonus check). Phase 1 → Tasks 3–6. Phase 2 → Tasks 2 + 7. Phase 3 → addressed in pre-flight audit (clean). Migration is added as Task 8 (issue says "background migration job is available" — Task 8 provides it). ✅
+
+2. **Placeholder scan:** No "TBD" / "implement later" / "similar to Task N". All code blocks contain real, runnable code. Checked. ✅
+
+3. **Type consistency:**
+   - `expr_path`, `expr_parent`, `expr_depth` — same names used in Task 2 dispatch and in helpers `_path_subtree`, `_path_exact`, etc. (existing in query.py). ✅
+   - `compute_path_info(path) -> (parent_path, path_depth)` — used identically in Tasks 5 (processor) and references real signature in catalog.py / indexing.py. ✅
+   - Migration `run(conn, batch_size=5000) -> dict` — signature matches both test calls and the changelog snippet. ✅
+   - Index names retained verbatim from the existing schema; no rename collisions. ✅
+
+4. **Open question from issue (`idx->>'path'` consumed elsewhere?):** The exploration agent confirmed only `query.py` reads these keys in production code. No REST/serialiser path. ZCatalog readers go through the typed-column-backed `path` brain attribute, not the JSONB. Documented in plan as resolved. ✅
+
+5. **Risk: planner regression on un-migrated rows.** During the brief window after deploy but before `strip_path_keys.run()` is invoked, queries will use the new typed-column indexes. Old rows still have the JSONB keys but the new query builder doesn't read them — so old rows behave identically to new rows from the query side. Migration only reclaims JSONB storage; it is not required for correctness. ✅
+
+---
+
+## Future Work (not in this plan)
+
+- **`id` / `getId` 100% duplication inside idx (~4.5 MB):** different code path (Plone-side index registration; both indexes register and both end up in idx via the catalog extraction loop). File a separate issue. Likely fix: filter one out at extraction time, or alias them via an SQL view.
+- **`overview_image` is the largest single JSONB key (16 MB total):** turns out to be a path-component array, not image data. Worth investigating what consumes it and whether it justifies the size.
+- **Drop `idx_os_path` (typed-column duplicate of `idx_os_cat_path`):** after this PR lands, both indexes have identical content. Delete the redundant one in a follow-up to free another ~27 MB.
+- **`idx_os_cat_events_upcoming` (0 scans ever):** unrelated cleanup, already noted in #131.

--- a/docs/superpowers/specs/2026-04-15-suggestions-engine-pr-alpha-design.md
+++ b/docs/superpowers/specs/2026-04-15-suggestions-engine-pr-alpha-design.md
@@ -1,0 +1,325 @@
+# Suggestions Engine — PR α: Bundle Data Model + Partial GIN + Hybrid Templates
+
+**Status:** Approved design
+**Date:** 2026-04-15
+**Issue:** [bluedynamics/plone-pgcatalog#122](https://github.com/bluedynamics/plone-pgcatalog/issues/122) (gap-analysis comment on 2026-04-15)
+**Follows:** PR 1 (extended statistics, v1.0.0b51), PR 2 (field categorization + sort covering, v1.0.0b53)
+**Precedes:** PR β (EXPLAIN-driven grading + JSON/JS UI) — see companion notes file `2026-04-15-suggestions-engine-pr-beta-notes.md`
+
+## Problem
+
+After PR 1 + PR 2 rolled to production (AAF, ~3.9M objects), a canonical slow-query pattern remains uncovered:
+
+```
+portal_type = 'Event' AND review_state = 'published'
+AND Subject = 'AT26'
+AND effective <= now AND expires >= now
+ORDER BY effective
+```
+
+Still 900–1600 ms. Three structural reasons:
+
+1. **KEYWORD fields don't get GIN templates.** PR 2 emits only btree composites. `Subject` is a JSONB-array KEYWORD and needs `GIN ((idx->'Subject'))`.
+2. **No partial-index templates.** The effective fix is a GIN *scoped by* `portal_type='Event' AND review_state='published'` — smaller, more specific, planner picks it preferentially. The engine has no way to express that WHERE clause.
+3. **Engine thinks one-index-per-query.** Real solutions are pairs: btree composite for range+sort axes, partial GIN for the tag filter. The output model is flat — no way to say "apply these two together".
+
+The existing `idx_os_cat_subject_gin` does exist, but the planner bypasses it in favor of `idx_os_allowed_roles` (a BitmapAnd input that scans billions of tuples). Extended statistics from PR 1 don't fix this specific plan shape.
+
+## Goal
+
+Make the suggestion engine express and emit **bundles of indexes** whose members are chosen by **rule-based shape classification** of the slow query, with **data-driven partial-predicate scoping** probing live DB selectivity. Closes the AT26-style gap for any customer, not just AAF — rule operates on `IndexType` shapes, not on field names.
+
+## Design decisions
+
+Seven clarifying questions were resolved during brainstorming.
+
+### Q3 — Approach: scenario catalog vs. data-driven inference
+
+**Hybrid (c).** Rules encode "shape → template family"; live DB stats inform "should this filter be baked into a partial WHERE?"
+
+Reason: Plone's query-shape vocabulary is finite (`FIELD/DATE/BOOL/KEYWORD/TEXT/UUID/PATH` + virtual `effectiveRange` + `path`), so a rule table is tractable. Pure data-driven inference of plan shape is a research project; pure catalog is AAF-specific and rejects the "generic" brief.
+
+### Q4 — Output model
+
+**Bundles (b).** `suggest_indexes()` returns `list[Bundle]` where each `Bundle` carries `name`, `rationale`, `shape_classification`, and `members: list[BundleMember]`. Single-member bundles back-compat with current UI by flattening; multi-member bundles express "these go together".
+
+Reason: hybrid patterns are genuinely sets. Applying half a pair is worse than applying neither (the planner may still pick the wrong index). Bundle is also the natural unit for PR β's EXPLAIN grading.
+
+### Q5 — EXPLAIN's role (PR β scope)
+
+**Two-stage (c):** rules propose bundles; EXPLAIN grades and annotates. PR α ships only the proposer; PR β adds the grader.
+
+### Q6 — Template vocabulary
+
+| Family | DDL | Trigger |
+|---|---|---|
+| T1 btree composite | `CREATE INDEX … ON object_state (<expr>, …)` | filter shape = `BTREE_ONLY` |
+| ~~T2 partial btree~~ | *cut* | *YAGNI — maintenance-cost savings don't justify complexity* |
+| T3 plain GIN | `CREATE INDEX … USING gin ((idx->'<k>'))` | single KEYWORD, no scoping opportunity |
+| T4 partial GIN | T3 + `WHERE idx->>'<k1>'='<v1>' AND …` | KEYWORD + low-selectivity equality co-filters |
+| T5 hybrid bundle | T1 + T3/T4 (multiple members in one bundle) | filter shape = `MIXED` |
+| T6 tsvector | existing dedicated path | filter shape = `TEXT_ONLY` — no new DDL |
+
+T2 cut. c/d extensibility deferred (we acknowledge the possibility but time will tell).
+
+### Q7 — EXPLAIN trigger strategy (PR β scope)
+
+**Eager plain + opt-in ANALYZE (c).** JS fetches plain `EXPLAIN (FORMAT JSON)` per slow-query row on tab load. Per-row "deep inspect" button triggers `EXPLAIN (ANALYZE, TIMING off, BUFFERS off)` with 10 s timeout. PR α doesn't implement this; PR β does.
+
+### Q8 — Partial-predicate scoping
+
+**Bake all qualifying equality filters (b).** Every scalar-equality filter whose live selectivity is below the threshold goes into the partial WHERE. Over-specificity is the goal, not a bug — the index is tailored to the observed slow-query shape.
+
+**Probe via MCV-first hybrid (iii).** `pg_stats.most_common_vals` gives the selectivity for common values with no DB round-trip. Miss → fall back to `SELECT COUNT(*) FROM object_state WHERE idx->>'k'='v'`. Cached per request-scoped connection.
+
+Threshold: 10 %. Module constant `_PARTIAL_PREDICATE_SELECTIVITY_THRESHOLD = 0.1`, overridable via `PGCATALOG_PARTIAL_SELECTIVITY_THRESHOLD` env var.
+
+### Q9 — PR decomposition
+
+**Two PRs.** PR α = engine upgrade (this spec). PR β = UI + EXPLAIN grading. PR α is independently releasable and closes the AT26 gap on its own; PR β adds the live-DB insight layer.
+
+## Section 1 — Architecture & Scope
+
+**In scope for PR α:**
+
+- `Bundle` + `BundleMember` dataclasses (frozen).
+- `suggest_indexes()` signature change: return type `list[Suggestion]` → `list[Bundle]`. Fifth positional arg `conn` added (`None`-safe for unit tests).
+- New templates T3, T4, T5 as defined above. T1 unchanged in DDL, re-wrapped in a Bundle. T6 stays as-is (existing tsvector path).
+- `_classify_filter_shape(filter_fields)` → enum.
+- `_dispatch_templates(shape, filter_fields, sort_field, probes, existing_indexes)` — pure function.
+- `_probe_selectivity(conn, key, value)` — MCV-first hybrid, request-scoped cache.
+- `_partial_where_terms(equality_filters, probes)` — threshold enforcement, quote escaping.
+- Backward-compatibility flatten in `manage_get_slow_query_stats` so the existing DTML renders without change.
+
+**Not in scope:**
+
+- EXPLAIN grading, JSON endpoint, async JS, HypoPG — all go to PR β.
+- Changes to `pgcatalog_slow_queries` schema — PR 2's `representative_params` via LATERAL already provides the input.
+- New IndexType support beyond IndexRegistry's existing set.
+- ZCA plugin points for customer-specific templates (architected — the dispatcher takes an internal emitter list — but not exposed publicly; that's a one-liner addition when a real use case appears).
+- Automatic cleanup of unused `idx_os_sug_*` indexes.
+
+**Multi-pod safety:** Pure Python change. No DDL, no schema migration. Signature of `suggest_indexes()` changes but has a single call site in `catalog.py`. Safe to ship mid-fleet.
+
+**Compat note:** the fifth `conn` argument is `None`-defaulted in tests. When `conn is None` the probe returns `1.0` for every `(key, value)`, which means no partial scoping ever qualifies, which means T4 degrades to T3 and T1 stays as-is — identical to pre-α behavior for any caller that doesn't pass `conn`.
+
+## Section 2 — Bundle data model & template dispatch
+
+### Dataclasses
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BundleMember:
+    """One index in a bundle."""
+    ddl: str
+    fields: list[str]
+    field_types: list[str]   # IndexType.name strings
+    status: str              # "new" | "already_covered"
+    role: str                # "btree_composite" | "plain_gin" | "partial_gin"
+    reason: str
+
+
+@dataclass(frozen=True)
+class Bundle:
+    """One or more indexes that together address a slow-query shape."""
+    name: str                            # deterministic: shape + sorted filter names
+    rationale: str                       # human-readable
+    shape_classification: str            # BTREE_ONLY | KEYWORD_ONLY | MIXED | TEXT_ONLY | UNKNOWN
+    members: list[BundleMember]          # 1..N indexes
+```
+
+### Backward-compat render in `manage_get_slow_query_stats`
+
+Two keys per row (instead of today's single `suggestions`):
+
+- `suggestions` — flat list `[m for b in bundles for m in b.members]` rendered by existing DTML. No UI change in PR α.
+- `suggestions_bundles` — the full `[asdict(b) for b in bundles]` structure, present for PR β's JS to consume.
+
+### Dispatcher
+
+```python
+def _dispatch_templates(filter_fields, sort_field, registry, probes, existing_indexes):
+    shape = _classify_filter_shape(filter_fields)
+    if shape == "BTREE_ONLY":
+        return [_bundle_btree_composite(filter_fields, sort_field, probes, existing_indexes)]
+    if shape == "KEYWORD_ONLY":
+        return [_bundle_keyword_gin(filter_fields, probes, existing_indexes)]
+    if shape == "MIXED":
+        return [_bundle_hybrid(filter_fields, sort_field, probes, existing_indexes)]
+    if shape == "TEXT_ONLY":
+        return []   # dedicated tsvector handles this; nothing for PR α to add
+    return []       # UNKNOWN — silent skip; PR β may still grade via EXPLAIN
+```
+
+### Shape classification rules
+
+- All filter IndexTypes ∈ `{FIELD, DATE, BOOL, UUID, PATH}` → `BTREE_ONLY`
+- All filter IndexTypes == `KEYWORD` → `KEYWORD_ONLY`
+- Mix of btree-eligible and KEYWORD → `MIXED`
+- Any `TEXT` in the filter set → `TEXT_ONLY` (dominates)
+- Any IndexType the registry doesn't classify → `UNKNOWN`
+
+### Probe resolution order
+
+1. Walk all slow-query groups in the current `manage_get_slow_query_stats` call.
+2. Enumerate unique `(key, value)` pairs across all candidate equality filters.
+3. Resolve each once via `_probe_selectivity(conn, key, value)`; cache in a dict threaded through dispatcher calls.
+4. Bounds DB round-trips to O(unique equality pairs) per ZMI page load, not O(slow queries × filters).
+
+## Section 3 — Classification inputs & partial-scoping algorithm
+
+### Input extraction (per slow-query group)
+
+1. `query_keys` — already normalized by PR 2 (`_FILTER_VIRTUAL` expands `effectiveRange` → `('effective', DATE)`).
+2. `representative_params` — per-group params from PR 2's LATERAL. For each key, infer operator:
+   - scalar string → `equality`, value candidate for partial WHERE
+   - list of scalars with length > 1 → `equality_multi`, *excluded* from partial WHERE (value ambiguous)
+   - dict with `range` key → `range`, excluded from partial WHERE
+3. Registry lookup: key → `(IndexType, idx_key, source_attrs)`.
+4. Sort field: `_extract_sort_field()` from PR 2, unchanged.
+5. Partial-scoping candidates: filter entries whose operator is `equality` AND IndexType ∈ `{FIELD, BOOL, PATH, UUID}` (not DATE — DATE values are timestamps, rarely appear in MCV lists, and partial-DATE scoping is usually a range-query anti-pattern).
+
+### Probe algorithm
+
+```python
+_request_cache: dict[tuple[str, str], float] = {}   # threaded, not module-global
+_pg_stats_cache: dict[str, Optional[dict]] = {}      # per-attname stats row
+
+
+def _probe_selectivity(conn, key, value):
+    cache_key = (key, value)
+    if cache_key in _request_cache:
+        return _request_cache[cache_key]
+
+    # Step 1: MCV lookup (one fetch per distinct attname per request)
+    attname = _derived_attname_for_key(key)
+    stats = _pg_stats_cache.setdefault(attname, _fetch_pg_stats(conn, attname))
+    if stats and stats["most_common_vals"] is not None and value in stats["most_common_vals"]:
+        idx = stats["most_common_vals"].index(value)
+        sel = stats["most_common_freqs"][idx]
+        _request_cache[cache_key] = sel
+        return sel
+
+    # Step 2: fallback live COUNT
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) AS c FROM object_state "
+            "WHERE idx IS NOT NULL AND idx->>%s = %s",
+            (key, value),
+        )
+        count = cur.fetchone()["c"]
+        cur.execute(
+            "SELECT reltuples::bigint AS t FROM pg_class WHERE relname = 'object_state'"
+        )
+        total = max(cur.fetchone()["t"], 1)
+    sel = count / total
+    _request_cache[cache_key] = sel
+    return sel
+```
+
+### Open implementation question (documented, not blocking design)
+
+`_derived_attname_for_key(key)` depends on whether expression-index statistics are reachable via `pg_stats`. Three paths to explore in implementation:
+
+1. If we've named expression-index columns (e.g. `idx_os_cat_portal_type` on `(idx->>'portal_type')`), PG keeps stats under the expression index's implicit attname `idx_expr_*`.
+2. If `CREATE STATISTICS` from PR 1 produced queryable per-pair stats, we can read those.
+3. If neither works, MCV path is a no-op and we always fall through to COUNT.
+
+COUNT is cheap on a well-indexed column (~ms on 3M rows via the existing btree), so MCV is a "nice fast path" — not a correctness requirement. Spec-level fallback is "ship COUNT-only if MCV turns out infeasible, revisit in β".
+
+### Partial predicate construction
+
+```python
+_PARTIAL_PREDICATE_SELECTIVITY_THRESHOLD = 0.1  # 10 %
+
+
+def _partial_where_terms(equality_filters, probes):
+    terms = []
+    for (name, value) in equality_filters:
+        sel = probes.get((name, value), 1.0)   # missing probe = 1.0 = never qualifies
+        if sel < _PARTIAL_PREDICATE_SELECTIVITY_THRESHOLD:
+            # Quote escape: single-quote in value → doubled
+            safe_value = value.replace("'", "''")
+            terms.append(f"idx->>'{name}' = '{safe_value}'")
+    return terms
+```
+
+### Hybrid bundle construction (T5, shape = MIXED)
+
+- Partition filter_fields into `btree_candidates` (btree-eligible types) and `keyword_candidates` (KEYWORD).
+- Build one btree composite member (T1, with PR 2 sort covering logic), using `btree_candidates` + `sort_field`. Do NOT bake any WHERE — the btree composite gains nothing from partial scoping for the cases we see.
+- Build one T3/T4 member per KEYWORD filter:
+  - Compute `partial_where_terms` from *all* qualifying equality filters (both btree-eligible and KEYWORD equalities qualify, though KEYWORD equalities are rare as scalar values).
+  - Empty terms → T3 plain GIN; non-empty → T4 partial GIN with `WHERE idx IS NOT NULL AND <terms AND-joined>`.
+- Bundle rationale: machine-built string describing the shape and naming the members.
+
+### Existing-index detection
+
+`_check_covered()` from PR 2 stays unchanged for T1 members. For T3 / T4:
+
+- Add `_normalize_gin_expr()` — canonicalizes `((idx->'<k>'))` and `(idx -> '<k>')` to a single form, handles `::text` stripping similar to `_normalize_idx_expr()`.
+- Partial GINs with `WHERE`: the normalized form must also capture the WHERE clause for equality comparison. A second partial GIN with stricter WHERE is not equivalent, so we treat broader WHERE as "covers"; stricter WHERE as "new" (different index). Implemented as WHERE-clause normalization + set-subset check on equality predicates.
+
+Each member's `status` is set per-member. Bundle-level status is not computed in PR α — the UI layer decides how to present per-member statuses (PR β will define "bundle grades").
+
+## Section 4 — Testing, data flow, PR β carryover
+
+### Test strategy
+
+All pure unit tests. Fake `IndexRegistry` from PR 2 reused. Probes injected as deterministic dicts — no live DB.
+
+- **`TestShapeClassifier`** — 6 tests covering each shape enum outcome (including empty + UNKNOWN).
+- **`TestPartialWhereTerms`** — threshold enforcement (just-above / just-below / well-above / well-below), multi-filter AND order, single-quote escaping, list-value exclusion, range-value exclusion.
+- **`TestBundleDispatch`**:
+  - BTREE_ONLY input → 1 bundle, 1 T1 member (existing behavior, new wrapper).
+  - KEYWORD_ONLY input with no low-selectivity co-filter → 1 bundle, 1 T3 member.
+  - KEYWORD_ONLY + low-selectivity equality on another KEYWORD → T4 (rare but valid).
+  - MIXED input → 1 bundle, N+1 members (1 btree composite + N GIN members).
+  - TEXT_ONLY → empty bundle list.
+  - UNKNOWN IndexType → empty bundle list.
+- **`TestProbeSelectivity`** — mock psycopg cursor; verify MCV hit returns frequency, MCV miss falls through to COUNT, request-scoped dict caches both paths, pg_stats fetch happens at most once per attname per request.
+- **`TestIssue122AT26Regression`** — the canonical slow query (portal_type, review_state, Subject, effective, expires, sort_on=effective):
+  - probes `{('portal_type', 'Event'): 0.05, ('review_state', 'published'): 0.25}` → MIXED bundle with btree `(portal_type, review_state, effective)` + partial GIN on Subject scoped `WHERE portal_type='Event'` only.
+  - probes `{('portal_type', 'Event'): 0.05, ('review_state', 'published'): 0.03}` → same bundle but GIN scoped `WHERE portal_type='Event' AND review_state='published'`.
+- **Existing PR 2 tests** — update assertions to reach through `bundles[*].members[*]` for `fields`/`ddl`/`status`/`reason`. Helpers `_first_suggestion(result)` / `_all_suggestions(result)` centralize the unwrap so individual tests stay readable.
+
+### Data flow
+
+```
+manage_get_slow_query_stats (catalog.py)
+  → per row: query_keys, representative_params
+  → suggest_indexes(query_keys, params, registry, existing_indexes, conn)
+       ↓
+       _extract_filter_fields(query_keys, params, registry)
+       ↓
+       _resolve_probes(conn, filter_fields)           # MCV+COUNT, request-cached
+       ↓
+       _dispatch_templates(shape, filter_fields, sort_field, probes, existing_indexes)
+       ↓ returns list[Bundle]
+  row["suggestions"]         = [m for b in bundles for m in b.members]   # legacy DTML
+  row["suggestions_bundles"] = [asdict(b) for b in bundles]               # PR β JSON
+```
+
+### Out of scope (→ PR β)
+
+- JSON endpoint + async JS fetches.
+- EXPLAIN plan parsing + bundle grading.
+- HypoPG integration.
+- DTML → JSON+JS UI refactor.
+- Opt-in ANALYZE button.
+
+### Estimated size
+
+- `src/plone/pgcatalog/suggestions.py`: +~400 lines (dataclasses, classifier, dispatcher, probe, partial-where, hybrid builder, GIN normalizer); existing `_add_btree_suggestions` reorganized into the bundle-aware form.
+- `src/plone/pgcatalog/catalog.py`: ~30 line change (threaded `conn` into `suggest_indexes` call, expose both flat + bundle outputs).
+- `tests/test_suggestions.py`: +~300 lines (5 new test classes + helpers).
+- No schema / DDL / migration. No multi-pod coordination beyond the PR 2 baseline.
+
+---
+
+## PR β carryover
+
+All PR β decisions and open questions live in `2026-04-15-suggestions-engine-pr-beta-notes.md`, committed alongside this spec. That file is the starting point for PR β's brainstorm — it captures everything we decided during this brainstorm but deferred out of PR α's scope, plus the open questions we know need answering then.

--- a/docs/superpowers/specs/2026-04-15-suggestions-engine-pr-beta-notes.md
+++ b/docs/superpowers/specs/2026-04-15-suggestions-engine-pr-beta-notes.md
@@ -1,0 +1,99 @@
+# PR β (Suggestions Engine) — Pre-brainstorm Notes
+
+> **This is NOT a design spec.** It captures decisions and open questions agreed during the PR α brainstorm (2026-04-15) that belong to PR β but were deferred. Use this as the starting material for the PR β brainstorm; don't re-derive these answers.
+
+**Parent spec:** `2026-04-15-suggestions-engine-pr-alpha-design.md`
+**Issue:** [bluedynamics/plone-pgcatalog#122](https://github.com/bluedynamics/plone-pgcatalog/issues/122)
+
+## Scope of PR β
+
+Build on PR α's Bundle data model to add:
+
+1. **EXPLAIN-driven grading** — live-DB insight per slow-query row and per bundle.
+2. **JSON endpoint** — server renders grades + plans as JSON; UI fetches async.
+3. **ZMI UI refactor** — DTML → JSON + vanilla JS for the Slow Queries tab (no heavy framework, per project rule).
+4. **Opt-in ANALYZE** — user-triggered deep inspection per row.
+
+## Decisions already locked
+
+### Q5 (EXPLAIN's role) — two-stage: rules propose, EXPLAIN grades + annotates
+
+Bundle candidates come from PR α's rule-based dispatcher. For each slow-query group, PR β runs `EXPLAIN (FORMAT JSON)` on the representative row and:
+
+- Extracts the chosen plan (indexes used, top cost nodes, estimated rows, filter predicates).
+- Grades each candidate bundle against the baseline plan.
+- Attaches a diagnostic panel: the top filter-cost node (node type, estimated Rows Removed by Filter when inferable from plan shape), so users see **why** the query is slow even if no bundle changes it.
+
+### Q7 (EXPLAIN trigger) — eager plain + opt-in ANALYZE
+
+- **Default on tab load:** JS fetches plain `EXPLAIN (FORMAT JSON)` per visible slow-query row. Cheap (~10 ms per plan). Grades computed on the server, returned with the plan.
+- **On click:** per-row "deep inspect" button triggers `EXPLAIN (ANALYZE, TIMING off, BUFFERS off)` with `SET LOCAL statement_timeout = '10s'`. UI shows a spinner. On completion, Rows Removed by Filter and actual row counts replace the estimates. Timeout → user sees "query too slow to analyze; here are the estimates we have".
+
+### Grading semantics
+
+Three states per bundle (plus the row-level row-is-in-slow-queries fact):
+
+| Grade | Meaning | Signal |
+|---|---|---|
+| `already_fast` | Query wouldn't be in `pgcatalog_slow_queries`. Not shown — the row wouldn't be listed. | N/A |
+| `covered_but_slow` | Current plan uses indexes that match the bundle's target predicates, but the query is still observed slow (it's in the slow-queries table definitionally). | Planner's chosen indexes cover the filter set; Rows Removed by Filter low / low-ish; something else bites (stats drift, bloat, correlation, or the GIN is too big → partial GIN bundle would help). |
+| `uncovered` | Current plan has a Seq Scan on `object_state`, OR chosen indexes don't cover the bundle's target predicates. Bundle would plausibly help. | Seq Scan node present, OR index-set difference between chosen and target non-empty. |
+
+Grade applies per-bundle, not per-row. A single slow query may yield multiple bundles each with its own grade.
+
+### Async JS fetch model
+
+- Page initial load: fast (bundles only, no per-row plans).
+- On DOMContentLoaded: JS iterates visible slow-query rows, issues `fetch()` to the per-row plan endpoint. Fills in grades and diagnostic panels as responses arrive.
+- Per-row "deep inspect" button triggers a second fetch with `?analyze=true`. Separate endpoint or query-param on the same endpoint — design open.
+
+### HypoPG as optional enhancement, graceful degradation
+
+- At startup, check `SELECT 1 FROM pg_extension WHERE extname = 'hypopg'`.
+- If present, bundle grading gains a "what-if plan" mode: `SELECT hypopg_create_index('<ddl without CONCURRENTLY>')`, run `EXPLAIN` again, compare. Gives confidence that applying the bundle would actually change the plan. Wrap in a read-only transaction that gets rolled back so hypothetical index disappears.
+- If absent, grade only from the baseline plan + index-set comparison heuristic.
+
+### UI refactor scope
+
+- Replace `manage_slow_queries.dtml` with a small JSON+JS page (or keep DTML as HTML shell + JS doing the rendering — **decide in PR β brainstorm**).
+- No heavy framework. Vanilla JS, optional lightweight helpers (alpine.js is acceptable per user's earlier "leichtes ok"; React/Vue are not).
+- Per-row expansion → shows plan tree, bundles with grade badges, "deep inspect" button.
+
+### PR α → PR β contract
+
+PR β's UI consumes what PR α's `manage_get_slow_query_stats` puts under `row["suggestions_bundles"]`:
+
+- `bundles[*].name` — stable identifier for UI keyed updates.
+- `bundles[*].rationale` — rendered as bundle description.
+- `bundles[*].shape_classification` — shown as a small badge.
+- `bundles[*].members[*]` — rendered as DDL code blocks with Apply / Drop buttons.
+
+## Open questions deferred to PR β brainstorm
+
+1. **JSON endpoint URL shape.** Per-row endpoint keyed by `query_keys` hash? Single batch endpoint? Separate endpoints for baseline plan vs. ANALYZE? Affects caching.
+2. **Plan caching.** Key by `(query_keys, representative_params_hash)`? TTL? Invalidate on index apply/drop? How do we handle plans that are valid for 5 seconds but not 5 hours (stats drift)?
+3. **Deep-inspect authorization + UX.** ANALYZE actually runs the slow query. Should the UI show a confirmation dialog ("this may take up to 10 s — proceed?") or silently trigger with a spinner? Who is allowed to trigger — `Manage portal` only, or any ZMI user?
+4. **Handling missing `query_text`.** PR 2's slow-query log stores the SQL. If an old row has null `query_text` (logged under a pre-PR-2 schema?), we can't EXPLAIN it. Skip? Reconstruct from `query_keys + params`? How do we reconstruct safely?
+5. **`_derived_attname_for_key` resolution for MCV stats** — carried over from PR α. If PR α ships COUNT-only, PR β may want to improve it once we know which pg_stats path is reachable for expression indexes.
+6. **Bundle-level grade aggregation.** A bundle has N members, each with their own `status` (new / already_covered). Bundle grade aggregates: what's the rule when some members are new and some already covered? Needed for the UI badge.
+7. **Rate limiting.** 50 slow queries × 1 EXPLAIN each on every tab load. At 10 ms each that's 500 ms total. Acceptable. If EXPLAIN is ever slow (stats issues), do we need a global timeout / circuit breaker?
+8. **Drop-bundle flow.** If a bundle's members were applied together, should there be a "drop bundle" action (drops all members in sequence)? Or only per-member?
+9. **HypoPG production readiness.** Is `hypopg` available in typical Plone PG deployments? Is asking customers to install an extension acceptable? (Extended statistics from PR 1 didn't need an extension; this would be new.)
+10. **Auto-apply opt-in.** Far future — a "trust the engine" mode where highly-confident uncovered-grade bundles get applied automatically during low-traffic windows? Definitely not PR β, but worth capturing the ergonomic target.
+
+## Non-goals for PR β
+
+- New templates beyond PR α's T1/T3/T4/T5/T6.
+- Changing the shape classifier or the partial-scoping threshold.
+- Cross-pod coordination for EXPLAIN caching (each pod EXPLAINs independently; that's fine).
+- Writing to `pgcatalog_slow_queries` from PR β (read-only).
+
+## Recommended next actions when PR β becomes the active work
+
+1. Re-invoke `superpowers:brainstorming` with this notes file as context.
+2. Answer the open questions above in the same Q-by-Q flow as PR α.
+3. Produce a proper design spec (`YYYY-MM-DD-suggestions-engine-pr-beta-design.md`).
+4. Feed spec into `superpowers:writing-plans`.
+5. Execute via `superpowers:subagent-driven-development`.
+
+All PR α infrastructure (Bundle dataclass, `suggestions_bundles` catalog.py output key, test helpers) is ready for PR β to consume — no re-plumbing needed.

--- a/src/plone/pgcatalog/catalog.py
+++ b/src/plone/pgcatalog/catalog.py
@@ -28,7 +28,6 @@ from OFS.Folder import Folder
 from plone.pgcatalog.backends import BM25Backend
 from plone.pgcatalog.backends import get_backend
 from plone.pgcatalog.brain import CatalogSearchResults
-from plone.pgcatalog.columns import compute_path_info
 from plone.pgcatalog.columns import get_registry
 from plone.pgcatalog.extraction import extract_from_translators
 from plone.pgcatalog.extraction import extract_idx
@@ -496,12 +495,11 @@ class PlonePGCatalogTool(UniqueObject, Folder):
         wrapper = self._wrap_object(obj)
         idx = self._extract_idx(wrapper)
         searchable_text = self._extract_searchable_text(wrapper)
-        parent_path, path_depth = compute_path_info(uid)
 
-        # Store built-in path data in idx JSONB for unified path queries
-        idx["path"] = uid
-        idx["path_parent"] = parent_path
-        idx["path_depth"] = path_depth
+        # Path data lives in typed columns only.  The typed `path` column
+        # is set below via pending_data["path"]; parent_path and path_depth
+        # are derived from it by CatalogStateProcessor.
+        # See: docs/plans/2026-04-15-strip-path-from-idx-jsonb.md (#132)
 
         pending_data = {
             "path": uid,

--- a/src/plone/pgcatalog/indexing.py
+++ b/src/plone/pgcatalog/indexing.py
@@ -40,10 +40,8 @@ def catalog_object(conn, zoid, path, idx, searchable_text=None, language="simple
     """
     parent_path, path_depth = compute_path_info(path)
 
-    # Store path data in idx JSONB for unified path queries
-    idx.setdefault("path", path)
-    idx.setdefault("path_parent", parent_path)
-    idx.setdefault("path_depth", path_depth)
+    # Path data lives in typed columns only (path, parent_path, path_depth).
+    # See: docs/plans/2026-04-15-strip-path-from-idx-jsonb.md (#132)
 
     # Extract registered extra idx columns (pops from idx → dedicated columns)
     extra = extract_extra_idx_columns(idx)

--- a/src/plone/pgcatalog/migrations/__init__.py
+++ b/src/plone/pgcatalog/migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Migration helpers for evolving plone-pgcatalog schema/data in place."""

--- a/src/plone/pgcatalog/migrations/strip_path_keys.py
+++ b/src/plone/pgcatalog/migrations/strip_path_keys.py
@@ -1,0 +1,91 @@
+"""One-shot migration: remove path/path_parent/path_depth from idx JSONB.
+
+After issue #132, these three keys live exclusively in typed columns
+(path, parent_path, path_depth).  This script removes them from existing
+rows that were written before the cleanup.
+
+Idempotent and batched.  Safe to re-run; safe to interrupt.
+
+Usage (from a shell with a configured psycopg connection):
+
+    from plone.pgcatalog.migrations.strip_path_keys import run
+    result = run(conn, batch_size=5000)
+    print(result)  # {"batches": N, "rows_updated": M}
+"""
+
+import logging
+
+
+log = logging.getLogger(__name__)
+
+# Rows that still have any of the three keys present in idx
+_DIRTY_PREDICATE = "idx ?| ARRAY['path', 'path_parent', 'path_depth']"
+
+_BATCH_SQL = f"""
+    WITH batch AS (
+        SELECT zoid
+        FROM object_state
+        WHERE zoid > %(after_zoid)s
+          AND idx IS NOT NULL
+          AND {_DIRTY_PREDICATE}
+        ORDER BY zoid
+        LIMIT %(batch_size)s
+    )
+    UPDATE object_state os
+       SET idx = idx - 'path' - 'path_parent' - 'path_depth'
+      FROM batch
+     WHERE os.zoid = batch.zoid
+    RETURNING os.zoid
+"""
+
+
+def run(conn, batch_size: int = 5000) -> dict:
+    """Strip path keys from idx in batches.
+
+    Args:
+        conn: psycopg connection.  Each batch commits independently --
+              the caller's transaction state (if any) is committed first
+              before switching to autocommit.
+        batch_size: rows per batch.  Default 5000 keeps each UPDATE under
+                    ~10 MB WAL and ~1 s on a typical pod.
+
+    Returns: {"batches": int, "rows_updated": int}
+    """
+    if not conn.autocommit:
+        conn.commit()
+        conn.autocommit = True
+
+    after_zoid = -1
+    batches = 0
+    total = 0
+
+    while True:
+        with conn.cursor() as cur:
+            cur.execute(
+                _BATCH_SQL,
+                {
+                    "after_zoid": after_zoid,
+                    "batch_size": batch_size,
+                },
+            )
+            zoids = [
+                row[0] if isinstance(row, tuple) else row["zoid"]
+                for row in cur.fetchall()
+            ]
+
+        if not zoids:
+            break
+
+        batches += 1
+        total += len(zoids)
+        after_zoid = max(zoids)
+        log.info(
+            "strip_path_keys: batch %d, %d rows, last zoid=%d, total=%d",
+            batches,
+            len(zoids),
+            after_zoid,
+            total,
+        )
+
+    log.info("strip_path_keys: done. %d batches, %d rows updated.", batches, total)
+    return {"batches": batches, "rows_updated": total}

--- a/src/plone/pgcatalog/migrations/strip_path_keys.py
+++ b/src/plone/pgcatalog/migrations/strip_path_keys.py
@@ -42,50 +42,61 @@ _BATCH_SQL = f"""
 def run(conn, batch_size: int = 5000) -> dict:
     """Strip path keys from idx in batches.
 
+    The connection is switched to autocommit for the duration of the
+    migration so each batch commits independently; the prior autocommit
+    state is restored on return (even if an exception escapes).  If the
+    caller had an open transaction, ``conn.commit()`` is called first to
+    flush pending work before flipping autocommit on.
+
     Args:
         conn: psycopg connection.  Each batch commits independently --
               the caller's transaction state (if any) is committed first
-              before switching to autocommit.
+              before switching to autocommit, and the original autocommit
+              flag is restored on exit.
         batch_size: rows per batch.  Default 5000 keeps each UPDATE under
                     ~10 MB WAL and ~1 s on a typical pod.
 
     Returns: {"batches": int, "rows_updated": int}
     """
-    if not conn.autocommit:
-        conn.commit()
+    original_autocommit = conn.autocommit
+    if not original_autocommit:
+        conn.commit()  # flush any pending work; migration needs per-batch commits
         conn.autocommit = True
 
     after_zoid = -1
     batches = 0
     total = 0
 
-    while True:
-        with conn.cursor() as cur:
-            cur.execute(
-                _BATCH_SQL,
-                {
-                    "after_zoid": after_zoid,
-                    "batch_size": batch_size,
-                },
+    try:
+        while True:
+            with conn.cursor() as cur:
+                cur.execute(
+                    _BATCH_SQL,
+                    {
+                        "after_zoid": after_zoid,
+                        "batch_size": batch_size,
+                    },
+                )
+                zoids = [
+                    row[0] if isinstance(row, tuple) else row["zoid"]
+                    for row in cur.fetchall()
+                ]
+
+            if not zoids:
+                break
+
+            batches += 1
+            total += len(zoids)
+            after_zoid = max(zoids)
+            log.info(
+                "strip_path_keys: batch %d, %d rows, last zoid=%d, total=%d",
+                batches,
+                len(zoids),
+                after_zoid,
+                total,
             )
-            zoids = [
-                row[0] if isinstance(row, tuple) else row["zoid"]
-                for row in cur.fetchall()
-            ]
 
-        if not zoids:
-            break
-
-        batches += 1
-        total += len(zoids)
-        after_zoid = max(zoids)
-        log.info(
-            "strip_path_keys: batch %d, %d rows, last zoid=%d, total=%d",
-            batches,
-            len(zoids),
-            after_zoid,
-            total,
-        )
-
-    log.info("strip_path_keys: done. %d batches, %d rows updated.", batches, total)
-    return {"batches": batches, "rows_updated": total}
+        log.info("strip_path_keys: done. %d batches, %d rows updated.", batches, total)
+        return {"batches": batches, "rows_updated": total}
+    finally:
+        conn.autocommit = original_autocommit

--- a/src/plone/pgcatalog/processor.py
+++ b/src/plone/pgcatalog/processor.py
@@ -285,7 +285,9 @@ class CatalogStateProcessor:
                     {"zoid": zoid, "patch": Json(idx_updates), **extra_params},
                 )
 
-        # Execute bulk path moves (one SQL per moved subtree)
+        # Execute bulk path moves (one SQL per moved subtree).
+        # Touches typed columns only — idx no longer carries path keys.
+        # See: docs/plans/2026-04-15-strip-path-from-idx-jsonb.md (#132)
         moves = pop_all_pending_moves()
         for old_prefix, new_prefix, depth_delta in moves:
             cursor.execute(
@@ -293,17 +295,8 @@ class CatalogStateProcessor:
                 UPDATE object_state SET
                     path = %(new)s || substring(path FROM length(%(old)s) + 1),
                     parent_path = %(new)s || substring(parent_path FROM length(%(old)s) + 1),
-                    path_depth = path_depth + %(dd)s,
-                    idx = idx || jsonb_build_object(
-                        'path',
-                        %(new)s || substring(idx->>'path' FROM length(%(old)s) + 1),
-                        'path_parent',
-                        %(new)s || substring(idx->>'path_parent' FROM length(%(old)s) + 1),
-                        'path_depth',
-                        (idx->>'path_depth')::int + %(dd)s
-                    )
+                    path_depth = path_depth + %(dd)s
                 WHERE path LIKE %(like)s
-                  AND idx IS NOT NULL
                 """,
                 {
                     "old": old_prefix,

--- a/src/plone/pgcatalog/processor.py
+++ b/src/plone/pgcatalog/processor.py
@@ -6,6 +6,7 @@ state during tpc_vote.
 """
 
 from plone.pgcatalog.backends import get_backend
+from plone.pgcatalog.columns import compute_path_info
 from plone.pgcatalog.columns import extract_extra_idx_columns
 from plone.pgcatalog.columns import get_extra_idx_columns
 from plone.pgcatalog.pending import _MISSING
@@ -228,10 +229,19 @@ class CatalogStateProcessor:
         idx = pending.get("idx")
         extra_values = extract_extra_idx_columns(idx)
 
+        # Path data lives in typed columns only.  parent_path and path_depth
+        # are derived from the canonical `path` field — not from idx.
+        # See: docs/plans/2026-04-15-strip-path-from-idx-jsonb.md (#132)
+        path = pending.get("path")
+        if path:
+            parent_path, path_depth = compute_path_info(path)
+        else:
+            parent_path, path_depth = None, None
+
         result = {
-            "path": pending.get("path"),
-            "parent_path": idx.get("path_parent") if idx else None,
-            "path_depth": idx.get("path_depth") if idx else None,
+            "path": path,
+            "parent_path": parent_path,
+            "path_depth": path_depth,
             "idx": Json(idx) if idx else None,
             "searchable_text": pending.get("searchable_text"),
             **extra_values,

--- a/src/plone/pgcatalog/query.py
+++ b/src/plone/pgcatalog/query.py
@@ -514,12 +514,19 @@ class _QueryBuilder:
 
         paths = [_validate_path(p) for p in paths]  # validates AND normalizes
 
-        # All path indexes (built-in "path" and additional like "tgpath")
-        # store their data in idx JSONB and query via expression indexes.
-        key = name if idx_key is None else idx_key
-        expr_path = f"idx->>'{key}'"
-        expr_parent = f"idx->>'{key}_parent'"
-        expr_depth = f"(idx->>'{key}_depth')::integer"
+        # Dispatch: the built-in "path" index lives in typed columns
+        # (path, parent_path, path_depth).  Custom path indexes
+        # (e.g. "tgpath") still store their data in idx JSONB.
+        # See: docs/plans/2026-04-15-strip-path-from-idx-jsonb.md (#132)
+        if idx_key is None and name == "path":
+            expr_path = "path"
+            expr_parent = "parent_path"
+            expr_depth = "path_depth"
+        else:
+            key = name if idx_key is None else idx_key
+            expr_path = f"idx->>'{key}'"
+            expr_parent = f"idx->>'{key}_parent'"
+            expr_depth = f"(idx->>'{key}_depth')::integer"
 
         if navtree:
             self._path_navtree(expr_path, expr_parent, paths[0], depth, navtree_start)

--- a/src/plone/pgcatalog/query.py
+++ b/src/plone/pgcatalog/query.py
@@ -659,6 +659,11 @@ class _QueryBuilder:
                 continue
 
             idx_type, idx_key, _source_attrs = entry
+            # Built-in "path" sort lives in the typed `path` column (#132).
+            # Custom PATH indexes (e.g. "tgpath") still store data in idx JSONB.
+            if idx_type == IndexType.PATH and idx_key is None and sort_on == "path":
+                parts.append(f"path {direction}")
+                continue
             if idx_key is None:
                 if idx_type == IndexType.PATH:
                     idx_key = sort_on

--- a/src/plone/pgcatalog/schema.py
+++ b/src/plone/pgcatalog/schema.py
@@ -7,8 +7,8 @@ only extends it.
 
 CATALOG_COLUMNS = """\
 -- Catalog columns on object_state (plone.pgcatalog extension)
--- path: dedicated column for brain construction (SELECT zoid, path)
--- parent_path/path_depth: legacy columns, path queries use idx JSONB
+-- path / parent_path / path_depth: typed columns are the source of truth
+-- for path-related queries and indexes (idx JSONB no longer carries them).
 ALTER TABLE object_state ADD COLUMN IF NOT EXISTS path TEXT;
 ALTER TABLE object_state ADD COLUMN IF NOT EXISTS parent_path TEXT;
 ALTER TABLE object_state ADD COLUMN IF NOT EXISTS path_depth INTEGER;
@@ -102,15 +102,21 @@ CREATE INDEX IF NOT EXISTS idx_os_path
 CREATE INDEX IF NOT EXISTS idx_os_catalog
     ON object_state USING gin (idx) WHERE idx IS NOT NULL;
 
--- Path expression indexes on idx JSONB (unified path query support)
+-- Path indexes on typed columns (path / parent_path / path_depth).
+-- DROP + CREATE so existing installs self-heal when the idx-JSONB form
+-- from older versions is still present under the same name.
+DROP INDEX IF EXISTS idx_os_cat_path;
 CREATE INDEX IF NOT EXISTS idx_os_cat_path
-    ON object_state ((idx->>'path')) WHERE idx IS NOT NULL;
+    ON object_state (path) WHERE path IS NOT NULL;
+DROP INDEX IF EXISTS idx_os_cat_path_pattern;
 CREATE INDEX IF NOT EXISTS idx_os_cat_path_pattern
-    ON object_state USING btree ((idx->>'path') text_pattern_ops) WHERE idx IS NOT NULL;
+    ON object_state USING btree (path text_pattern_ops) WHERE path IS NOT NULL;
+DROP INDEX IF EXISTS idx_os_cat_path_parent;
 CREATE INDEX IF NOT EXISTS idx_os_cat_path_parent
-    ON object_state ((idx->>'path_parent')) WHERE idx IS NOT NULL;
+    ON object_state (parent_path) WHERE parent_path IS NOT NULL;
+DROP INDEX IF EXISTS idx_os_cat_path_depth;
 CREATE INDEX IF NOT EXISTS idx_os_cat_path_depth
-    ON object_state (((idx->>'path_depth')::integer)) WHERE idx IS NOT NULL;
+    ON object_state (path_depth) WHERE path_depth IS NOT NULL;
 
 -- Expression indexes for date range queries (B-tree via immutable wrapper)
 CREATE INDEX IF NOT EXISTS idx_os_cat_modified
@@ -138,22 +144,25 @@ CREATE INDEX IF NOT EXISTS idx_os_cat_uid
 -- multi-column index scan (sub-millisecond).
 
 -- Folder listings, navigation: parent + type (most common pattern)
+DROP INDEX IF EXISTS idx_os_cat_parent_type;
 CREATE INDEX IF NOT EXISTS idx_os_cat_parent_type
-    ON object_state ((idx->>'path_parent'), (idx->>'portal_type'))
-    WHERE idx IS NOT NULL;
+    ON object_state (parent_path, (idx->>'portal_type'))
+    WHERE parent_path IS NOT NULL;
 
 -- Path prefix queries with type filter (collections, search)
+DROP INDEX IF EXISTS idx_os_cat_path_type;
 CREATE INDEX IF NOT EXISTS idx_os_cat_path_type
-    ON object_state ((idx->>'path') text_pattern_ops, (idx->>'portal_type'))
-    WHERE idx IS NOT NULL;
+    ON object_state (path text_pattern_ops, (idx->>'portal_type'))
+    WHERE path IS NOT NULL;
 
 -- Path prefix + depth (navigation tree queries)
+DROP INDEX IF EXISTS idx_os_cat_path_depth_type;
 CREATE INDEX IF NOT EXISTS idx_os_cat_path_depth_type
     ON object_state (
-        (idx->>'path') text_pattern_ops,
-        ((idx->>'path_depth')::integer),
+        path text_pattern_ops,
+        path_depth,
         (idx->>'portal_type')
-    ) WHERE idx IS NOT NULL;
+    ) WHERE path IS NOT NULL;
 
 -- Type + review state (workflow-filtered listings)
 CREATE INDEX IF NOT EXISTS idx_os_cat_type_state
@@ -162,9 +171,10 @@ CREATE INDEX IF NOT EXISTS idx_os_cat_type_state
 
 -- Partial index for navigation listings (exclude_from_nav = false is ~1.6%
 -- of rows — highly selective, eliminates 98% before heap scan).
+DROP INDEX IF EXISTS idx_os_cat_nav_visible;
 CREATE INDEX IF NOT EXISTS idx_os_cat_nav_visible
-    ON object_state ((idx->>'path') text_pattern_ops, (idx->>'portal_type'))
-    WHERE idx IS NOT NULL AND (idx->>'exclude_from_nav')::boolean = false;
+    ON object_state (path text_pattern_ops, (idx->>'portal_type'))
+    WHERE path IS NOT NULL AND (idx->>'exclude_from_nav')::boolean = false;
 
 -- Partial index for upcoming events (portal_type = Event + sidecalendar).
 -- Allows direct index scan on end date for calendar widgets.
@@ -229,28 +239,29 @@ CREATE STATISTICS IF NOT EXISTS stts_os_type_state
 
 -- Folder listings: parent path x type filter (every navigation render).
 -- Matches idx_os_cat_parent_type.
+DROP STATISTICS IF EXISTS stts_os_parent_type;
 CREATE STATISTICS IF NOT EXISTS stts_os_parent_type
     (mcv, dependencies)
-    ON (idx->>'path_parent'), (idx->>'portal_type')
+    ON parent_path, (idx->>'portal_type')
     FROM object_state;
 
 -- Path prefix + type: matches idx_os_cat_path_type and idx_os_cat_nav_visible
 -- (same expression pair; one stats object covers both).  Path is
 -- high-cardinality in CMS (essentially unique per row) so no mcv.
+DROP STATISTICS IF EXISTS stts_os_path_type;
 CREATE STATISTICS IF NOT EXISTS stts_os_path_type
     (dependencies)
-    ON (idx->>'path'), (idx->>'portal_type')
+    ON path, (idx->>'portal_type')
     FROM object_state;
 
 -- Navigation tree: path prefix + depth + type.  Matches
 -- idx_os_cat_path_depth_type.  CMS structures are wide-shallow so
 -- path_depth has very few distinct values; the dependency between
 -- it and path is the interesting bit for the planner.
+DROP STATISTICS IF EXISTS stts_os_path_depth_type;
 CREATE STATISTICS IF NOT EXISTS stts_os_path_depth_type
     (dependencies)
-    ON (idx->>'path'),
-       ((idx->>'path_depth')::integer),
-       (idx->>'portal_type')
+    ON path, path_depth, (idx->>'portal_type')
     FROM object_state;
 
 -- Published-content filters: type x effective date.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from plone.pgcatalog.schema import install_catalog_schema
 from plone.pgcatalog.testing import PGCATALOG_INTEGRATION_TESTING
 from psycopg.rows import dict_row
 from psycopg.types.json import Json
+from types import SimpleNamespace
 from zodb_pgjsonb.schema import HISTORY_FREE_SCHEMA
 from zodb_pgjsonb.testing import get_test_dsn
 from zope.pytestlayer import fixture
@@ -206,12 +207,7 @@ def plone_obj():
     in the test so no Plone adapter layer is needed.
     """
 
-    class _Obj:
-        pass
-
-    obj = _Obj()
-    obj.getPhysicalPath = lambda: ("", "Plone", "doc")
-    return obj
+    return SimpleNamespace(getPhysicalPath=lambda: ("", "Plone", "doc"))
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,6 +182,120 @@ def query_zoids(conn, query_dict):
     return sorted(row["zoid"] for row in rows)
 
 
+# ─────────────────────────────────────────────────────────────────────
+# Fixtures for test_strip_path_from_idx.py (issue #132).
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def sample_zoid(pg_conn_with_catalog):
+    """A zoid with a bare object_state row already inserted."""
+    zoid = 1001
+    insert_object(pg_conn_with_catalog, zoid)
+    return zoid
+
+
+@pytest.fixture
+def plone_obj():
+    """Minimal stub object for ``PlonePGCatalogTool._set_pg_annotation``.
+
+    Needs ``getPhysicalPath()``, an assigned ``_p_oid`` (so the tool
+    takes the happy-path branch — set_pending + _p_changed), and a
+    real ``__dict__`` for the fallback branch.  We mock the tool's
+    ``_wrap_object`` / ``_extract_idx`` / ``_extract_searchable_text``
+    in the test so no Plone adapter layer is needed.
+    """
+
+    class _Obj:
+        pass
+
+    obj = _Obj()
+    obj.getPhysicalPath = lambda: ("", "Plone", "doc")
+    return obj
+
+
+@pytest.fixture
+def sample_pending():
+    """A pending annotation dict shaped like _set_pg_annotation produces."""
+    return {
+        "path": "/a/b/c",
+        "idx": {"portal_type": "Document"},
+        "searchable_text": None,
+    }
+
+
+@pytest.fixture
+def two_objects_at(pg_conn_with_catalog):
+    """Insert two objects under ``/Plone/old`` with typed cols + empty idx.
+
+    Returns the list of zoids.  Used by the bulk-move test: after
+    ``add_pending_move('/Plone/old', '/Plone/new', 0)`` + finalize(),
+    both rows should end up at ``/Plone/new/*`` with no path keys in idx.
+    """
+    zoids = []
+    for zoid, path in ((2001, "/Plone/old/a"), (2002, "/Plone/old/b")):
+        insert_object(pg_conn_with_catalog, zoid)
+        pg_conn_with_catalog.execute(
+            """
+            UPDATE object_state SET
+                path = %(path)s,
+                parent_path = %(parent)s,
+                path_depth = %(depth)s,
+                idx = %(idx)s
+            WHERE zoid = %(zoid)s
+            """,
+            {
+                "zoid": zoid,
+                "path": path,
+                "parent": "/Plone/old",
+                "depth": 3,
+                "idx": Json({"portal_type": "Document"}),
+            },
+        )
+        zoids.append(zoid)
+    pg_conn_with_catalog.commit()
+    return zoids
+
+
+@pytest.fixture
+def dirty_rows(pg_conn_with_catalog):
+    """Insert 5 rows whose idx JSONB contains legacy path keys.
+
+    Simulates a pre-migration database state.  Returns the list of zoids.
+    """
+    zoids = []
+    for i in range(5):
+        zoid = 3000 + i
+        path = f"/Plone/item-{i}"
+        insert_object(pg_conn_with_catalog, zoid)
+        legacy_idx = {
+            "portal_type": "Document",
+            "path": path,
+            "path_parent": "/Plone",
+            "path_depth": 2,
+        }
+        pg_conn_with_catalog.execute(
+            """
+            UPDATE object_state SET
+                path = %(path)s,
+                parent_path = %(parent)s,
+                path_depth = %(depth)s,
+                idx = %(idx)s
+            WHERE zoid = %(zoid)s
+            """,
+            {
+                "zoid": zoid,
+                "path": path,
+                "parent": "/Plone",
+                "depth": 2,
+                "idx": Json(legacy_idx),
+            },
+        )
+        zoids.append(zoid)
+    pg_conn_with_catalog.commit()
+    return zoids
+
+
 def insert_object(conn, zoid, tid=1, class_mod="myapp", class_name="Doc", state=None):
     """Insert a bare object_state row for testing.
 

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -58,23 +58,18 @@ def _get_row(conn, zoid):
 
 
 def _execute_bulk_path_update(conn, old_prefix, new_prefix, depth_delta):
-    """Execute the bulk path update SQL (same as processor.finalize will use)."""
+    """Execute the bulk path update SQL (same as processor.finalize uses).
+
+    Path data lives in typed columns only since #132; idx JSONB is not
+    touched by bulk path updates.
+    """
     conn.execute(
         """
         UPDATE object_state SET
             path = %(new)s || substring(path FROM length(%(old)s) + 1),
             parent_path = %(new)s || substring(parent_path FROM length(%(old)s) + 1),
-            path_depth = path_depth + %(dd)s,
-            idx = idx || jsonb_build_object(
-                'path',
-                %(new)s || substring(idx->>'path' FROM length(%(old)s) + 1),
-                'path_parent',
-                %(new)s || substring(idx->>'path_parent' FROM length(%(old)s) + 1),
-                'path_depth',
-                (idx->>'path_depth')::int + %(dd)s
-            )
+            path_depth = path_depth + %(dd)s
         WHERE path LIKE %(like)s
-          AND idx IS NOT NULL
         """,
         {
             "old": old_prefix,
@@ -107,15 +102,19 @@ class TestBulkPathUpdateRename:
         assert row["path_depth"] == 3  # unchanged
 
     def test_rename_updates_child_idx(self, pg_conn_with_catalog):
+        # Path keys moved to typed columns (#132); idx no longer carries them.
+        # Verify typed columns, and that idx preserves the non-path keys.
         conn = pg_conn_with_catalog
         _setup_tree(conn)
 
         _execute_bulk_path_update(conn, "/plone/source", "/plone/source-renamed", 0)
 
         row = _get_row(conn, 102)
-        assert row["idx"]["path"] == "/plone/source-renamed/doc-a"
-        assert row["idx"]["path_parent"] == "/plone/source-renamed"
-        assert row["idx"]["path_depth"] == 3
+        assert row["path"] == "/plone/source-renamed/doc-a"
+        assert row["parent_path"] == "/plone/source-renamed"
+        assert row["path_depth"] == 3
+        # idx preserves the non-path keys
+        assert row["idx"]["Title"] == "Doc A"
 
     def test_rename_updates_deep_descendant(self, pg_conn_with_catalog):
         conn = pg_conn_with_catalog
@@ -124,10 +123,9 @@ class TestBulkPathUpdateRename:
         _execute_bulk_path_update(conn, "/plone/source", "/plone/source-renamed", 0)
 
         row = _get_row(conn, 104)  # was /plone/source/sub/deep-doc
+        # Path lives in typed columns only (#132).
         assert row["path"] == "/plone/source-renamed/sub/deep-doc"
         assert row["parent_path"] == "/plone/source-renamed/sub"
-        assert row["idx"]["path"] == "/plone/source-renamed/sub/deep-doc"
-        assert row["idx"]["path_parent"] == "/plone/source-renamed/sub"
 
     def test_rename_updates_intermediate_folder(self, pg_conn_with_catalog):
         conn = pg_conn_with_catalog
@@ -162,9 +160,9 @@ class TestBulkPathUpdateCrossContainer:
         _execute_bulk_path_update(conn, "/plone/source", "/plone/target/source", 1)
 
         row = _get_row(conn, 104)  # was /plone/source/sub/deep-doc
+        # Path depth lives in typed column only (#132).
         assert row["path"] == "/plone/target/source/sub/deep-doc"
         assert row["path_depth"] == 5  # was 4, +1
-        assert row["idx"]["path_depth"] == 5
 
     def test_move_up_decreases_depth(self, pg_conn_with_catalog):
         """Move from /plone/source/sub to /plone/sub (depth decreases by 1)."""
@@ -198,10 +196,11 @@ class TestBulkPathUpdatePreservesOtherIdx:
         _execute_bulk_path_update(conn, "/plone/source", "/plone/source-renamed", 0)
 
         row = _get_row(conn, 103)
+        # Non-path idx keys survive the bulk path update.
         assert row["idx"]["Title"] == "Subfolder"
         assert row["idx"]["portal_type"] == "Folder"
-        # Path keys updated
-        assert row["idx"]["path"] == "/plone/source-renamed/sub"
+        # Path updated on typed column (idx no longer carries path keys, #132).
+        assert row["path"] == "/plone/source-renamed/sub"
 
 
 class TestParentNotMatchedByLike:
@@ -215,8 +214,8 @@ class TestParentNotMatchedByLike:
         _execute_bulk_path_update(conn, "/plone/source", "/plone/source-renamed", 0)
 
         row = _get_row(conn, 101)  # /plone/source (the parent)
+        # Path lives in typed column only (#132); parent row not matched by LIKE.
         assert row["path"] == "/plone/source"  # unchanged!
-        assert row["idx"]["path"] == "/plone/source"
 
     def test_sibling_unchanged(self, pg_conn_with_catalog):
         conn = pg_conn_with_catalog

--- a/tests/test_move_integration.py
+++ b/tests/test_move_integration.py
@@ -1102,14 +1102,12 @@ class TestRenameUpdatesDescendants:
         assert row["path"] == "/plone/source-renamed/doc-a"
         assert row["parent_path"] == "/plone/source-renamed"
         assert row["path_depth"] == 3
-        assert row["idx"]["path"] == "/plone/source-renamed/doc-a"
 
         row = _get_row(conn, 103)
         assert row["path"] == "/plone/source-renamed/sub"
 
         row = _get_row(conn, 104)
         assert row["path"] == "/plone/source-renamed/sub/deep-doc"
-        assert row["idx"]["path"] == "/plone/source-renamed/sub/deep-doc"
 
     def test_rename_parent_updated(self, pg_conn_with_catalog):
         conn = pg_conn_with_catalog
@@ -1125,7 +1123,6 @@ class TestRenameUpdatesDescendants:
 
         row = _get_row(conn, 101)
         assert row["path"] == "/plone/source-renamed"
-        assert row["idx"]["path"] == "/plone/source-renamed"
 
     def test_rename_siblings_unchanged(self, pg_conn_with_catalog):
         conn = pg_conn_with_catalog
@@ -1161,7 +1158,6 @@ class TestMoveUpdatesDescendants:
         row = _get_row(conn, 102)
         assert row["path"] == "/plone/target/source/doc-a"
         assert row["path_depth"] == 4
-        assert row["idx"]["path_depth"] == 4
 
         row = _get_row(conn, 104)
         assert row["path"] == "/plone/target/source/sub/deep-doc"

--- a/tests/test_plone_integration.py
+++ b/tests/test_plone_integration.py
@@ -479,12 +479,15 @@ class TestSetPGAnnotationPipeline:
                 data = all_pending.get(zoid, {})
 
             expected_path = "/".join(doc.getPhysicalPath())
+            # Path lives in pending["path"] (typed column target); idx no
+            # longer carries path/path_parent/path_depth (#132).  parent_path
+            # and path_depth are derived by CatalogStateProcessor from path.
             assert data.get("path") == expected_path
 
             idx = data.get("idx", {})
-            assert idx.get("path") == expected_path
-            assert "path_parent" in idx
-            assert "path_depth" in idx
+            assert "path" not in idx
+            assert "path_parent" not in idx
+            assert "path_depth" not in idx
         finally:
             registry._indexes = old_indexes
             registry._metadata = old_metadata

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -308,8 +308,10 @@ class TestSearchableText:
 class TestPathIndex:
     def test_subtree_default(self):
         qr = build_query({"path": "/plone/folder"})
-        assert "idx->>'path' =" in qr["where"]
-        assert "idx->>'path' LIKE" in qr["where"]
+        # Built-in "path" dispatches to typed columns (#132)
+        assert "path =" in qr["where"]
+        assert "path LIKE" in qr["where"]
+        assert "idx->>'path'" not in qr["where"]
         # LIKE pattern should end with /%
         like_val = [
             v for v in qr["params"].values() if isinstance(v, str) and v.endswith("/%")
@@ -318,29 +320,35 @@ class TestPathIndex:
 
     def test_exact_depth_0(self):
         qr = build_query({"path": {"query": "/plone/folder", "depth": 0}})
-        assert "idx->>'path' =" in qr["where"]
+        assert "path = " in qr["where"]
+        assert "idx->>'path'" not in qr["where"]
         assert "LIKE" not in qr["where"]
 
     def test_children_depth_1(self):
         qr = build_query({"path": {"query": "/plone/folder", "depth": 1}})
-        assert "idx->>'path_parent' =" in qr["where"]
+        assert "parent_path =" in qr["where"]
+        assert "idx->>'path_parent'" not in qr["where"]
 
     def test_limited_depth(self):
         qr = build_query({"path": {"query": "/plone/folder", "depth": 2}})
-        assert "idx->>'path' LIKE" in qr["where"]
-        assert "(idx->>'path_depth')::integer <=" in qr["where"]
+        assert "path LIKE" in qr["where"]
+        assert "path_depth <=" in qr["where"]
+        assert "idx->>'path'" not in qr["where"]
+        assert "idx->>'path_depth'" not in qr["where"]
 
     def test_navtree_depth_1(self):
         qr = build_query(
             {"path": {"query": "/plone/folder/doc", "navtree": True, "depth": 1}}
         )
-        assert "idx->>'path_parent' = ANY(" in qr["where"]
+        assert "parent_path = ANY(" in qr["where"]
+        assert "idx->>'path_parent'" not in qr["where"]
 
     def test_navtree_depth_0_breadcrumbs(self):
         qr = build_query(
             {"path": {"query": "/plone/folder/doc", "navtree": True, "depth": 0}}
         )
-        assert "idx->>'path' = ANY(" in qr["where"]
+        assert "path = ANY(" in qr["where"]
+        assert "idx->>'path'" not in qr["where"]
 
     def test_navtree_start(self):
         qr = build_query(
@@ -704,11 +712,12 @@ class TestAdditionalPathIndex:
         )
         assert qr["order_by"] == "idx->>'tgpath' DESC"
 
-    def test_builtin_path_uses_same_pattern(self):
-        """Built-in 'path' index uses same idx JSONB pattern as tgpath."""
+    def test_builtin_path_uses_typed_columns(self):
+        """Built-in 'path' index dispatches to typed columns, not idx JSONB (#132)."""
         qr = build_query({"path": "/plone/folder"})
-        assert "idx->>'path' =" in qr["where"]
-        assert "idx->>'path' LIKE" in qr["where"]
+        assert "path =" in qr["where"]
+        assert "path LIKE" in qr["where"]
+        assert "idx->>'path'" not in qr["where"]
 
     def test_builtin_path_sort(self):
         """Built-in 'path' sort uses idx JSONB."""
@@ -716,7 +725,7 @@ class TestAdditionalPathIndex:
         assert qr["order_by"] == "idx->>'path' ASC"
 
     def test_combined_path_and_tgpath(self):
-        """Both path and tgpath can be queried simultaneously."""
+        """Built-in path uses typed columns; tgpath (custom) still uses idx JSONB (#132)."""
         qr = build_query(
             {
                 "path": "/plone/folder",
@@ -724,8 +733,10 @@ class TestAdditionalPathIndex:
             }
         )
         where = qr["where"]
-        # Both use idx JSONB with different keys
-        assert "idx->>'path' =" in where or "idx->>'path' LIKE" in where
+        # Built-in path dispatches to typed columns
+        assert "path = " in where or "path LIKE" in where
+        assert "idx->>'path'" not in where
+        # Custom tgpath still uses idx JSONB
         assert "idx->>'tgpath_parent' =" in where
 
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -720,9 +720,18 @@ class TestAdditionalPathIndex:
         assert "idx->>'path'" not in qr["where"]
 
     def test_builtin_path_sort(self):
-        """Built-in 'path' sort uses idx JSONB."""
+        """Built-in 'path' sort uses the typed `path` column, not idx JSONB (#132)."""
         qr = build_query({"path": "/plone", "sort_on": "path"})
-        assert qr["order_by"] == "idx->>'path' ASC"
+        assert qr["order_by"] == "path ASC"
+        assert "idx->>'path'" not in qr["order_by"]
+
+    def test_builtin_path_sort_descending(self):
+        """Built-in 'path' sort honors descending order on typed column (#132)."""
+        qr = build_query(
+            {"path": "/plone", "sort_on": "path", "sort_order": "descending"}
+        )
+        assert qr["order_by"] == "path DESC"
+        assert "idx->>'path'" not in qr["order_by"]
 
     def test_combined_path_and_tgpath(self):
         """Built-in path uses typed columns; tgpath (custom) still uses idx JSONB (#132)."""

--- a/tests/test_strip_path_from_idx.py
+++ b/tests/test_strip_path_from_idx.py
@@ -40,6 +40,7 @@ class TestWriterDoesNotDuplicatePath:
             "FROM object_state WHERE zoid = %s",
             (sample_zoid,),
         ).fetchone()
+        assert row is not None
         assert row["path"] == "/Plone/doc"
         assert row["parent_path"] == "/Plone"
         assert row["path_depth"] == 2
@@ -65,6 +66,9 @@ class TestWriterDoesNotDuplicatePath:
             ok = tool._set_pg_annotation(plone_obj, "/Plone/doc")
         assert ok is True
         pending = plone_obj.__dict__[ANNOTATION_KEY]
+        # Positive contract: path stays on the pending dict itself —
+        # only the duplication into idx JSONB should be removed.
+        assert pending["path"] == "/Plone/doc"
         for key in PATH_KEYS_IN_IDX:
             assert key not in pending["idx"], (
                 f"{key!r} must not be in pending idx after cleanup"
@@ -111,19 +115,21 @@ class TestBulkMoveDoesNotTouchIdxPathKeys:
 class TestQueryBuilderDispatchesPathToTypedColumns:
     def test_builtin_path_index_uses_typed_columns(self):
         sql, _ = _build_sql({"path": {"query": "/Plone/x", "depth": -1}})
+        # Contract: don't use the JSONB extract. The builder is free to
+        # emit `path = …`, `path LIKE …`, or any other typed-column form.
         assert "idx->>'path'" not in sql, (
             f"subtree path query should use typed column, got: {sql}"
         )
-        assert "path" in sql  # the typed column must appear
 
     def test_builtin_path_navtree_uses_typed_parent_path(self):
         sql, _ = _build_sql(
             {"path": {"query": "/Plone/a/b", "navtree": True, "depth": 1}}
         )
+        # No positive column assertion: navtree may use `parent_path = …`
+        # OR `path LIKE … AND path_depth = …` — both are valid typed forms.
         assert "idx->>'path_parent'" not in sql, (
             f"navtree query should use typed parent_path, got: {sql}"
         )
-        assert "parent_path" in sql
 
     def test_builtin_path_depth_uses_typed_path_depth(self):
         sql, _ = _build_sql({"path": {"query": "/Plone", "depth": 2}})
@@ -158,6 +164,11 @@ class TestSchemaUsesTypedColumns:
             (self.EXPECTED_INDEXES,),
         ).fetchall()
         assert rows, "expected catalog path indexes to be present"
+        found = {r["indexname"] for r in rows}
+        missing = set(self.EXPECTED_INDEXES) - found
+        assert not missing, (
+            f"expected indexes missing after migration: {sorted(missing)}"
+        )
         for r in rows:
             assert "idx ->> 'path'" not in r["indexdef"], (
                 f"{r['indexname']}: still uses idx->>'path' — migration incomplete"
@@ -197,6 +208,9 @@ class TestMigrationStripsPathKeys:
             "SELECT idx FROM object_state WHERE zoid = ANY(%s)",
             (dirty_rows,),
         ).fetchall()
+        assert len(rows) == len(dirty_rows), (
+            f"expected {len(dirty_rows)} rows, got {len(rows)}"
+        )
         for r in rows:
             for key in PATH_KEYS_IN_IDX:
                 assert key not in r["idx"]

--- a/tests/test_strip_path_from_idx.py
+++ b/tests/test_strip_path_from_idx.py
@@ -1,0 +1,209 @@
+"""Tests for stripping path/parent_path/path_depth from idx JSONB.
+
+See: docs/plans/2026-04-15-strip-path-from-idx-jsonb.md
+Issue: bluedynamics/plone-pgcatalog#132
+
+Task 1 — failing test scaffold.  Later tasks make these green one by one.
+"""
+
+from typing import ClassVar
+from unittest import mock
+
+
+PATH_KEYS_IN_IDX = ("path", "path_parent", "path_depth")
+
+
+def _build_sql(query_dict):
+    """Run build_query() and return the generated SQL + params.
+
+    Mirrors what ``_execute_query`` produces — enough for WHERE-clause
+    assertions without hitting the database.
+    """
+    from plone.pgcatalog.query import build_query
+
+    qr = build_query(query_dict)
+    sql = f"SELECT zoid FROM object_state WHERE {qr['where']}"
+    if qr["order_by"]:
+        sql += f" ORDER BY {qr['order_by']}"
+    return sql, qr["params"]
+
+
+class TestWriterDoesNotDuplicatePath:
+    def test_catalog_object_strips_path_keys(self, pg_conn_with_catalog, sample_zoid):
+        from plone.pgcatalog.indexing import catalog_object
+
+        idx_in = {"portal_type": "Document", "Title": "T"}
+        catalog_object(pg_conn_with_catalog, sample_zoid, "/Plone/doc", idx_in)
+        pg_conn_with_catalog.commit()
+        row = pg_conn_with_catalog.execute(
+            "SELECT path, parent_path, path_depth, idx "
+            "FROM object_state WHERE zoid = %s",
+            (sample_zoid,),
+        ).fetchone()
+        assert row["path"] == "/Plone/doc"
+        assert row["parent_path"] == "/Plone"
+        assert row["path_depth"] == 2
+        for key in PATH_KEYS_IN_IDX:
+            assert key not in row["idx"], (
+                f"{key!r} must not be written to idx JSONB after cleanup"
+            )
+
+    def test_pgcatalog_tool_set_pg_annotation_strips_path_keys(self, plone_obj):
+        from plone.pgcatalog.catalog import PlonePGCatalogTool
+        from plone.pgcatalog.processor import ANNOTATION_KEY
+
+        tool = PlonePGCatalogTool.__new__(PlonePGCatalogTool)
+        with (
+            mock.patch.object(
+                PlonePGCatalogTool, "_wrap_object", return_value=plone_obj
+            ),
+            mock.patch.object(PlonePGCatalogTool, "_extract_idx", return_value={}),
+            mock.patch.object(
+                PlonePGCatalogTool, "_extract_searchable_text", return_value=None
+            ),
+        ):
+            ok = tool._set_pg_annotation(plone_obj, "/Plone/doc")
+        assert ok is True
+        pending = plone_obj.__dict__[ANNOTATION_KEY]
+        for key in PATH_KEYS_IN_IDX:
+            assert key not in pending["idx"], (
+                f"{key!r} must not be in pending idx after cleanup"
+            )
+
+    def test_processor_reads_typed_cols_not_idx(self, sample_pending):
+        """CatalogStateProcessor.process must source parent_path/path_depth
+        from compute_path_info(path), not from idx.
+        """
+        from plone.pgcatalog.pending import set_pending
+        from plone.pgcatalog.processor import CatalogStateProcessor
+
+        processor = CatalogStateProcessor()
+        zoid = 4242
+        set_pending(zoid, sample_pending)
+        result = processor.process(zoid, "mymod", "MyCls", {})
+        assert result["path"] == "/a/b/c"
+        assert result["parent_path"] == "/a/b"
+        assert result["path_depth"] == 3
+
+
+class TestBulkMoveDoesNotTouchIdxPathKeys:
+    def test_bulk_move_updates_typed_only(self, pg_conn_with_catalog, two_objects_at):
+        from plone.pgcatalog.pending import add_pending_move
+        from plone.pgcatalog.processor import CatalogStateProcessor
+
+        add_pending_move("/Plone/old", "/Plone/new", 0)
+        with pg_conn_with_catalog.cursor() as cursor:
+            processor = CatalogStateProcessor()
+            processor.finalize(cursor)
+        pg_conn_with_catalog.commit()
+        for old_path in ("/Plone/old/a", "/Plone/old/b"):
+            new_path = old_path.replace("/old/", "/new/")
+            row = pg_conn_with_catalog.execute(
+                "SELECT path, parent_path, idx FROM object_state WHERE path = %s",
+                (new_path,),
+            ).fetchone()
+            assert row is not None, f"row not found at {new_path}"
+            assert row["parent_path"] == "/Plone/new"
+            for key in PATH_KEYS_IN_IDX:
+                assert key not in row["idx"]
+
+
+class TestQueryBuilderDispatchesPathToTypedColumns:
+    def test_builtin_path_index_uses_typed_columns(self):
+        sql, _ = _build_sql({"path": {"query": "/Plone/x", "depth": -1}})
+        assert "idx->>'path'" not in sql, (
+            f"subtree path query should use typed column, got: {sql}"
+        )
+        assert "path" in sql  # the typed column must appear
+
+    def test_builtin_path_navtree_uses_typed_parent_path(self):
+        sql, _ = _build_sql(
+            {"path": {"query": "/Plone/a/b", "navtree": True, "depth": 1}}
+        )
+        assert "idx->>'path_parent'" not in sql, (
+            f"navtree query should use typed parent_path, got: {sql}"
+        )
+        assert "parent_path" in sql
+
+    def test_builtin_path_depth_uses_typed_path_depth(self):
+        sql, _ = _build_sql({"path": {"query": "/Plone", "depth": 2}})
+        assert "(idx->>'path_depth')::integer" not in sql, (
+            f"depth-limited query should use typed path_depth, got: {sql}"
+        )
+        assert "path_depth" in sql
+
+    def test_custom_path_index_keeps_jsonb_keys(self):
+        sql, _ = _build_sql({"tgpath": {"query": "/Plone/x", "depth": -1}})
+        assert "idx->>'tgpath'" in sql, (
+            f"custom path index must still query idx JSONB, got: {sql}"
+        )
+
+
+class TestSchemaUsesTypedColumns:
+    EXPECTED_INDEXES: ClassVar[list[str]] = [
+        "idx_os_cat_path",
+        "idx_os_cat_path_pattern",
+        "idx_os_cat_path_parent",
+        "idx_os_cat_path_depth",
+        "idx_os_cat_parent_type",
+        "idx_os_cat_path_type",
+        "idx_os_cat_path_depth_type",
+        "idx_os_cat_nav_visible",
+    ]
+
+    def test_path_indexes_reference_typed_columns(self, pg_conn_with_catalog):
+        rows = pg_conn_with_catalog.execute(
+            "SELECT indexname, indexdef FROM pg_indexes "
+            "WHERE tablename='object_state' AND indexname = ANY(%s)",
+            (self.EXPECTED_INDEXES,),
+        ).fetchall()
+        assert rows, "expected catalog path indexes to be present"
+        for r in rows:
+            assert "idx ->> 'path'" not in r["indexdef"], (
+                f"{r['indexname']}: still uses idx->>'path' — migration incomplete"
+            )
+            assert "idx ->> 'path_parent'" not in r["indexdef"], (
+                f"{r['indexname']}: still uses idx->>'path_parent'"
+            )
+            assert "idx ->> 'path_depth'" not in r["indexdef"], (
+                f"{r['indexname']}: still uses idx->>'path_depth'"
+            )
+
+    def test_extended_statistics_reference_typed_columns(self, pg_conn_with_catalog):
+        rows = pg_conn_with_catalog.execute(
+            """
+            SELECT stxname, pg_get_statisticsobjdef(oid) AS stxdef
+            FROM pg_statistic_ext
+            WHERE stxname IN (
+                'stts_os_parent_type',
+                'stts_os_path_type',
+                'stts_os_path_depth_type'
+            )
+            """
+        ).fetchall()
+        assert rows, "expected path-related extended statistics to be present"
+        for r in rows:
+            assert "idx ->> 'path'" not in r["stxdef"]
+            assert "idx ->> 'path_parent'" not in r["stxdef"]
+            assert "idx ->> 'path_depth'" not in r["stxdef"]
+
+
+class TestMigrationStripsPathKeys:
+    def test_strip_removes_keys_idempotently(self, pg_conn_with_catalog, dirty_rows):
+        from plone.pgcatalog.migrations.strip_path_keys import run
+
+        run(pg_conn_with_catalog, batch_size=2)  # forces multiple batches
+        rows = pg_conn_with_catalog.execute(
+            "SELECT idx FROM object_state WHERE zoid = ANY(%s)",
+            (dirty_rows,),
+        ).fetchall()
+        for r in rows:
+            for key in PATH_KEYS_IN_IDX:
+                assert key not in r["idx"]
+
+    def test_strip_is_idempotent(self, pg_conn_with_catalog, dirty_rows):
+        from plone.pgcatalog.migrations.strip_path_keys import run
+
+        run(pg_conn_with_catalog)
+        result = run(pg_conn_with_catalog)
+        assert result["rows_updated"] == 0

--- a/tests/test_strip_path_from_idx.py
+++ b/tests/test_strip_path_from_idx.py
@@ -199,6 +199,48 @@ class TestSchemaUsesTypedColumns:
             assert "idx ->> 'path_depth'" not in r["stxdef"]
 
 
+class TestBuiltinPathSortEndToEnd:
+    """Regression guard: built-in 'path' sort must order rows correctly (#132).
+
+    After stripping path keys from idx JSONB, ``ORDER BY idx->>'path'`` returns
+    NULL for every row.  This test asserts that ``sort_on='path'`` against the
+    typed column produces the expected alphabetical order.
+    """
+
+    def test_path_sort_orders_rows_alphabetically(self, pg_conn_with_catalog):
+        from plone.pgcatalog.indexing import catalog_object
+        from plone.pgcatalog.query import build_query
+        from tests.conftest import insert_object
+
+        # Insert in non-alphabetical order to prove the ORDER BY is doing work.
+        objects = [
+            (5001, "/Plone/b"),
+            (5002, "/Plone/a"),
+            (5003, "/Plone/c"),
+        ]
+        for zoid, path in objects:
+            insert_object(pg_conn_with_catalog, zoid)
+            catalog_object(
+                pg_conn_with_catalog,
+                zoid,
+                path,
+                {"portal_type": "Document"},
+            )
+        pg_conn_with_catalog.commit()
+
+        qr = build_query({"path": "/Plone", "sort_on": "path"})
+        sql = (
+            f"SELECT zoid, path FROM object_state "
+            f"WHERE {qr['where']} ORDER BY {qr['order_by']}"
+        )
+        rows = pg_conn_with_catalog.execute(sql, qr["params"]).fetchall()
+        inserted_paths = {p for _, p in objects}
+        paths = [r["path"] for r in rows if r["path"] in inserted_paths]
+        assert paths == ["/Plone/a", "/Plone/b", "/Plone/c"], (
+            f"sort_on='path' must use typed column, got: {paths}"
+        )
+
+
 class TestMigrationStripsPathKeys:
     def test_strip_removes_keys_idempotently(self, pg_conn_with_catalog, dirty_rows):
         from plone.pgcatalog.migrations.strip_path_keys import run


### PR DESCRIPTION
## Summary

Closes #132.

Removes duplication of `path`, `path_parent`, and `path_depth` between the typed columns on `object_state` and the `idx` JSONB. These three fields now live exclusively in their typed columns (`path`, `parent_path`, `path_depth`). Previously identical values were stored in both places, wasting ~10% of JSONB storage and — more importantly — blocking the planner from collecting per-column selectivity statistics on path-subtree filters.

### Four axes of change

1. **Writers** (`indexing.py`, `catalog.py`) — stop copying path keys into `idx`. Typed columns are still populated as before.
2. **Processor** (`processor.py`) — derives `parent_path` / `path_depth` from `path` via `compute_path_info` instead of reading them from `idx`. Bulk-move SQL updates typed columns only; the `idx IS NOT NULL` filter is dropped since `path` is only set via the catalog pipeline which always also sets `idx`.
3. **Query builder** (`query.py`) — the `_handle_path` and `_process_sort` paths dispatch the built-in `path` index (`idx_key=None AND name="path"`) to the typed columns. Custom `PATH`-type indexes (e.g. `tgpath`) continue to use JSONB — unaffected.
4. **Schema** (`schema.py`) — 8 indexes and 3 extended-statistics objects are rewritten to reference typed columns. Every affected DDL entry is reissued with idempotent `DROP … IF EXISTS` + `CREATE … IF NOT EXISTS` so existing deployments self-heal on next startup.

### Migration

A new one-shot helper cleans up existing rows:

```python
from plone.pgcatalog.migrations.strip_path_keys import run
result = run(conn, batch_size=5000)
# {"batches": N, "rows_updated": M}
```

- Batched, keyset-paginated (`WHERE zoid > last AND idx ?| …`).
- Idempotent — safe to re-run; rows already cleaned are skipped by the predicate.
- Commits each batch; restores the caller's original autocommit state on exit.
- Safe to run online and interruptible.

### Impact

From [diagnostic queries on aaf-prod](https://github.com/bluedynamics/plone-pgcatalog/issues/132) during the investigation:
- ~21 MB of JSONB storage freed (before TOAST recompression).
- ~140 MB of duplicate index storage freed (after this lands, `idx_os_cat_path` and `idx_os_path` become content-identical — a follow-up can drop the redundant one).
- Unlocks #131 and other path-scoped query optimizations: the planner finally gets full statistics on `path` / `parent_path` / `path_depth`.

### Out of scope

- `id` / `getId` JSONB duplication (also 100% identical, ~4.5 MB) — separate code path, separate follow-up.
- `idx_os_cat_events_upcoming` cleanup (0 scans ever) — noted in #131.
- Dropping the redundant `idx_os_path` typed-column index once `idx_os_cat_path` also references the typed column — follow-up.

## Test plan

- [x] New `tests/test_strip_path_from_idx.py` (13 tests) locks down the writer/processor/query/schema/migration contracts.
- [x] End-to-end regression guard: `TestBuiltinPathSortEndToEnd` inserts three rows in non-alphabetical order and asserts `sort_on="path"` returns them alphabetical.
- [x] Existing legacy tests (`test_move.py`, `test_move_integration.py`, `test_plone_integration.py`, `test_query.py`) updated where they asserted on the old JSONB-based storage — behavior assertions preserved.
- [x] Full suite: **1345 passed, 39 skipped, 0 failed** (up from 1331 baseline).
- [x] `ruff check` clean.
- [x] Plan doc in `docs/plans/2026-04-15-strip-path-from-idx-jsonb.md`.

## Rollout

1. Merge → deploys bring in new writer / processor / query / schema code.
2. On first startup of the updated pod, `install_catalog_schema` reissues the 8 indexes and 3 statistics objects via DROP+CREATE. Brief window of absent indexes (partial scans fall back to other indexes; 137k-row table).
3. New writes no longer populate the path keys in `idx`.
4. Optionally run `strip_path_keys.run(conn)` once on each site to clean up existing rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)