### PR TITLE
fix(pgindex): make _PGIndexMapping iterable and keyword-aware (#143 follow-up)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 1.0.0b60
+
+### Fixed
+
+- ``_PGIndexMapping`` (backing ``PGIndex._index``) is now iterable and
+  branches its SQL on the index type.  ``plone.app.vocabularies.Keywords``
+  iterates ``index._index`` directly to populate the tag-autocomplete
+  widget in the Plone edit form — the previous mapping had no
+  ``__iter__`` and its ``keys()`` coerced JSONB arrays to their text
+  representation.  Net effect on b59: typing into the ``Schlagwort``
+  field offered zero suggestions even when matching keywords existed.
+  ``keys()`` / ``__iter__`` now use the same ``UNION ALL`` expansion as
+  ``uniqueValues`` for KEYWORD, and ``get()`` uses ``idx->key @>
+  to_jsonb(value::text)`` so membership checks against a keyword
+  actually match.  Follow-up to #143.
+
 ## 1.0.0b59
 
 ### Fixed

--- a/src/plone/pgcatalog/pgindex.py
+++ b/src/plone/pgcatalog/pgindex.py
@@ -40,24 +40,38 @@ class _PGIndexMapping:
 
     Translates ``_index.get(value)`` into a PG query on the ``idx``
     JSONB column.  Returns ZOID as the record ID.
+
+    ``plone.app.vocabularies.Keywords.all_keywords`` iterates
+    ``index._index`` directly and feeds the values into
+    ``safe_simplevocabulary_from_values`` for the tag-autocomplete
+    widget — so the mapping must be iterable and, for KeywordIndex,
+    yield individual keywords instead of the JSON-text representation
+    of the whole array.
     """
 
-    __slots__ = ("_get_conn", "_idx_key")
+    __slots__ = ("_get_conn", "_idx_key", "_index_type")
 
-    def __init__(self, idx_key, get_conn):
+    def __init__(self, idx_key, get_conn, index_type=None):
         self._idx_key = idx_key
         self._get_conn = get_conn
+        self._index_type = index_type
 
     def get(self, value, default=None):
         try:
             conn = self._get_conn()
         except Exception:
             return default
-        with conn.cursor() as cur:
-            cur.execute(
-                "SELECT zoid FROM object_state WHERE idx->>%(key)s = %(val)s LIMIT 1",
-                {"key": self._idx_key, "val": _bool_to_lower_str(value)},
+        if self._index_type == IndexType.KEYWORD:
+            sql = (
+                "SELECT zoid FROM object_state "
+                "WHERE idx->%(key)s @> to_jsonb(%(val)s::text) LIMIT 1"
             )
+            params = {"key": self._idx_key, "val": value}
+        else:
+            sql = "SELECT zoid FROM object_state WHERE idx->>%(key)s = %(val)s LIMIT 1"
+            params = {"key": self._idx_key, "val": _bool_to_lower_str(value)}
+        with conn.cursor() as cur:
+            cur.execute(sql, params)
             row = cur.fetchone()
         return row["zoid"] if row else default
 
@@ -69,13 +83,40 @@ class _PGIndexMapping:
             conn = self._get_conn()
         except Exception:
             return []
-        with conn.cursor() as cur:
-            cur.execute(
-                "SELECT DISTINCT idx->>%(key)s AS val FROM object_state "
-                "WHERE idx ? %(key)s AND idx->>%(key)s IS NOT NULL",
-                {"key": self._idx_key},
+        if self._index_type == IndexType.KEYWORD:
+            # See PGIndex.uniqueValues for the ``UNION ALL`` rationale.
+            sql = (
+                "SELECT DISTINCT val FROM ("
+                "  SELECT jsonb_array_elements_text(idx->%(key)s) AS val "
+                "    FROM object_state "
+                "    WHERE idx ? %(key)s "
+                "      AND jsonb_typeof(idx->%(key)s) = 'array' "
+                "  UNION ALL "
+                "  SELECT idx->>%(key)s AS val "
+                "    FROM object_state "
+                "    WHERE idx ? %(key)s "
+                "      AND jsonb_typeof(idx->%(key)s) NOT IN ('array', 'null') "
+                ") u WHERE val IS NOT NULL"
             )
+        else:
+            sql = (
+                "SELECT DISTINCT idx->>%(key)s AS val FROM object_state "
+                "WHERE idx ? %(key)s AND idx->>%(key)s IS NOT NULL"
+            )
+        with conn.cursor() as cur:
+            cur.execute(sql, {"key": self._idx_key})
             return [row["val"] for row in cur.fetchall()]
+
+    def __iter__(self):
+        """Iterate over distinct values.
+
+        Matches ZCatalog's ``Index._index`` iteration shape: for a
+        FieldIndex / UUIDIndex the underlying OOBTree yields value
+        keys; for a KeywordIndex the OOBTree yields keyword keys.
+        The ``plone.app.vocabularies.Keywords`` vocabulary depends
+        on this.
+        """
+        return iter(self.keys())
 
 
 class PGIndex:
@@ -90,7 +131,7 @@ class PGIndex:
         self._wrapped = wrapped
         self._idx_key = idx_key
         self._index_type = index_type
-        self._pg_index = _PGIndexMapping(idx_key, get_conn)
+        self._pg_index = _PGIndexMapping(idx_key, get_conn, index_type=index_type)
 
     @property
     def _index(self):

--- a/tests/test_pgindex.py
+++ b/tests/test_pgindex.py
@@ -297,6 +297,86 @@ class TestPGIndexKeyword:
         assert set(idx.uniqueValues()) == {"Document", "Folder"}
 
 
+class TestPGIndexMappingKeyword:
+    """``_PGIndexMapping`` must expose individual keywords to callers
+    that iterate it directly — ``plone.app.vocabularies.Keywords``
+    iterates ``index._index`` to build the tag-autocomplete vocabulary
+    (edit-form ``Schlagwort`` widget).  Before the fix, the mapping
+    was not iterable and ``keys()`` returned serialized JSON arrays;
+    the widget produced no suggestions.  See follow-up to #143.
+    """
+
+    def _make_mapping(self, idx_key, get_conn, index_type=None):
+        from plone.pgcatalog.pgindex import _PGIndexMapping
+
+        return _PGIndexMapping(idx_key, get_conn, index_type=index_type)
+
+    def test_mapping_is_iterable_for_scalar_index(self, pg_conn_with_catalog):
+        """Pre-existing callers iterating a scalar ``_index`` must keep
+        seeing scalar values.
+        """
+        _catalog_objects(pg_conn_with_catalog)
+        mapping = self._make_mapping("portal_type", lambda: pg_conn_with_catalog)
+        assert set(iter(mapping)) == {"Document", "Folder"}
+
+    def test_mapping_iterates_individual_keywords(self, pg_conn_with_catalog):
+        from plone.pgcatalog.columns import IndexType
+
+        _catalog_keyword_objects(pg_conn_with_catalog)
+        mapping = self._make_mapping(
+            "Subject",
+            lambda: pg_conn_with_catalog,
+            index_type=IndexType.KEYWORD,
+        )
+        values = set(iter(mapping))
+        assert values == {"Werkvortrag", "Tirol", "Aktuelles", "AUSSCHREIBUNG"}
+        for v in values:
+            assert not v.startswith("[")
+
+    def test_mapping_keys_returns_individual_keywords(self, pg_conn_with_catalog):
+        from plone.pgcatalog.columns import IndexType
+
+        _catalog_keyword_objects(pg_conn_with_catalog)
+        mapping = self._make_mapping(
+            "Subject",
+            lambda: pg_conn_with_catalog,
+            index_type=IndexType.KEYWORD,
+        )
+        assert set(mapping.keys()) == {
+            "Werkvortrag",
+            "Tirol",
+            "Aktuelles",
+            "AUSSCHREIBUNG",
+        }
+
+    def test_vocabulary_autocomplete_picks_substring(self, pg_conn_with_catalog):
+        """End-to-end-ish: plone.app.vocabularies.Keywords.all_keywords
+        iterates ``index._index`` and filters by substring.  Build a
+        ``PGIndex`` wired to the PG connection and reproduce the
+        ``safe_simplevocabulary_from_values(index._index, query=...)``
+        call pattern.
+        """
+        from plone.pgcatalog.columns import IndexType
+        from plone.pgcatalog.pgindex import PGIndex
+
+        _catalog_keyword_objects(pg_conn_with_catalog)
+        wrapped = mock.Mock()
+        wrapped.id = "Subject"
+        pg_index = PGIndex(
+            wrapped,
+            "Subject",
+            lambda: pg_conn_with_catalog,
+            index_type=IndexType.KEYWORD,
+        )
+        # Substring "AT" should not match any of our test keywords;
+        # "Tir" should match "Tirol".
+        matches_tir = [i for i in pg_index._index if "Tir" in i]
+        assert matches_tir == ["Tirol"]
+
+        matches_ak = [i for i in pg_index._index if "Ak" in i]
+        assert matches_ak == ["Aktuelles"]
+
+
 # ---------------------------------------------------------------------------
 # PlonePGCatalogTool.getpath / .getrid / .Indexes integration tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

b59 fixed `PGIndex.uniqueValues()` but missed that `plone.app.vocabularies.Keywords.all_keywords` iterates `index._index` directly (not `uniqueValues`) to populate the `Schlagwort` autocomplete widget:

\`\`\`python
# plone/app/vocabularies/catalog.py : all_keywords
index = self.catalog._catalog.getIndex(self.keyword_index)
return safe_simplevocabulary_from_values(index._index, query=kwfilter)
\`\`\`

`index._index` → our `_PGIndexMapping`. That class had **no `__iter__`**, and `keys()` used the same `idx->>key` JSON-array-to-text coercion as the pre-b59 `uniqueValues`. Net effect on prod: the widget offered no suggestions even for stored tags (tested with `AT26` — typing `AT` or the full value produced no options; AjaxSelect only accepts suggestions).

## Fix

- Add `index_type` to `_PGIndexMapping.__init__`, forwarded from `PGIndex`.
- `keys()` branches on `IndexType.KEYWORD` → same `UNION ALL` expansion as `uniqueValues` (array rows → `jsonb_array_elements_text`; legacy scalar rows yield themselves).
- New `__iter__` delegates to `keys()` so `for v in index._index:` yields tag values.
- `get(value)` branches on KEYWORD → `idx->key @> to_jsonb(value::text)` so membership checks against an individual keyword actually match. Scalar path unchanged.

## Test plan

- [x] New tests (all four initially fail on `main`, pass with this change):
  - `test_mapping_is_iterable_for_scalar_index` — regression guard: FieldIndex iteration still yields scalars.
  - `test_mapping_iterates_individual_keywords` — keyword iteration yields `{Werkvortrag, Tirol, Aktuelles, AUSSCHREIBUNG}`, not serialized arrays.
  - `test_mapping_keys_returns_individual_keywords` — `.keys()` matches iteration.
  - `test_vocabulary_autocomplete_picks_substring` — reproduces the `safe_simplevocabulary_from_values(index._index, query=...)` call pattern; substring `Tir` → `['Tirol']`, `Ak` → `['Aktuelles']`.
- [x] Full suite: 1403 passed / 23 skipped / 0 failed.
- [ ] After deploy on aaf-prod: typing in the Collection `Schlagwort` field offers individual keyword suggestions.

Follow-up to #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)