### PR TITLE
fix: v1->v2 upgrade step was a silent no-op under GenericSetup (#139)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 1.0.0b56
+
+### Fixed
+
+- The v1->v2 upgrade step was silently no-op on production sites.  GenericSetup
+  invokes upgrade handlers with the ``portal_setup`` tool as the context, but
+  ``_resolve_compat`` only understood the ``ImportContext`` shape (``getSite()``),
+  so the setup-tool call path hit the ``return None, None`` branch and logged
+  ``migrate_catalog_indexes: no _CatalogCompat found; skipping`` — while
+  GenericSetup happily bumped the profile version to 2.  Net effect: the
+  persisted ``_CatalogCompat`` kept its legacy ``indexes`` attribute and the
+  new ``indexes`` property then raised ``AttributeError`` for ``_raw_indexes``,
+  which Acquisition swallowed and replaced with the tool's ``indexes()``
+  method — surfacing as ``'function' object has no attribute 'keys'`` from
+  ``catalog.indexes.keys()`` and ``'method' object is not subscriptable`` from
+  ``catalog.indexes[name]``.
+
+  ``_resolve_compat`` now also walks ``aq_parent(context)`` to reach the Plone
+  site when the context is the setup tool, so the normal ZMI
+  ``manage_upgrades`` path migrates the state as intended.
+
+- Made ``_CatalogCompat.indexes`` self-healing: if the legacy ``indexes``
+  attribute is still in ``__dict__`` (unmigrated or fresh-install site that
+  skipped v1), the property moves it to ``_raw_indexes`` on first access and
+  marks the instance dirty.  This avoids the Acquisition-swallowed
+  ``AttributeError`` failure mode even when the upgrade step never ran.
+
+  Closes #139.
+
 ## 1.0.0b55
 
 ### Fixed

--- a/src/plone/pgcatalog/maintenance.py
+++ b/src/plone/pgcatalog/maintenance.py
@@ -205,8 +205,26 @@ class _CatalogCompat(Implicit, Persistent):
         ``self.__parent__`` (set by ``PlonePGCatalogTool`` or by the
         profile upgrade step), so the catalog tool is reachable even
         through bare attribute access like ``tool._catalog.indexes``.
+
+        Self-heals an unmigrated persisted state where the legacy
+        ``indexes`` PersistentMapping is still in ``__dict__`` instead of
+        ``_raw_indexes``.  This matters because any AttributeError raised
+        here is swallowed by Acquisition, which then returns the tool's
+        ``indexes()`` method from the parent — producing the
+        "'function' object has no attribute 'keys'" traceback at
+        ``catalog.indexes.keys()`` instead of surfacing the real cause.
+        Fresh-install sites and sites where the v1->v2 upgrade step
+        silently no-op'd (see #139) hit this path.
         """
-        return _CatalogIndexesView(self, self._raw_indexes)
+        state = self.__dict__
+        raw = state.get("_raw_indexes")
+        if raw is None:
+            raw = state.pop("indexes", None)
+            if raw is None:
+                raw = PersistentMapping()
+            state["_raw_indexes"] = raw
+            self._p_changed = True
+        return _CatalogIndexesView(self, raw)
 
     def getIndex(self, name):
         """Return a PG-backed index wrapper for *name*.

--- a/src/plone/pgcatalog/upgrades/profile_2.py
+++ b/src/plone/pgcatalog/upgrades/profile_2.py
@@ -98,15 +98,29 @@ class _NoOpJar:
 
 def _resolve_compat(context):
     """Return ``(_CatalogCompat, catalog_tool)`` for either a compat
-    instance or a GenericSetup context.  Either element may be None."""
+    instance or a GenericSetup context.  Either element may be None.
+
+    GenericSetup hands two shapes to upgrade handlers depending on how
+    they're invoked:
+
+    * ``UpgradeStep.doStep`` (the normal v1->v2 path) passes the
+      ``portal_setup`` tool itself — acquisition-wrapped inside the
+      Plone site.
+    * ``UpgradeDepends.doStep`` / export+import helpers pass an
+      ``ImportContext`` exposing ``getSite()``.
+
+    Both must resolve to the site's ``portal_catalog._catalog``.  The
+    earlier version of this function only understood the ``ImportContext``
+    path and silently returned ``(None, None)`` for the setup-tool case,
+    so the migration no-op'd on every site that GenericSetup invokes via
+    the normal upgrade button (see #139).
+    """
+    from Acquisition import aq_parent
     from plone.pgcatalog.maintenance import _CatalogCompat
 
     if isinstance(context, _CatalogCompat):
-        # Unit-test shortcut: caller passed compat directly.  The catalog
-        # tool is reachable via aq_parent if already wired.
+        # Unit-test shortcut: caller passed compat directly.
         try:
-            from Acquisition import aq_parent
-
             catalog = aq_parent(context)
         except Exception:
             catalog = None
@@ -114,11 +128,14 @@ def _resolve_compat(context):
             catalog = context.__dict__.get("__parent__")
         return context, catalog
 
-    # GenericSetup: context is an ImportContext; its site is the Plone root.
+    # ImportContext-style callers first (preserves existing path).
+    # portal_setup-tool path: the setup tool's acquisition parent is
+    # the Plone site root.
     getSite = getattr(context, "getSite", None)
-    if getSite is None:
+    site = getSite() if getSite is not None else aq_parent(context)
+
+    if site is None:
         return None, None
-    site = getSite()
     catalog = getattr(site, "portal_catalog", None)
     if catalog is None:
         return None, None

--- a/tests/test_catalog_indexes_view.py
+++ b/tests/test_catalog_indexes_view.py
@@ -202,6 +202,105 @@ class TestProfileUpgradeV1ToV2:
         migrate_catalog_indexes(compat, _test_inject_jar=True)
         assert compat._p_changed is True
 
+    def test_migrate_from_portal_setup_tool_context(self):
+        """GenericSetup calls upgrade handlers with portal_setup as context.
+
+        Regression for #139: the upgrade was silently no-op on production
+        because ``_resolve_compat`` only understood ImportContext (getSite())
+        and returned (None, None) for the setup tool, logging a warning and
+        leaving the persisted state untouched even though GS bumped the
+        profile version to 2.
+        """
+        from OFS.Folder import Folder
+        from plone.pgcatalog.catalog import PlonePGCatalogTool
+        from plone.pgcatalog.maintenance import _CatalogCompat
+        from plone.pgcatalog.upgrades.profile_2 import migrate_catalog_indexes
+
+        # Build the shape GS gives us: portal_setup acquisition-wrapped
+        # inside a Plone site that owns portal_catalog -> _CatalogCompat.
+        site = Folder("plone")
+        tool = PlonePGCatalogTool.__new__(PlonePGCatalogTool)
+        compat = _CatalogCompat.__new__(_CatalogCompat)
+        legacy = PersistentMapping({"portal_type": mock.Mock()})
+        compat.__dict__["indexes"] = legacy
+        tool._catalog = compat
+        site.portal_catalog = tool
+
+        class _SetupTool(Folder):
+            pass
+
+        setup = _SetupTool("portal_setup")
+        site.portal_setup = setup
+        # GS passes the acquisition-wrapped setup tool
+        wrapped_setup = site.portal_setup
+
+        migrate_catalog_indexes(wrapped_setup, _test_inject_jar=True)
+
+        assert "_raw_indexes" in compat.__dict__, (
+            "migration must rename legacy 'indexes' attr when invoked "
+            "with the portal_setup tool context (real GS path)"
+        )
+        assert compat._raw_indexes is legacy
+        assert "indexes" not in compat.__dict__
+
+
+# ── Self-healing property survives unmigrated legacy state ──────────────
+
+
+class TestPropertySelfHealsLegacyState:
+    """If a site was installed with profile v2 directly (fresh install) or
+    the upgrade step silently no-op'd, ``_CatalogCompat`` may still have
+    the legacy ``indexes`` attribute in ``__dict__`` and no
+    ``_raw_indexes``.  Any AttributeError inside the property is
+    swallowed by Acquisition and the tool's ``indexes()`` method is
+    returned instead, producing ``'function' object has no attribute
+    'keys'`` on ``catalog.indexes.keys()``.  The property must handle
+    that state itself instead of raising.
+    """
+
+    def test_property_migrates_on_first_access(self):
+        from plone.pgcatalog.maintenance import _CatalogCompat
+
+        compat = _CatalogCompat.__new__(_CatalogCompat)
+        legacy = PersistentMapping({"portal_type": mock.Mock()})
+        compat.__dict__["indexes"] = legacy
+        # no _raw_indexes
+
+        view = compat.indexes
+        assert list(view.keys()) == ["portal_type"]
+        # side effect: state migrated in-place
+        assert "_raw_indexes" in compat.__dict__
+        assert compat._raw_indexes is legacy
+        assert "indexes" not in compat.__dict__
+
+    def test_property_creates_empty_when_no_legacy(self):
+        from plone.pgcatalog.maintenance import _CatalogCompat
+
+        compat = _CatalogCompat.__new__(_CatalogCompat)
+        # No indexes and no _raw_indexes — pathological but must not crash
+        view = compat.indexes
+        assert list(view.keys()) == []
+        assert "_raw_indexes" in compat.__dict__
+
+    def test_tool_indexes_method_works_on_unmigrated_compat(self):
+        """Regression for the observed production traceback:
+            AttributeError: 'function' object has no attribute 'keys'
+        at plone.pgcatalog.catalog:287.
+        """
+        from OFS.Folder import Folder
+        from plone.pgcatalog.catalog import PlonePGCatalogTool
+        from plone.pgcatalog.maintenance import _CatalogCompat
+
+        compat = _CatalogCompat.__new__(_CatalogCompat)
+        compat.__dict__["indexes"] = PersistentMapping({"a": mock.Mock()})
+        tool = PlonePGCatalogTool.__new__(PlonePGCatalogTool)
+        tool._catalog = compat
+        site = Folder("plone")
+        site.portal_catalog = tool
+
+        result = site.portal_catalog.indexes()
+        assert result == ["a"]
+
 
 # ── getIndex still works (existing API) ────────────────────────────────
 


### PR DESCRIPTION
## Summary

- `_resolve_compat` did not understand the ``portal_setup``-tool context that ``UpgradeStep.doStep`` hands to upgrade handlers (it only understood the ``ImportContext`` shape with ``getSite()``), so the normal ZMI ``manage_upgrades`` button silently hit ``"migrate_catalog_indexes: no _CatalogCompat found; skipping"`` while GenericSetup still bumped the profile version to 2. Production sites ended up running the new code against unmigrated persisted state.
- The unmigrated ``_CatalogCompat`` then raised ``AttributeError`` inside the new ``indexes`` property (no ``_raw_indexes``), which Acquisition swallowed and replaced with the tool's ``indexes()`` method — observed as ``'function' object has no attribute 'keys'`` at [catalog.py:287](https://github.com/bluedynamics/plone-pgcatalog/blob/fix/catalog-indexes-upgrade-resolve/src/plone/pgcatalog/catalog.py#L287) (plone.app.content folder contents) and ``'method' object is not subscriptable`` at ``plone.app.vocabularies.catalog:501`` (Tagging widget).
- Proven on aaf-prod: ``SELECT jsonb_object_keys(state) FROM object_state WHERE zoid=66615937`` still returns ``{schema, indexes}`` even though ``portal_setup`` reports the profile at v2.

## Fixes

1. ``_resolve_compat`` now additionally walks ``aq_parent(context)`` to reach the Plone site when the context is the setup tool. Existing ImportContext path preserved.
2. ``_CatalogCompat.indexes`` is now self-healing: if ``_raw_indexes`` is missing but legacy ``indexes`` sits in ``__dict__``, the property migrates it in place on first read and marks the instance dirty. This protects fresh-install sites where GS never runs a v1->v2 step.

Both fixes are orthogonal — either alone would prevent the observed traceback.

## Test plan

- [x] New regression tests covering both paths:
  - ``TestProfileUpgradeV1ToV2.test_migrate_from_portal_setup_tool_context`` — fails on ``main`` with the exact log warning ``"no _CatalogCompat found; skipping"``, passes with this fix.
  - ``TestPropertySelfHealsLegacyState.test_tool_indexes_method_works_on_unmigrated_compat`` — reproduces the exact production traceback against an unmigrated compat, passes with this fix.
- [x] Full suite: 1382 passed, 23 skipped on a clean ``zodb_test`` DB.
- [ ] After merge + release + deploy, re-verify aaf-prod: DB state for zoid 66615937 should flip to ``{schema, _raw_indexes, __parent__}`` on first access, and the ZMI folder_contents view + Tagging widget should render without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)