### PR TITLE
fix(brain): unrestricted-traverse parent, restricted only on leaf (#141)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 1.0.0b57
+
+### Fixed
+
+- ``PGCatalogBrain.getObject()`` now mirrors upstream
+  ``Products.ZCatalog.CatalogBrains.AbstractCatalogBrain.getObject``:
+  the parent path is traversed *unrestricted* and only the final
+  object is ``restrictedTraverse``-checked.  Previously the full
+  path went through ``restrictedTraverse``, so any intermediate
+  container with stricter permissions than the leaf raised
+  ``AccessControl.unauthorized.Unauthorized`` — even though the
+  catalog filter had already authorized access to the target.
+  Sites with a private parent folder publishing individual public
+  items (the common "kalender/event-xyz" pattern) hit this on every
+  anonymous render.  Closes #141.
+
 ## 1.0.0b56
 
 ### Fixed

--- a/src/plone/pgcatalog/brain.py
+++ b/src/plone/pgcatalog/brain.py
@@ -87,12 +87,29 @@ class PGCatalogBrain:
 
         Requires a catalog with traversal support (Phase 6 integration).
         Returns None if the object cannot be found.
+
+        Mirrors upstream ``Products.ZCatalog.CatalogBrains.AbstractCatalogBrain``
+        semantics: the catalog filter already authorized access to the
+        target object, so intermediate containers are traversed
+        unrestricted; only the leaf is permission-checked.  Without this
+        split, sites with a restricted parent folder (common pattern —
+        e.g. an internal calendar container publishing public events)
+        raise ``Unauthorized`` on the parent even though the user is
+        allowed to see the target.
         """
         if self._catalog is None:
             return None
         self._maybe_prefetch()
+        path = self.getPath().split("/")
+        if not path:
+            return None
         try:
-            return self._catalog.restrictedTraverse(self.getPath())
+            parent = (
+                self._catalog.unrestrictedTraverse(path[:-1])
+                if len(path) > 1
+                else self._catalog
+            )
+            return parent.restrictedTraverse(path[-1])
         except (KeyError, AttributeError):
             return None
 

--- a/tests/test_brain.py
+++ b/tests/test_brain.py
@@ -61,21 +61,86 @@ class TestBrainBasics:
         assert brain.getObject() is None
 
     def test_get_object_with_catalog(self):
+        """getObject traverses the parent unrestricted and the leaf restricted.
+
+        Matches upstream ``AbstractCatalogBrain.getObject``: the catalog
+        filter already authorized access to the target, so intermediate
+        containers are bypassed — only the final object is permission-
+        checked.
+        """
         from unittest import mock
 
         obj = mock.Mock()
+        parent = mock.Mock()
+        parent.restrictedTraverse.return_value = obj
         catalog = mock.Mock()
-        catalog.restrictedTraverse.return_value = obj
-        brain = PGCatalogBrain(_make_row(path="/plone/doc"), catalog=catalog)
+        catalog.unrestrictedTraverse.return_value = parent
+        brain = PGCatalogBrain(
+            _make_row(path="/plone/kalender/event-xyz"), catalog=catalog
+        )
+
+        assert brain.getObject() is obj
+        catalog.unrestrictedTraverse.assert_called_once_with(["", "plone", "kalender"])
+        parent.restrictedTraverse.assert_called_once_with("event-xyz")
+
+    def test_get_object_restricted_only_on_leaf(self):
+        """Regression for #141 — parent folder with stricter permissions.
+
+        Production symptom:
+            AccessControl.unauthorized.Unauthorized: You are not allowed
+            to access 'kalender' in this context
+
+        A common Plone pattern is to have a restricted parent container
+        (e.g. ``kalender/``) that publishes individual public items.
+        The catalog filter already authorized the leaf, so traversal
+        must not re-check the parent.
+        """
+        from AccessControl.unauthorized import Unauthorized
+        from unittest import mock
+
+        obj = mock.Mock()
+        parent = mock.Mock()
+        parent.restrictedTraverse.return_value = obj
+        catalog = mock.Mock()
+        # restrictedTraverse on the parent path would raise Unauthorized
+        # — the buggy implementation called restrictedTraverse on the
+        # full path, which bubbles through ``kalender``.
+        catalog.restrictedTraverse.side_effect = Unauthorized(
+            "You are not allowed to access 'kalender'"
+        )
+        catalog.unrestrictedTraverse.return_value = parent
+        brain = PGCatalogBrain(
+            _make_row(path="/plone/kalender/event-xyz"), catalog=catalog
+        )
+
+        # Must succeed — parent traversal is unrestricted.
         assert brain.getObject() is obj
 
     def test_get_object_traversal_error(self):
         from unittest import mock
 
         catalog = mock.Mock()
-        catalog.restrictedTraverse.side_effect = KeyError("not found")
+        catalog.unrestrictedTraverse.side_effect = KeyError("not found")
         brain = PGCatalogBrain(_make_row(path="/plone/doc"), catalog=catalog)
         assert brain.getObject() is None
+
+    def test_get_object_site_root_path(self):
+        """Path ``/plone`` splits to ``['', 'plone']`` — site root is the
+        "parent" (traversed unrestricted to ``['']``), leaf is ``plone``
+        (restricted).  Matches upstream ZCatalog semantics.
+        """
+        from unittest import mock
+
+        obj = mock.Mock()
+        root = mock.Mock()
+        root.restrictedTraverse.return_value = obj
+        catalog = mock.Mock()
+        catalog.unrestrictedTraverse.return_value = root
+        brain = PGCatalogBrain(_make_row(path="/plone"), catalog=catalog)
+
+        assert brain.getObject() is obj
+        catalog.unrestrictedTraverse.assert_called_once_with([""])
+        root.restrictedTraverse.assert_called_once_with("plone")
 
     def test_unrestricted_get_object_without_catalog(self):
         brain = PGCatalogBrain(_make_row())


### PR DESCRIPTION
## Summary

Production symptom (anonymous users on aaf-prod):

\`\`\`
AccessControl.unauthorized.Unauthorized: You are not allowed to access 'kalender' in this context
  File \".../plone/pgcatalog/brain.py\", line 95, in getObject
    return self._catalog.restrictedTraverse(self.getPath())
\`\`\`

Distinct unauthorized parent segments observed on prod: \`kalender\`, \`fotos\`.

\`PGCatalogBrain.getObject()\` used \`restrictedTraverse\` on the full path. Any intermediate container with stricter permissions than the leaf raised \`Unauthorized\` even though the catalog query (filtered on \`allowedRolesAndUsers\`) had already authorized access to the target.

## Fix

Match the upstream semantics of \`Products.ZCatalog.CatalogBrains.AbstractCatalogBrain.getObject\`:

- \`unrestrictedTraverse(path[:-1])\` to reach the parent container,
- \`restrictedTraverse(path[-1])\` only on the leaf name.

The catalog filter is the authoritative source of authorization; parent traversal is a bypass.

## Test plan

- [x] New regression test \`TestBrainBasics.test_get_object_restricted_only_on_leaf\` — fails on \`main\` with the exact \`Unauthorized('kalender')\` pattern, passes with this fix.
- [x] Existing tests updated to reflect the new call pattern (unrestricted parent, restricted leaf).
- [x] Full unit suite: 60 brain tests pass, 1384 total pass / 0 fail.
- [ ] After deploy, re-verify aaf-prod: anonymous \`@@aaf.tiles.sidecalendar\`, \`@@aaf.tiles.pins.masonry\` should render without \`Unauthorized\` subrequest errors.

Note: this is unrelated to the \`TypeError: keywords must be strings\` in \`plone.app.querystring.querybuilder._makequery\` — that one is an upstream Plone issue where \`queryparser.parseFormquery\` sets \`query[None] = value\` for malformed form rows (no \`"i"\` field). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)