### PR TITLE
fix(querymodifier): drop malformed rows before parseFormquery (#142)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 1.0.0b58
+
+### Fixed
+
+- Register ``SanitizeRowsModifier`` as an ``IQueryModifier`` utility so
+  that malformed Collection-query rows (missing or non-string ``i``
+  field) are dropped before ``plone.app.querystring.parseFormquery``
+  processes them.  Upstream ``queryparser.py:73`` otherwise sets
+  ``query[None] = ...`` and the subsequent ``catalog(**parsedquery)``
+  in ``querybuilder._makequery`` fails at the Python level with
+  ``TypeError: keywords must be strings`` — which the Collection edit
+  widget cannot recover from.  With the sanitizer in place the
+  preview renders again, so editors can open their Collections and
+  repair corrupted ``Subject`` / tag data through the UI.
+
+  This is a defensive workaround for an upstream gotcha, not a fix for
+  the underlying ``plone.app.querystring`` behavior.  Closes #142.
+
 ## 1.0.0b57
 
 ### Fixed

--- a/src/plone/pgcatalog/configure.zcml
+++ b/src/plone/pgcatalog/configure.zcml
@@ -39,6 +39,16 @@
       handler=".pool.release_request_connection"
       />
 
+  <!-- Filter malformed query rows (missing/None/non-string 'i') before
+       plone.app.querystring.parseFormquery turns them into a
+       parsedquery[None]=... entry that breaks catalog(**kw).  See
+       src/plone/pgcatalog/querymodifier.py for the full rationale. -->
+  <utility
+      factory=".querymodifier.SanitizeRowsModifier"
+      provides="plone.app.querystring.interfaces.IQueryModifier"
+      name="plone.pgcatalog.sanitize_rows"
+      />
+
   <!-- GenericSetup profile upgrade steps -->
   <include package=".upgrades" />
 

--- a/src/plone/pgcatalog/querymodifier.py
+++ b/src/plone/pgcatalog/querymodifier.py
@@ -1,0 +1,62 @@
+"""IQueryModifier that drops malformed rows before ``parseFormquery``.
+
+``plone.app.querystring.queryparser.parseFormquery`` does
+``row.get("i", None)`` and then sets ``query[row.index] = value`` — so a
+row without an ``i`` field produces a ``parsedquery[None] = ...`` entry.
+The downstream ``catalog(**parsedquery)`` in
+``plone.app.querystring.querybuilder._makequery`` then fails at the
+Python level with ``TypeError: keywords must be strings`` before any
+catalog code runs.
+
+This is an upstream Plone gotcha, not a pgcatalog bug — but under
+pgcatalog it became the visible failure mode for editors trying to
+repair their own Subject/tag fields via the Collection edit widget
+(stored-query corruption from the earlier compat issues).  Filtering
+incomplete rows here unblocks the UI so content can be fixed
+editorially.
+
+Registered as an ``IQueryModifier`` utility with a stable name so it
+runs deterministically in the modifier chain (``_makequery`` sorts by
+name).
+"""
+
+from plone.app.querystring.interfaces import IQueryModifier
+from zope.interface import implementer
+
+import logging
+
+
+log = logging.getLogger(__name__)
+
+
+@implementer(IQueryModifier)
+class SanitizeRowsModifier:
+    """Drop query rows whose ``i`` (index name) is missing or non-string.
+
+    Operates on the raw form-query (list of row dicts or Zope
+    ``HTTPRequest.record`` instances) that ``_makequery`` hands to its
+    modifier chain before ``parseFormquery``.  Non-list inputs are
+    returned untouched.
+    """
+
+    def __call__(self, query):
+        if not isinstance(query, (list, tuple)):
+            return query
+
+        clean = []
+        dropped = 0
+        for row in query:
+            index = row.get("i") if hasattr(row, "get") else None
+            if isinstance(index, str) and index:
+                clean.append(row)
+            else:
+                dropped += 1
+
+        if dropped:
+            log.warning(
+                "SanitizeRowsModifier: dropped %d query row(s) without valid "
+                "'i' field (upstream plone.app.querystring gotcha — would "
+                "have produced parsedquery[None]=...)",
+                dropped,
+            )
+        return clean if isinstance(query, list) else tuple(clean)

--- a/tests/test_query_modifier.py
+++ b/tests/test_query_modifier.py
@@ -1,0 +1,112 @@
+"""Tests for SanitizeRowsModifier.
+
+Registered as an IQueryModifier so that collection edit previews
+(``@@querybuilder_html_results``) survive rows missing the ``i``
+(index) field.  Without this filter, ``queryparser.parseFormquery``
+populates ``parsedquery[None] = ...`` and the subsequent
+``catalog(**parsedquery)`` call in ``plone.app.querystring`` fails at
+the Python level with ``TypeError: keywords must be strings`` — which
+tools like the Collection edit widget cannot recover from, blocking
+editorial fixes.  See README #142.
+"""
+
+from plone.pgcatalog.querymodifier import SanitizeRowsModifier
+
+
+class TestSanitizeRowsModifier:
+    def test_drops_row_without_i(self):
+        mod = SanitizeRowsModifier()
+        query = [
+            {"i": "portal_type", "o": "...selection.any", "v": ["Event"]},
+            {"o": "...selection.any", "v": ["AT26"]},  # missing i
+            {"i": "review_state", "o": "...selection.any", "v": ["published"]},
+        ]
+        assert mod(query) == [
+            {"i": "portal_type", "o": "...selection.any", "v": ["Event"]},
+            {"i": "review_state", "o": "...selection.any", "v": ["published"]},
+        ]
+
+    def test_drops_row_with_i_none(self):
+        mod = SanitizeRowsModifier()
+        query = [
+            {"i": None, "o": "op", "v": "x"},
+            {"i": "portal_type", "o": "op", "v": ["Event"]},
+        ]
+        assert mod(query) == [
+            {"i": "portal_type", "o": "op", "v": ["Event"]},
+        ]
+
+    def test_drops_row_with_i_empty_string(self):
+        mod = SanitizeRowsModifier()
+        query = [
+            {"i": "", "o": "op", "v": "x"},
+            {"i": "portal_type", "o": "op", "v": ["Event"]},
+        ]
+        assert mod(query) == [
+            {"i": "portal_type", "o": "op", "v": ["Event"]},
+        ]
+
+    def test_drops_row_with_non_string_i(self):
+        mod = SanitizeRowsModifier()
+        query = [
+            {"i": 1, "o": "op", "v": "x"},
+            {"i": b"portal_type", "o": "op", "v": ["Event"]},
+        ]
+        assert mod(query) == []
+
+    def test_passes_through_clean_query(self):
+        mod = SanitizeRowsModifier()
+        query = [
+            {"i": "portal_type", "o": "op", "v": ["Event"]},
+            {"i": "path", "o": "op", "v": "/Plone/"},
+        ]
+        assert mod(query) == query
+
+    def test_handles_none_query(self):
+        mod = SanitizeRowsModifier()
+        assert mod(None) is None
+
+    def test_handles_empty_query(self):
+        mod = SanitizeRowsModifier()
+        assert mod([]) == []
+
+    def test_handles_non_list_query_unchanged(self):
+        """Some callers pass dicts or tuples — pass them through unchanged."""
+        mod = SanitizeRowsModifier()
+        query = {"not_a_list": True}
+        assert mod(query) == query
+
+    def test_records_are_wrapped_by_publisher_as_dict_like(self):
+        """Zope's ``:records`` marshalling returns ``HTTPRequest.record``
+        instances, not plain dicts.  They behave like dicts (supports
+        ``.get()``) but aren't ``dict`` instances.
+        """
+
+        class FakeRecord:
+            def __init__(self, data):
+                self._data = data
+
+            def get(self, key, default=None):
+                return self._data.get(key, default)
+
+            def __eq__(self, other):
+                return isinstance(other, FakeRecord) and self._data == other._data
+
+        good = FakeRecord({"i": "portal_type", "v": ["Event"]})
+        bad = FakeRecord({"v": ["AT26"]})
+
+        mod = SanitizeRowsModifier()
+        result = mod([good, bad])
+        assert result == [good]
+
+
+class TestRegistration:
+    def test_modifier_is_registered_as_utility(self, pgcatalog_layer):
+        from plone.app.querystring.interfaces import IQueryModifier
+        from zope.component import getUtilitiesFor
+
+        utilities = dict(getUtilitiesFor(IQueryModifier))
+        assert "plone.pgcatalog.sanitize_rows" in utilities
+        assert isinstance(
+            utilities["plone.pgcatalog.sanitize_rows"], SanitizeRowsModifier
+        )


### PR DESCRIPTION
## Summary

Production symptom on aaf-prod, after the #137/#139/#141 fixes landed:

\`\`\`
File ".../plone/app/querystring/querybuilder.py", line 236, in _makequery
    results = catalog(**parsedquery)
TypeError: keywords must be strings
\`\`\`

Hit only on Collection edit-widget preview (\`@@querybuilder_html_results\`). The stored query for the affected Collection is clean, but the edit form submits in-flight form data — any row missing the \`i\` (index) field gets dropped into \`parsedquery[None] = ...\` by \`plone.app.querystring.queryparser.parseFormquery:73\`, and Python refuses to unpack a non-string key with \`**\`.

Before the earlier pgcatalog fixes the compat was broken further upstream, so this failure mode was masked. Now that indexes work correctly, the upstream gotcha surfaces. It also blocks editors from re-entering corrupted Subject/tag values via the Collection edit widget — the preview rendering for that widget is exactly what dies.

## Fix

Register \`SanitizeRowsModifier\` as an \`IQueryModifier\` utility:

- Runs before \`parseFormquery\`.
- Drops rows where \`i\` is missing, \`None\`, non-string, or empty.
- Passes clean rows through unchanged.
- Logs a warning on drop.

With this in place, the Collection edit widget renders again and editors can repair data through the UI.

This is a **defensive workaround** for an upstream \`plone.app.querystring\` behavior, not a fix for the underlying parser. An upstream fix should also reject \`row.index is None\` in \`queryparser.py\`.

## Test plan

- [x] Unit tests for the modifier — drops rows with missing/None/empty/non-string \`i\`, passes clean queries through, handles \`None\`/empty/non-list inputs, handles Zope \`HTTPRequest.record\` dict-likes.
- [x] Registration test — asserts the utility is registered under \`plone.pgcatalog.sanitize_rows\` with the PGCatalog integration layer loaded.
- [x] Full suite: 1394 passed, 23 skipped.
- [ ] After deploy, re-verify aaf-prod: anonymous/authenticated renders of \`@@querybuilder_html_results\` complete without \`TypeError: keywords must be strings\`, and the Collection edit widget preview renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)