### PR TITLE
fix(pgindex): expand KeywordIndex uniqueValues via jsonb_array_elements_text (#143)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 1.0.0b59
+
+### Fixed
+
+- ``PGIndex.uniqueValues()`` now branches on the wrapped index type.
+  For ``IndexType.KEYWORD`` the JSONB value is a list of tags, so the
+  SQL uses ``jsonb_array_elements_text`` to expand it into individual
+  entries.  Previously all index types went through ``idx->>key``,
+  which coerces a JSONB array to its JSON text representation —
+  producing entries like ``'["Werkvortrag", "Tirol"]'`` instead of
+  ``'Werkvortrag'`` / ``'Tirol'``.  Callers (the querystring
+  composer vocabulary, ``plone.app.vocabularies.Keywords``,
+  ``collective.collectionfilter`` tag clouds, etc.) now see the
+  distinct set of elements as expected.
+
+  A defensive ``UNION ALL`` branch treats a scalar row under the
+  same keyword key (corrupt/legacy data) as a single-value keyword
+  so the query does not raise ``cannot extract elements from a
+  scalar``.  ``_maybe_wrap_index`` passes the registered
+  ``IndexType`` through to ``PGIndex`` so callers that build the
+  wrapper directly keep getting the (correct) scalar path by
+  default.
+
+  Closes #143.
+
 ## 1.0.0b58
 
 ### Fixed

--- a/src/plone/pgcatalog/pgindex.py
+++ b/src/plone/pgcatalog/pgindex.py
@@ -22,6 +22,7 @@ matching ``getpath()``/``getrid()`` on the catalog.
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from plone.pgcatalog.columns import get_registry
+from plone.pgcatalog.columns import IndexType
 from plone.pgcatalog.interfaces import IPGCatalogTool
 from plone.pgcatalog.query import _bool_to_lower_str
 from Products.ZCatalog.ZCatalogIndexes import ZCatalogIndexes
@@ -85,9 +86,10 @@ class PGIndex:
     with PostgreSQL queries on the ``idx`` JSONB column.
     """
 
-    def __init__(self, wrapped, idx_key, get_conn):
+    def __init__(self, wrapped, idx_key, get_conn, index_type=None):
         self._wrapped = wrapped
         self._idx_key = idx_key
+        self._index_type = index_type
         self._pg_index = _PGIndexMapping(idx_key, get_conn)
 
     @property
@@ -95,6 +97,19 @@ class PGIndex:
         return self._pg_index
 
     def uniqueValues(self, name=None, withLengths=False):
+        """Return the distinct values of this index.
+
+        For ``IndexType.KEYWORD`` the JSONB value is a *list* of tags,
+        so the implementation expands the array with
+        ``jsonb_array_elements_text`` — otherwise ``idx->>key`` coerces
+        the array to its JSON text representation and callers (the
+        querybuilder vocabulary, tag-cloud widgets, ...) see entries
+        like ``'["a","b"]'`` instead of ``'a'`` and ``'b'``.  See #143.
+
+        A defensive ``CASE jsonb_typeof = 'array'`` branch keeps the
+        query alive if a single row holds a scalar under the same
+        keyword key (legacy/corrupted data).
+        """
         index_id = getattr(self._wrapped, "id", self._idx_key)
         if name is None:
             name = index_id
@@ -107,24 +122,50 @@ class PGIndex:
             return
 
         key = self._idx_key
+        params = {"key": key}
+
+        if self._index_type == IndexType.KEYWORD:
+            # ``jsonb_array_elements_text`` is a set-returning function
+            # and can't appear inside a ``CASE`` expression (Postgres
+            # raises 0A000), so the defensive array/scalar split is
+            # expressed as a ``UNION ALL`` subquery.  Array rows expand
+            # one row per element; a legacy scalar row yields itself.
+            inner = (
+                "SELECT jsonb_array_elements_text(idx->%(key)s) AS val "
+                "  FROM object_state "
+                "  WHERE idx ? %(key)s "
+                "    AND jsonb_typeof(idx->%(key)s) = 'array' "
+                "UNION ALL "
+                "SELECT idx->>%(key)s AS val "
+                "  FROM object_state "
+                "  WHERE idx ? %(key)s "
+                "    AND jsonb_typeof(idx->%(key)s) NOT IN ('array', 'null')"
+            )
+            distinct_sql = f"SELECT DISTINCT val FROM ({inner}) u WHERE val IS NOT NULL"
+            grouped_sql = (
+                f"SELECT val, COUNT(*) AS cnt FROM ({inner}) u "
+                "WHERE val IS NOT NULL GROUP BY val"
+            )
+        else:
+            distinct_sql = (
+                "SELECT DISTINCT idx->>%(key)s AS val "
+                "FROM object_state "
+                "WHERE idx ? %(key)s AND idx->>%(key)s IS NOT NULL"
+            )
+            grouped_sql = (
+                "SELECT idx->>%(key)s AS val, COUNT(*) AS cnt "
+                "FROM object_state "
+                "WHERE idx ? %(key)s AND idx->>%(key)s IS NOT NULL "
+                "GROUP BY 1"
+            )
+
         with conn.cursor() as cur:
             if not withLengths:
-                cur.execute(
-                    "SELECT DISTINCT idx->>%(key)s AS val "
-                    "FROM object_state "
-                    "WHERE idx ? %(key)s AND idx->>%(key)s IS NOT NULL",
-                    {"key": key},
-                )
+                cur.execute(distinct_sql, params)
                 for row in cur.fetchall():
                     yield row["val"]
             else:
-                cur.execute(
-                    "SELECT idx->>%(key)s AS val, COUNT(*) AS cnt "
-                    "FROM object_state "
-                    "WHERE idx ? %(key)s AND idx->>%(key)s IS NOT NULL "
-                    "GROUP BY 1",
-                    {"key": key},
-                )
+                cur.execute(grouped_sql, params)
                 for row in cur.fetchall():
                     yield (row["val"], row["cnt"])
 
@@ -154,14 +195,21 @@ def _maybe_wrap_index(catalog, name, raw_index):
 
     registry = get_registry()
     entry = registry.get(name)
+    index_type = None
     if entry is not None:
+        index_type = entry[0]
         idx_key = entry[1]  # (IndexType, idx_key, source_attrs)
         if idx_key is None:
             return raw_index  # Special index — no wrapping needed
     else:
         idx_key = name  # Fallback: use index name as JSONB key
 
-    return PGIndex(raw_index, idx_key, catalog._get_pg_read_connection)
+    return PGIndex(
+        raw_index,
+        idx_key,
+        catalog._get_pg_read_connection,
+        index_type=index_type,
+    )
 
 
 class PGCatalogIndexes(ZCatalogIndexes):

--- a/tests/test_pgindex.py
+++ b/tests/test_pgindex.py
@@ -167,6 +167,137 @@ class TestPGIndex:
 
 
 # ---------------------------------------------------------------------------
+# KeywordIndex-specific uniqueValues behavior (#143)
+# ---------------------------------------------------------------------------
+
+
+def _catalog_keyword_objects(conn):
+    """Insert three docs with an array-valued ``Subject`` (KeywordIndex)."""
+    objects = {
+        200: {
+            "path": "/plone/tag-doc-1",
+            "idx": {
+                "portal_type": "Document",
+                "Subject": ["Werkvortrag", "Tirol", "Aktuelles"],
+            },
+        },
+        201: {
+            "path": "/plone/tag-doc-2",
+            "idx": {
+                "portal_type": "Document",
+                "Subject": ["Tirol", "AUSSCHREIBUNG"],
+            },
+        },
+        202: {
+            "path": "/plone/tag-doc-3",
+            "idx": {
+                "portal_type": "Folder",
+                "Subject": ["Aktuelles"],
+            },
+        },
+    }
+    for zoid, data in objects.items():
+        insert_object(conn, zoid)
+        catalog_object(conn, zoid=zoid, path=data["path"], idx=data["idx"])
+    conn.commit()
+    return objects
+
+
+class TestPGIndexKeyword:
+    """Regression tests for #143 — KeywordIndex must expose individual
+    keywords, not serialized JSON arrays, in ``uniqueValues()``.
+    """
+
+    def _make_keyword_pg_index(self, idx_key, get_conn):
+        from plone.pgcatalog.columns import IndexType
+        from plone.pgcatalog.pgindex import PGIndex
+
+        wrapped = mock.Mock()
+        wrapped.id = idx_key
+        return PGIndex(wrapped, idx_key, get_conn, index_type=IndexType.KEYWORD)
+
+    def test_keyword_unique_values_returns_individual_tags(self, pg_conn_with_catalog):
+        _catalog_keyword_objects(pg_conn_with_catalog)
+        idx = self._make_keyword_pg_index("Subject", lambda: pg_conn_with_catalog)
+
+        values = set(idx.uniqueValues())
+
+        assert values == {"Werkvortrag", "Tirol", "Aktuelles", "AUSSCHREIBUNG"}
+        for v in values:
+            assert not v.startswith("[")
+
+    def test_keyword_unique_values_with_lengths_counts_elements(
+        self, pg_conn_with_catalog
+    ):
+        _catalog_keyword_objects(pg_conn_with_catalog)
+        idx = self._make_keyword_pg_index("Subject", lambda: pg_conn_with_catalog)
+
+        result = dict(idx.uniqueValues(withLengths=True))
+
+        assert result == {
+            "Werkvortrag": 1,
+            "Tirol": 2,
+            "Aktuelles": 2,
+            "AUSSCHREIBUNG": 1,
+        }
+
+    def test_keyword_unique_values_survives_mixed_scalar_row(
+        self, pg_conn_with_catalog
+    ):
+        """Defensive branch: if some row's idx->'Subject' is a scalar
+        (corrupted legacy state) the query must not crash —
+        ``jsonb_array_elements_text`` would otherwise raise
+        ``cannot extract elements from a scalar``.  Treat the scalar as
+        a single-element "pseudo-keyword" to keep the query going.
+        """
+        _catalog_keyword_objects(pg_conn_with_catalog)
+        insert_object(pg_conn_with_catalog, 203)
+        catalog_object(
+            pg_conn_with_catalog,
+            zoid=203,
+            path="/plone/legacy-scalar",
+            idx={"portal_type": "Document", "Subject": "Legacy"},
+        )
+        pg_conn_with_catalog.commit()
+
+        idx = self._make_keyword_pg_index("Subject", lambda: pg_conn_with_catalog)
+
+        values = set(idx.uniqueValues())
+
+        assert "Legacy" in values
+        assert "Tirol" in values
+
+    def test_scalar_field_index_still_returns_scalars(self, pg_conn_with_catalog):
+        """Regression guard: FieldIndex-backed uniqueValues must keep
+        returning the scalar values (not wrapped in arrays).
+        """
+        _catalog_keyword_objects(pg_conn_with_catalog)
+        from plone.pgcatalog.columns import IndexType
+        from plone.pgcatalog.pgindex import PGIndex
+
+        wrapped = mock.Mock()
+        wrapped.id = "portal_type"
+        idx = PGIndex(
+            wrapped,
+            "portal_type",
+            lambda: pg_conn_with_catalog,
+            index_type=IndexType.FIELD,
+        )
+        assert set(idx.uniqueValues()) == {"Document", "Folder"}
+
+    def test_default_index_type_is_scalar(self, pg_conn_with_catalog):
+        """PGIndex without an explicit ``index_type`` keeps the
+        pre-#143 scalar SQL path.  Preserves behavior for any caller
+        that builds PGIndex directly without specifying the type.
+        """
+        _catalog_objects(pg_conn_with_catalog)
+        wrapped = mock.Mock()
+        wrapped.id = "portal_type"
+        idx = PGIndex(wrapped, "portal_type", lambda: pg_conn_with_catalog)
+        assert set(idx.uniqueValues()) == {"Document", "Folder"}
+
+
+# ---------------------------------------------------------------------------
 # PlonePGCatalogTool.getpath / .getrid / .Indexes integration tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`PGIndex.uniqueValues()` used `idx->>key` for every wrapped index. For `KeywordIndex` the JSONB value is a list of tags, so that SQL coerced it to its JSON text representation — callers saw entries like `'["Werkvortrag", "Tirol"]'` instead of `'Werkvortrag'` / `'Tirol'`.

User-visible fallout (aaf-prod, post-b55 verification):

- Querystring-composer `Schlagwort` autocomplete offered serialized-array strings; picking one produced an impossible query and returned 0 results.
- `plone.app.vocabularies.Keywords`, `plone.app.querystring.registryreader`, tag clouds, `collective.collectionfilter` — all iterate `catalog.Indexes["<keyword>"].uniqueValues()` and therefore all affected.

Pre-b55 the failure was masked because `_catalog.indexes` returned raw ZCatalog indexes with empty BTrees; `uniqueValues()` returned empty rather than wrong. Once the wrapper started firing, the SQL bug became visible.

## Fix

- `PGIndex.__init__` accepts an optional `index_type` (defaults to `None`, preserving the scalar path).
- `_maybe_wrap_index` pulls `IndexType` from the registry entry and forwards it.
- For `IndexType.KEYWORD` the SQL uses a `UNION ALL` subquery so array rows expand via `jsonb_array_elements_text` and any legacy scalar row under the same key still yields itself. `jsonb_array_elements_text` is a set-returning function and can't appear inside a `CASE` expression (Postgres raises `0A000`), hence the union.
- Scalar indexes keep the original `idx->>key` path.

## Test plan

- [x] New regression tests:
  - `test_keyword_unique_values_returns_individual_tags` — distinct keywords, not serialized arrays.
  - `test_keyword_unique_values_with_lengths_counts_elements` — `{Tirol: 2, Aktuelles: 2, Werkvortrag: 1, AUSSCHREIBUNG: 1}`.
  - `test_keyword_unique_values_survives_mixed_scalar_row` — legacy scalar row under `Subject` doesn't crash the query.
  - `test_scalar_field_index_still_returns_scalars` + `test_default_index_type_is_scalar` — regression guards for the FieldIndex path.
- [x] Full suite: 1399 passed / 23 skipped / 0 failed.
- [ ] After deploy, re-verify aaf-prod: querystring-composer `Schlagwort` autocomplete offers individual tag values; tag clouds show single-keyword entries instead of JSON arrays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)