### PR TITLE
fix(pgindex): _apply_index + robust catalog resolution (#146)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## 1.0.0b61
+
+### Fixed
+
+- `_CatalogCompat.getIndex` and `_CatalogIndexesView.__getitem__` no
+  longer silently fall back to the raw ZCatalog index when they
+  cannot find the catalog tool — that fallback returned empty BTrees
+  and masked #143 / #146 for weeks.  A new private helper
+  ``_resolve_catalog`` tries three paths in order (``__parent__`` →
+  Acquisition chain → ``zope.component.hooks.getSite().portal_catalog``)
+  and raises ``RuntimeError`` if all three fail.
+
+- ``_CatalogCompat.indexes`` property now self-heals a missing
+  ``__parent__`` on first access via ``getSite().portal_catalog``.
+  First page render after deploy persists ``__parent__``; no second
+  upgrade-step click required on sites where the #139 upgrade ran
+  before that fix landed.  Zero-touch prod recovery.
+
+### Added
+
+- ``PGIndex._apply_index(request, resultset=None)`` — ZCatalog-
+  compatible low-level query entry point.  Returns
+  ``(IITreeSet(zoids), (index_name,))``.  Reuses
+  ``_QueryBuilder._process_index`` so every registered IndexType
+  (FIELD, KEYWORD, PATH, DATE, DATE_RANGE, UUID, TEXT, BOOLEAN, GOPIP)
+  plus every ``IPGIndexTranslator`` utility works for free.  No
+  implicit security filtering — matches ZCatalog semantics; use
+  ``catalog(**query)`` for secured results.  Emits a
+  ``DeprecationWarning`` once per caller site.
+
+- ``_PGIndexMapping.__getitem__`` / ``__len__`` — round out the
+  PG-backed mapping so Plone core callers
+  (``plone.app.uuid.utils``, ``plone.app.vocabularies.Keywords``)
+  work against ``catalog._catalog.getIndex(name)._index`` without
+  needing ``catalog.Indexes[name]`` acquisition.
+
+- ``_PGIndexMapping.items()`` / ``values()`` raise
+  ``NotImplementedError`` with guidance pointing at ``uniqueValues``,
+  ``_apply_index``, and ``catalog(**query)`` as alternatives.  No
+  Plone-core caller uses them on a wrapped index; a concrete usecase
+  can land in a future issue with server-side-cursor streaming.
+
+- ``PGIndex._index`` property emits a ``DeprecationWarning`` on
+  access — signals callers that the BTree-shaped API is an
+  emulation and suggests the preferred pgcatalog-native
+  alternatives.
+
+Closes #146.
+
 ## 1.0.0b60
 
 ### Fixed

--- a/docs/superpowers/plans/2026-04-20-pgindex-apply-index-and-parent-resolution.md
+++ b/docs/superpowers/plans/2026-04-20-pgindex-apply-index-and-parent-resolution.md
@@ -1,0 +1,1602 @@
+# PGIndex `_apply_index` + robust catalog resolution — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the silent raw-index fallback in `_CatalogCompat`, implement `PGIndex._apply_index` via `_QueryBuilder` reuse, complete the `_PGIndexMapping` BTree-shaped read surface, and self-heal missing `__parent__` on first access so aaf-prod recovers with zero touch.
+
+**Architecture:** One helper `_resolve_catalog(compat)` in `maintenance.py` becomes the single lookup path (explicit parent → Acquisition → `getSite`). `_CatalogCompat.indexes` property extends its b60 self-heal to also persist `__parent__`. `PGIndex._apply_index` instantiates `_QueryBuilder`, reuses its `_process_index` dispatch, wraps the resulting `WHERE`-fragment in `SELECT zoid FROM object_state`. `_PGIndexMapping` gains `__getitem__`/`__len__` for Plone-core compat and raises `NotImplementedError` with guidance on `items()`/`values()`. All emit-once `DeprecationWarning`s.
+
+**Tech Stack:** Python 3.13, psycopg 3, `Acquisition.Implicit`, `zope.component.hooks.getSite`, `BTrees.IIBTree.IITreeSet`, `plone.pgcatalog.query._QueryBuilder`, pytest, `plone.app.testing`.
+
+**Spec:** `docs/superpowers/specs/2026-04-20-pgindex-apply-index-design.md`
+
+**Branch:** `fix/pgindex-apply-index-and-parent-resolution` (already exists; spec committed on it).
+
+**Target release:** 1.0.0b61.
+
+---
+
+## File Map
+
+- **Create:** none — no new modules.
+- **Modify:**
+  - `src/plone/pgcatalog/maintenance.py` — add `_resolve_catalog`; extend `_CatalogCompat.indexes` self-heal; rewrite `_CatalogCompat.getIndex`; rewrite `_CatalogIndexesView.__getitem__`.
+  - `src/plone/pgcatalog/pgindex.py` — add `_apply_index` on `PGIndex`; add `__getitem__`, `__len__`, `items`, `values` on `_PGIndexMapping`; wrap `_index` property in a `DeprecationWarning`.
+  - `CHANGES.md` — `## 1.0.0b61` entry (last task).
+- **Test (modify):**
+  - `tests/test_catalog_indexes_view.py` — add `TestResolveCatalog`, `TestParentSelfHeal`, `TestGetIndexWithoutParent`; rewrite `TestViewWithoutCatalog` to match the new no-silent-fallback contract.
+  - `tests/test_pgindex.py` — add `TestPGIndexMappingNewMethods`, `TestPGIndexIndexDeprecation`, `TestPGIndexApplyIndex`.
+  - `tests/test_plone_integration.py` — add `TestKeywordsVocabulary` (integration layer).
+
+**No changes to:** `src/plone/pgcatalog/query.py` (`_QueryBuilder` reused as-is).
+
+---
+
+## Task 1: `_resolve_catalog` helper
+
+**Files:**
+- Modify: `src/plone/pgcatalog/maintenance.py` — add helper right above `class _CatalogIndexesView`
+- Test: `tests/test_catalog_indexes_view.py` — new class `TestResolveCatalog` at the end of the file
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_catalog_indexes_view.py`:
+
+```python
+# ── _resolve_catalog: three-step lookup, no silent None ──────────────────
+
+
+class TestResolveCatalog:
+    def test_returns_explicit_parent_first(self):
+        from plone.pgcatalog.maintenance import _CatalogCompat
+        from plone.pgcatalog.maintenance import _resolve_catalog
+
+        compat = _CatalogCompat()
+        tool = mock.Mock(name="tool-via-parent")
+        compat.__dict__["__parent__"] = tool
+
+        assert _resolve_catalog(compat) is tool
+
+    def test_falls_through_to_acquisition_parent(self):
+        from Acquisition import Implicit
+        from plone.pgcatalog.maintenance import _CatalogCompat
+        from plone.pgcatalog.maintenance import _resolve_catalog
+
+        class _ParentHolder(Implicit):
+            pass
+
+        parent = _ParentHolder()
+        compat = _CatalogCompat()
+        wrapped = compat.__of__(parent)  # Acquisition wrapper
+
+        assert _resolve_catalog(wrapped) is parent
+
+    def test_falls_through_to_get_site_portal_catalog(self):
+        from plone.pgcatalog.maintenance import _CatalogCompat
+        from plone.pgcatalog.maintenance import _resolve_catalog
+
+        compat = _CatalogCompat()
+        tool = mock.Mock(name="tool-via-get-site")
+        site = mock.Mock(portal_catalog=tool)
+
+        with mock.patch(
+            "plone.pgcatalog.maintenance.getSite", return_value=site
+        ):
+            assert _resolve_catalog(compat) is tool
+
+    def test_raises_runtimeerror_when_all_three_fail(self):
+        import pytest
+        from plone.pgcatalog.maintenance import _CatalogCompat
+        from plone.pgcatalog.maintenance import _resolve_catalog
+
+        compat = _CatalogCompat()
+        with (
+            mock.patch("plone.pgcatalog.maintenance.getSite", return_value=None),
+            pytest.raises(RuntimeError, match="cannot find portal_catalog"),
+        ):
+            _resolve_catalog(compat)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+.venv/bin/python -m pytest tests/test_catalog_indexes_view.py::TestResolveCatalog -v
+```
+
+Expected: four FAILs with `ImportError: cannot import name '_resolve_catalog' from 'plone.pgcatalog.maintenance'`.
+
+- [ ] **Step 3: Add module-level import and helper**
+
+Add to the imports block at the top of `src/plone/pgcatalog/maintenance.py` (merge alphabetically with existing `Acquisition` imports):
+
+```python
+from zope.component.hooks import getSite
+```
+
+Insert the helper just before `class _CatalogIndexesView:` (≈ line 94):
+
+```python
+def _resolve_catalog(compat):
+    """Find the PlonePGCatalogTool that owns this _CatalogCompat.
+
+    Tries three resolution paths in order:
+
+    1. ``__parent__`` set on the bare instance (by the v1->v2 migration
+       step or by the ``indexes`` property's self-heal).
+    2. Acquisition chain — ``aq_parent(aq_inner(compat))`` — when the
+       compat is reached via an Acquisition wrapper and some parent in
+       the chain is the catalog tool.
+    3. ``zope.component.hooks.getSite().portal_catalog`` — works during
+       request handling and in any code path that sets up the local
+       site hook.
+
+    Raises ``RuntimeError`` if all three fail.  **Never returns
+    ``None``** — a silent ``None`` triggered the raw-index fallback
+    bug that masked #143 / #146 for weeks.
+    """
+    parent = compat.__dict__.get("__parent__")
+    if parent is not None:
+        return parent
+    via_aq = aq_parent(aq_inner(compat))
+    if via_aq is not None:
+        return via_aq
+    site = getSite()
+    if site is not None:
+        tool = getattr(site, "portal_catalog", None)
+        if tool is not None:
+            return tool
+    raise RuntimeError(
+        "plone.pgcatalog._CatalogCompat: cannot find portal_catalog "
+        "(no __parent__, no acquisition context, no getSite). "
+        "_CatalogCompat is not usable outside a Plone site."
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/test_catalog_indexes_view.py::TestResolveCatalog -v
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/plone/pgcatalog/maintenance.py tests/test_catalog_indexes_view.py
+git commit -m "feat(maintenance): _resolve_catalog helper with three-step lookup (#146)"
+```
+
+---
+
+## Task 2: `_CatalogCompat.indexes` property — self-heal `__parent__`
+
+**Files:**
+- Modify: `src/plone/pgcatalog/maintenance.py` — `_CatalogCompat.indexes` property body
+- Test: `tests/test_catalog_indexes_view.py` — new class `TestParentSelfHeal`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_catalog_indexes_view.py`:
+
+```python
+# ── Self-heal: __parent__ gets persisted on first indexes access ─────────
+
+
+class TestParentSelfHeal:
+    def test_property_heals_missing_parent_via_get_site(self):
+        from plone.pgcatalog.maintenance import _CatalogCompat
+
+        compat = _CatalogCompat.__new__(_CatalogCompat)
+        compat.__dict__["_raw_indexes"] = PersistentMapping()
+        compat.__dict__["schema"] = PersistentMapping()
+        # no __parent__
+        compat._p_changed = False
+
+        tool = mock.Mock(name="portal_catalog")
+        site = mock.Mock(portal_catalog=tool)
+
+        # Need a fake jar so ``_p_changed = True`` sticks under Persistent.
+        from plone.pgcatalog.upgrades.profile_2 import _NoOpJar
+
+        compat._p_jar = _NoOpJar()
+
+        with mock.patch(
+            "plone.pgcatalog.maintenance.getSite", return_value=site
+        ):
+            _view = compat.indexes  # trigger property
+
+        assert compat.__dict__.get("__parent__") is tool
+        assert compat._p_changed is True
+
+    def test_property_tolerates_get_site_returning_none(self):
+        from plone.pgcatalog.maintenance import _CatalogCompat
+
+        compat = _CatalogCompat.__new__(_CatalogCompat)
+        compat.__dict__["_raw_indexes"] = PersistentMapping()
+        # no __parent__, no site hook
+
+        with mock.patch(
+            "plone.pgcatalog.maintenance.getSite", return_value=None
+        ):
+            _view = compat.indexes  # must not raise
+
+        assert "__parent__" not in compat.__dict__
+
+    def test_property_leaves_existing_parent_untouched(self):
+        from plone.pgcatalog.maintenance import _CatalogCompat
+
+        explicit = mock.Mock(name="explicit-parent")
+        other = mock.Mock(name="get-site-tool")
+        site = mock.Mock(portal_catalog=other)
+
+        compat = _CatalogCompat.__new__(_CatalogCompat)
+        compat.__dict__["_raw_indexes"] = PersistentMapping()
+        compat.__dict__["__parent__"] = explicit
+
+        with mock.patch(
+            "plone.pgcatalog.maintenance.getSite", return_value=site
+        ):
+            _view = compat.indexes
+
+        # Still the explicit parent — self-heal must only set when missing.
+        assert compat.__dict__["__parent__"] is explicit
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+.venv/bin/python -m pytest tests/test_catalog_indexes_view.py::TestParentSelfHeal -v
+```
+
+Expected: `test_property_heals_missing_parent_via_get_site` FAILs (`__parent__` missing after access). The other two may pass accidentally.
+
+- [ ] **Step 3: Extend `_CatalogCompat.indexes` property**
+
+In `src/plone/pgcatalog/maintenance.py`, locate the `indexes` property on `_CatalogCompat` (≈ line 198 in b60) and replace the body:
+
+```python
+    @property
+    def indexes(self):
+        """..."""  # keep existing docstring — extend with "and __parent__"
+        state = self.__dict__
+        raw = state.get("_raw_indexes")
+        if raw is None:
+            raw = state.pop("indexes", None)
+            if raw is None:
+                raw = PersistentMapping()
+            state["_raw_indexes"] = raw
+            self._p_changed = True
+        if state.get("__parent__") is None:
+            site = getSite()
+            tool = getattr(site, "portal_catalog", None) if site else None
+            if tool is not None:
+                state["__parent__"] = tool
+                self._p_changed = True
+        return _CatalogIndexesView(self, raw)
+```
+
+Extend the docstring to mention that `__parent__` is also self-healed when `getSite` yields a tool — the b60 docstring already describes the raw-indexes rename; add one paragraph.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/test_catalog_indexes_view.py::TestParentSelfHeal -v
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Regression — full existing view/compat suite**
+
+```bash
+.venv/bin/python -m pytest tests/test_catalog_indexes_view.py -q
+```
+
+Expected: all pre-existing tests still pass (one failure is acceptable at this point only if it's `TestViewWithoutCatalog::test_view_returns_raw_on_getitem_when_no_catalog` — we rewrite that in Task 4).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/plone/pgcatalog/maintenance.py tests/test_catalog_indexes_view.py
+git commit -m "feat(maintenance): self-heal __parent__ on indexes property access (#146)"
+```
+
+---
+
+## Task 3: `_CatalogCompat.getIndex` uses `_resolve_catalog`
+
+**Files:**
+- Modify: `src/plone/pgcatalog/maintenance.py` — `_CatalogCompat.getIndex`
+- Test: `tests/test_catalog_indexes_view.py` — new class `TestGetIndexWithoutParent`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_catalog_indexes_view.py`:
+
+```python
+# ── getIndex no longer falls back to the raw index silently ─────────────
+
+
+class TestGetIndexWithoutParent:
+    def test_finds_catalog_via_get_site_returns_wrapped(
+        self, pg_conn_with_catalog
+    ):
+        from plone.pgcatalog.catalog import PlonePGCatalogTool
+        from plone.pgcatalog.maintenance import _CatalogCompat
+        from plone.pgcatalog.pgindex import PGIndex
+
+        tool = PlonePGCatalogTool.__new__(PlonePGCatalogTool)
+        tool._get_pg_read_connection = lambda: pg_conn_with_catalog
+        compat = _CatalogCompat()
+        tool._catalog = compat
+        raw = mock.Mock(id="portal_type", meta_type="FieldIndex")
+        compat._raw_indexes["portal_type"] = raw
+
+        # no __parent__, no acquisition — only getSite works
+        site = mock.Mock(portal_catalog=tool)
+        with mock.patch(
+            "plone.pgcatalog.maintenance.getSite", return_value=site
+        ):
+            result = compat.getIndex("portal_type")
+
+        assert isinstance(result, PGIndex)
+        assert result._wrapped is raw
+
+    def test_raises_runtimeerror_when_all_three_fail(self):
+        import pytest
+        from plone.pgcatalog.maintenance import _CatalogCompat
+
+        compat = _CatalogCompat()
+        raw = mock.Mock(id="portal_type", meta_type="FieldIndex")
+        compat._raw_indexes["portal_type"] = raw
+
+        with (
+            mock.patch("plone.pgcatalog.maintenance.getSite", return_value=None),
+            pytest.raises(RuntimeError, match="cannot find portal_catalog"),
+        ):
+            compat.getIndex("portal_type")
+
+    def test_explicit_parent_still_works(self, pg_conn_with_catalog):
+        """Regression guard — the happy path remains unchanged."""
+        from plone.pgcatalog.catalog import PlonePGCatalogTool
+        from plone.pgcatalog.maintenance import _CatalogCompat
+        from plone.pgcatalog.pgindex import PGIndex
+
+        tool = PlonePGCatalogTool.__new__(PlonePGCatalogTool)
+        tool._get_pg_read_connection = lambda: pg_conn_with_catalog
+        compat = _CatalogCompat(parent=tool)
+        tool._catalog = compat
+        raw = mock.Mock(id="portal_type", meta_type="FieldIndex")
+        compat._raw_indexes["portal_type"] = raw
+
+        result = compat.getIndex("portal_type")
+        assert isinstance(result, PGIndex)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+.venv/bin/python -m pytest tests/test_catalog_indexes_view.py::TestGetIndexWithoutParent -v
+```
+
+Expected:
+- `test_finds_catalog_via_get_site_returns_wrapped` FAILs (getIndex returns raw mock, not PGIndex — currently falls back to raw).
+- `test_raises_runtimeerror_when_all_three_fail` FAILs (currently no raise).
+- `test_explicit_parent_still_works` PASSES (unchanged path).
+
+- [ ] **Step 3: Rewrite `_CatalogCompat.getIndex`**
+
+Replace the body of `_CatalogCompat.getIndex` in `src/plone/pgcatalog/maintenance.py` (≈ line 211 in b60):
+
+```python
+    def getIndex(self, name):
+        """Return a PG-backed index wrapper for *name*.
+
+        Mirrors ``self.indexes[name]`` but implemented directly on the
+        method so legacy callers (eea.facetednavigation,
+        plone.app.vocabularies.Keywords) keep working through the
+        Acquisition wrapper.
+
+        Unlike the pre-#146 implementation, this does **not** fall back
+        to the raw ZCatalog index when the catalog tool is
+        unreachable — a raw index has empty BTrees in pgcatalog and
+        silently returns empty result sets, which masked #143/#146 for
+        weeks.  Instead, ``_resolve_catalog`` raises ``RuntimeError``
+        if none of its three lookup strategies finds the catalog.
+        """
+        raw_index = self._raw_indexes[name]  # raises KeyError if missing
+        catalog = _resolve_catalog(self)
+        return _maybe_wrap_index(catalog, name, raw_index)
+```
+
+Note: the existing import of `_maybe_wrap_index` at the top of `maintenance.py` stays.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/test_catalog_indexes_view.py::TestGetIndexWithoutParent -v
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/plone/pgcatalog/maintenance.py tests/test_catalog_indexes_view.py
+git commit -m "feat(maintenance): getIndex uses _resolve_catalog, no raw fallback (#146)"
+```
+
+---
+
+## Task 4: `_CatalogIndexesView.__getitem__` uses `_resolve_catalog` + update legacy tests
+
+**Files:**
+- Modify: `src/plone/pgcatalog/maintenance.py` — `_CatalogIndexesView.__getitem__` + `.get`
+- Test: `tests/test_catalog_indexes_view.py` — rewrite `TestViewWithoutCatalog`
+
+- [ ] **Step 1: Rewrite `TestViewWithoutCatalog` to match the new contract**
+
+Replace the existing class in `tests/test_catalog_indexes_view.py`:
+
+```python
+# ── View with no reachable catalog: must raise, not return raw ───────────
+
+
+class TestViewWithoutCatalog:
+    """Pre-#146 behavior: getitem returned the raw ZCatalog index when
+    aq_parent returned None.  That masked silent "empty results" bugs.
+    New contract: the view raises RuntimeError when no catalog is
+    reachable.  Callers that intentionally work without a catalog now
+    need to set __parent__ explicitly.
+    """
+
+    def test_getitem_raises_when_no_catalog_reachable(self):
+        import pytest
+        compat = _fresh_compat()
+        raw = mock.Mock(id="portal_type", meta_type="FieldIndex")
+        compat._raw_indexes["portal_type"] = raw
+
+        with (
+            mock.patch(
+                "plone.pgcatalog.maintenance.getSite", return_value=None
+            ),
+            pytest.raises(RuntimeError, match="cannot find portal_catalog"),
+        ):
+            _ = compat.indexes["portal_type"]
+
+    def test_view_keys_are_unwrapped_strings(self):
+        compat = _fresh_compat()
+        compat._raw_indexes["a"] = mock.Mock()
+        compat._raw_indexes["b"] = mock.Mock()
+        assert set(compat.indexes.keys()) == {"a", "b"}
+
+    def test_view_contains_and_len(self):
+        compat = _fresh_compat()
+        compat._raw_indexes["a"] = mock.Mock()
+        assert "a" in compat.indexes
+        assert "missing" not in compat.indexes
+        assert len(compat.indexes) == 1
+
+    def test_view_iteration_yields_keys(self):
+        compat = _fresh_compat()
+        compat._raw_indexes["a"] = mock.Mock()
+        compat._raw_indexes["b"] = mock.Mock()
+        assert sorted(iter(compat.indexes)) == ["a", "b"]
+```
+
+Note: `keys`, `__contains__`, `__len__`, `__iter__` don't need the catalog at all — they operate on `_raw` directly. Those tests stay green without change.
+
+- [ ] **Step 2: Run tests — only `test_getitem_raises_when_no_catalog_reachable` fails**
+
+```bash
+.venv/bin/python -m pytest tests/test_catalog_indexes_view.py::TestViewWithoutCatalog -v
+```
+
+Expected: 3 pass, 1 FAIL (`test_getitem_raises_when_no_catalog_reachable`).
+
+- [ ] **Step 3: Rewrite `_CatalogIndexesView.__getitem__` and `.get`**
+
+In `src/plone/pgcatalog/maintenance.py`, locate `_CatalogIndexesView.__getitem__` (≈ line 116) and replace:
+
+```python
+    # read-through access → wrapped
+    def __getitem__(self, key):
+        raw_index = self._raw[key]  # raises KeyError
+        catalog = _resolve_catalog(self._compat)
+        return _maybe_wrap_index(catalog, key, raw_index)
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+```
+
+Note the `get` method's behavior: it catches only `KeyError` (missing key), **not** `RuntimeError`. An unreachable catalog is a configuration bug, not a missing key — the `RuntimeError` must propagate to the caller.
+
+- [ ] **Step 4: Run tests to verify all pass**
+
+```bash
+.venv/bin/python -m pytest tests/test_catalog_indexes_view.py -q
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/plone/pgcatalog/maintenance.py tests/test_catalog_indexes_view.py
+git commit -m "feat(maintenance): view __getitem__ uses _resolve_catalog (#146)"
+```
+
+---
+
+## Task 5: `_PGIndexMapping.__getitem__`
+
+**Files:**
+- Modify: `src/plone/pgcatalog/pgindex.py` — `_PGIndexMapping`
+- Test: `tests/test_pgindex.py` — new class `TestPGIndexMappingNewMethods`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_pgindex.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# _PGIndexMapping: __getitem__, __len__, items/values NotImplementedError
+# ---------------------------------------------------------------------------
+
+
+class TestPGIndexMappingNewMethods:
+    def test_getitem_returns_zoid_for_existing_value(
+        self, pg_conn_with_catalog
+    ):
+        _catalog_objects(pg_conn_with_catalog)
+        mapping = _PGIndexMapping("UID", lambda: pg_conn_with_catalog)
+        assert mapping["uid-aaa-100"] == 100
+
+    def test_getitem_raises_keyerror_on_miss(self, pg_conn_with_catalog):
+        import pytest
+        _catalog_objects(pg_conn_with_catalog)
+        mapping = _PGIndexMapping("UID", lambda: pg_conn_with_catalog)
+        with pytest.raises(KeyError, match="nonexistent-uid"):
+            _ = mapping["nonexistent-uid"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+.venv/bin/python -m pytest tests/test_pgindex.py::TestPGIndexMappingNewMethods -v
+```
+
+Expected: both FAIL with `TypeError: '_PGIndexMapping' object is not subscriptable`.
+
+- [ ] **Step 3: Add `__getitem__`**
+
+Insert into `_PGIndexMapping` in `src/plone/pgcatalog/pgindex.py` right after `__contains__`:
+
+```python
+    def __getitem__(self, value):
+        """Dict-style lookup, raising ``KeyError`` on miss.
+
+        For KeywordIndex, returns the zoid of *some* object whose array
+        contains *value* (matches the ``get()`` semantics — not the
+        full IITreeSet that ZCatalog's OOBTree[value] would return).
+        Callers wanting the IITreeSet should use
+        ``PGIndex._apply_index({name: value})``.
+        """
+        zoid = self.get(value)
+        if zoid is None:
+            raise KeyError(value)
+        return zoid
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/test_pgindex.py::TestPGIndexMappingNewMethods -v
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/plone/pgcatalog/pgindex.py tests/test_pgindex.py
+git commit -m "feat(pgindex): _PGIndexMapping.__getitem__ raises KeyError on miss (#146)"
+```
+
+---
+
+## Task 6: `_PGIndexMapping.__len__`
+
+**Files:**
+- Modify: `src/plone/pgcatalog/pgindex.py` — `_PGIndexMapping`
+- Test: `tests/test_pgindex.py` — extend `TestPGIndexMappingNewMethods`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `TestPGIndexMappingNewMethods`:
+
+```python
+    def test_len_scalar_index(self, pg_conn_with_catalog):
+        _catalog_objects(pg_conn_with_catalog)  # 2 Documents, 1 Folder
+        mapping = _PGIndexMapping(
+            "portal_type", lambda: pg_conn_with_catalog
+        )
+        assert len(mapping) == 2  # distinct values
+
+    def test_len_keyword_index(self, pg_conn_with_catalog):
+        from plone.pgcatalog.columns import IndexType
+        _catalog_keyword_objects(pg_conn_with_catalog)
+        mapping = _PGIndexMapping(
+            "Subject",
+            lambda: pg_conn_with_catalog,
+            index_type=IndexType.KEYWORD,
+        )
+        # distinct keywords across the three fixture docs
+        assert len(mapping) == 4
+
+    def test_len_keyword_with_legacy_scalar_row(self, pg_conn_with_catalog):
+        from plone.pgcatalog.columns import IndexType
+        _catalog_keyword_objects(pg_conn_with_catalog)
+        insert_object(pg_conn_with_catalog, 299)
+        catalog_object(
+            pg_conn_with_catalog,
+            zoid=299,
+            path="/plone/legacy-scalar",
+            idx={"portal_type": "Document", "Subject": "Legacy"},
+        )
+        pg_conn_with_catalog.commit()
+        mapping = _PGIndexMapping(
+            "Subject",
+            lambda: pg_conn_with_catalog,
+            index_type=IndexType.KEYWORD,
+        )
+        assert len(mapping) == 5  # 4 array keywords + "Legacy" scalar
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+.venv/bin/python -m pytest "tests/test_pgindex.py::TestPGIndexMappingNewMethods::test_len_scalar_index" "tests/test_pgindex.py::TestPGIndexMappingNewMethods::test_len_keyword_index" "tests/test_pgindex.py::TestPGIndexMappingNewMethods::test_len_keyword_with_legacy_scalar_row" -v
+```
+
+Expected: all FAIL with `TypeError: object of type '_PGIndexMapping' has no len()`.
+
+- [ ] **Step 3: Add `__len__`**
+
+Insert into `_PGIndexMapping`, after `__iter__`:
+
+```python
+    def __len__(self):
+        """Count distinct index values.
+
+        For scalar indexes: ``SELECT COUNT(DISTINCT idx->>key)``.
+        For KEYWORD: same ``UNION ALL`` pattern as ``keys()``, wrapped
+        in ``COUNT(DISTINCT val)``.
+        """
+        try:
+            conn = self._get_conn()
+        except Exception:
+            return 0
+        if self._index_type == IndexType.KEYWORD:
+            sql = (
+                "SELECT COUNT(DISTINCT val) AS n FROM ("
+                "  SELECT jsonb_array_elements_text(idx->%(key)s) AS val "
+                "    FROM object_state "
+                "    WHERE idx ? %(key)s "
+                "      AND jsonb_typeof(idx->%(key)s) = 'array' "
+                "  UNION ALL "
+                "  SELECT idx->>%(key)s AS val "
+                "    FROM object_state "
+                "    WHERE idx ? %(key)s "
+                "      AND jsonb_typeof(idx->%(key)s) NOT IN ('array', 'null') "
+                ") u WHERE val IS NOT NULL"
+            )
+        else:
+            sql = (
+                "SELECT COUNT(DISTINCT idx->>%(key)s) AS n "
+                "FROM object_state "
+                "WHERE idx ? %(key)s AND idx->>%(key)s IS NOT NULL"
+            )
+        with conn.cursor() as cur:
+            cur.execute(sql, {"key": self._idx_key})
+            row = cur.fetchone()
+        return int(row["n"]) if row and row["n"] is not None else 0
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/test_pgindex.py::TestPGIndexMappingNewMethods -v
+```
+
+Expected: all 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/plone/pgcatalog/pgindex.py tests/test_pgindex.py
+git commit -m "feat(pgindex): _PGIndexMapping.__len__ via COUNT DISTINCT (#146)"
+```
+
+---
+
+## Task 7: `_PGIndexMapping.items` / `values` raise `NotImplementedError`
+
+**Files:**
+- Modify: `src/plone/pgcatalog/pgindex.py` — `_PGIndexMapping`
+- Test: `tests/test_pgindex.py` — extend `TestPGIndexMappingNewMethods`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `TestPGIndexMappingNewMethods`:
+
+```python
+    def test_items_raises_notimplemented_with_guidance(
+        self, pg_conn_with_catalog
+    ):
+        import pytest
+        _catalog_objects(pg_conn_with_catalog)
+        mapping = _PGIndexMapping("UID", lambda: pg_conn_with_catalog)
+        with pytest.raises(NotImplementedError) as excinfo:
+            mapping.items()
+        msg = str(excinfo.value)
+        assert "items()" in msg
+        assert "uniqueValues" in msg
+        assert "_apply_index" in msg
+        assert "catalog(**query)" in msg
+        assert "https://github.com/bluedynamics/plone-pgcatalog/issues" in msg
+
+    def test_values_raises_notimplemented_with_guidance(
+        self, pg_conn_with_catalog
+    ):
+        import pytest
+        _catalog_objects(pg_conn_with_catalog)
+        mapping = _PGIndexMapping("UID", lambda: pg_conn_with_catalog)
+        with pytest.raises(NotImplementedError) as excinfo:
+            mapping.values()
+        assert "values()" in str(excinfo.value)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+.venv/bin/python -m pytest "tests/test_pgindex.py::TestPGIndexMappingNewMethods::test_items_raises_notimplemented_with_guidance" "tests/test_pgindex.py::TestPGIndexMappingNewMethods::test_values_raises_notimplemented_with_guidance" -v
+```
+
+Expected: both FAIL with `AttributeError: '_PGIndexMapping' object has no attribute 'items'`.
+
+- [ ] **Step 3: Add message template and methods**
+
+Above the `_PGIndexMapping` class in `src/plone/pgcatalog/pgindex.py`, add:
+
+```python
+_ITEMS_VALUES_NOT_IMPLEMENTED = (
+    "PGIndex._index.{method}() is not implemented in plone.pgcatalog: "
+    "the ZCatalog BTree shape [(value, IITreeSet(rids)), ...] materializes "
+    "all (value, objects)-pairs of the index, which would be prohibitively "
+    "expensive against the PG-backed catalog.  Alternatives:\n"
+    "  * catalog.Indexes[name].uniqueValues()                 — distinct values\n"
+    "  * catalog.Indexes[name]._apply_index({{name: value}})  — zoids per value\n"
+    "  * catalog(**query)                                      — full secured search\n"
+    "If you have a legitimate usecase, please file an issue at "
+    "https://github.com/bluedynamics/plone-pgcatalog/issues with the "
+    "caller and the expected result shape."
+)
+```
+
+Insert into `_PGIndexMapping` after `__len__`:
+
+```python
+    def items(self):
+        raise NotImplementedError(
+            _ITEMS_VALUES_NOT_IMPLEMENTED.format(method="items")
+        )
+
+    def values(self):
+        raise NotImplementedError(
+            _ITEMS_VALUES_NOT_IMPLEMENTED.format(method="values")
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/test_pgindex.py::TestPGIndexMappingNewMethods -v
+```
+
+Expected: 7 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/plone/pgcatalog/pgindex.py tests/test_pgindex.py
+git commit -m "feat(pgindex): items/values raise NotImplementedError with guidance (#146)"
+```
+
+---
+
+## Task 8: `PGIndex._index` property emits `DeprecationWarning`
+
+**Files:**
+- Modify: `src/plone/pgcatalog/pgindex.py` — `PGIndex._index` property
+- Test: `tests/test_pgindex.py` — new class `TestPGIndexIndexDeprecation`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_pgindex.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# PGIndex._index deprecation warning
+# ---------------------------------------------------------------------------
+
+
+class TestPGIndexIndexDeprecation:
+    def test_index_property_emits_deprecation_warning(self):
+        import pytest
+        from plone.pgcatalog.pgindex import PGIndex
+
+        wrapped = mock.Mock()
+        wrapped.id = "portal_type"
+
+        def no_conn():
+            raise RuntimeError("no conn")
+
+        idx = PGIndex(wrapped, "portal_type", no_conn)
+        with pytest.warns(DeprecationWarning, match="PGIndex._index accessed"):
+            _ = idx._index
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+.venv/bin/python -m pytest tests/test_pgindex.py::TestPGIndexIndexDeprecation -v
+```
+
+Expected: FAIL — no warning emitted.
+
+- [ ] **Step 3: Add `warnings` import and wrap `_index` property**
+
+At the top of `src/plone/pgcatalog/pgindex.py` — alongside the existing `import logging`:
+
+```python
+import warnings
+```
+
+Replace the `PGIndex._index` property (currently a one-line `return self._pg_index`):
+
+```python
+    @property
+    def _index(self):
+        """PG-backed mapping that emulates ZCatalog's ``Index._index``
+        OOBTree.
+
+        Emitting a ``DeprecationWarning`` signals callers that they are
+        on an emulation path; the preferred APIs are
+        ``catalog.Indexes[name].uniqueValues()`` for distinct values
+        and ``catalog(**query)`` for full searches.  Python's default
+        warning filter shows each unique ``(module, lineno, message)``
+        once per process, so this amounts to one log line per caller
+        site per deploy — no log flood.
+        """
+        warnings.warn(
+            f"PGIndex._index accessed for {self._idx_key!r}: ZCatalog "
+            f"BTree-shaped API is emulated against PostgreSQL; prefer "
+            f"catalog.Indexes[name].uniqueValues() or catalog(**query).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._pg_index
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+.venv/bin/python -m pytest tests/test_pgindex.py::TestPGIndexIndexDeprecation -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Regression — existing pgindex tests still green**
+
+```bash
+.venv/bin/python -m pytest tests/test_pgindex.py -q
+```
+
+Expected: all green.
+
+Note: some existing tests access `idx._index` without expecting a warning. `pytest.warns` is only needed when the test *asserts* on a warning; passive accesses are fine — Python's default filter downgrades `DeprecationWarning` to a displayed warning but does not error unless `pytest.ini` or command-line flags turn them into errors. `pyproject.toml` in this repo currently does not have `filterwarnings = error`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/plone/pgcatalog/pgindex.py tests/test_pgindex.py
+git commit -m "feat(pgindex): emit DeprecationWarning on PGIndex._index access (#146)"
+```
+
+---
+
+## Task 9: `PGIndex._apply_index` via `_QueryBuilder` reuse
+
+**Files:**
+- Modify: `src/plone/pgcatalog/pgindex.py` — new method on `PGIndex`
+- Test: `tests/test_pgindex.py` — new class `TestPGIndexApplyIndex`
+
+This is the largest task. Split into a series of TDD rounds — one failing test per IndexType.
+
+### 9a. Scaffolding + FIELD
+
+- [ ] **Step 1: Write the failing scaffolding + field tests**
+
+Append to `tests/test_pgindex.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# PGIndex._apply_index (issue #146)
+# ---------------------------------------------------------------------------
+
+
+def _apply_pg_index(idx_key, index_type, pg_conn, request):
+    """Test helper: build a PGIndex and call _apply_index."""
+    from plone.pgcatalog.pgindex import PGIndex
+
+    wrapped = mock.Mock()
+    wrapped.id = idx_key
+    pg_index = PGIndex(
+        wrapped, idx_key, lambda: pg_conn, index_type=index_type
+    )
+    return pg_index._apply_index(request)
+
+
+class TestPGIndexApplyIndex:
+    def test_returns_empty_set_when_index_not_in_request(
+        self, pg_conn_with_catalog
+    ):
+        from BTrees.IIBTree import IITreeSet
+        from plone.pgcatalog.columns import IndexType
+
+        result, info = _apply_pg_index(
+            "portal_type",
+            IndexType.FIELD,
+            pg_conn_with_catalog,
+            {"other_index": "whatever"},
+        )
+        assert isinstance(result, IITreeSet)
+        assert list(result) == []
+        assert info == ("portal_type",)
+
+    def test_field_index_single_value(self, pg_conn_with_catalog):
+        from plone.pgcatalog.columns import IndexType
+
+        _catalog_objects(pg_conn_with_catalog)
+        result, info = _apply_pg_index(
+            "portal_type",
+            IndexType.FIELD,
+            pg_conn_with_catalog,
+            {"portal_type": "Document"},
+        )
+        assert set(result) == {100, 101}
+        assert info == ("portal_type",)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+.venv/bin/python -m pytest tests/test_pgindex.py::TestPGIndexApplyIndex -v
+```
+
+Expected: both FAIL with `AttributeError` (PGIndex has no `_apply_index`) or similar.
+
+- [ ] **Step 3: Add scaffolding + field dispatch**
+
+At the top of `src/plone/pgcatalog/pgindex.py`:
+
+```python
+from BTrees.IIBTree import IITreeSet
+```
+
+Insert into `PGIndex` (below `uniqueValues`, above `__getattr__`):
+
+```python
+    def _apply_index(self, request, resultset=None):
+        """ZCatalog-compatible low-level query entry point.
+
+        Returns ``(IITreeSet(zoids), (index_name,))``.  Matches
+        ZCatalog semantics:
+
+        * No implicit security filtering.  Callers that need secured
+          results must use ``catalog(**query)``.
+        * Empty set if this index isn't in ``request``.
+        * ``resultset`` is accepted for signature compatibility but
+          currently ignored (see #146 non-goals — index-chaining can
+          land in a follow-up issue if a caller needs SQL-side
+          intersection).
+
+        Implementation reuses ``plone.pgcatalog.query._QueryBuilder``
+        so every registered IndexType and every
+        ``IPGIndexTranslator`` utility works for free — the dispatch
+        table stays in one place.
+        """
+        from plone.pgcatalog.query import _QueryBuilder
+
+        index_id = getattr(self._wrapped, "id", self._idx_key)
+        if index_id not in request:
+            return IITreeSet(), (index_id,)
+
+        warnings.warn(
+            f"PGIndex._apply_index({index_id!r}) called: this is a "
+            f"ZCatalog-compatibility shim; prefer catalog(**query) for "
+            f"the full pgcatalog query pipeline.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        try:
+            conn = self._pg_index._get_conn()
+        except Exception:
+            return IITreeSet(), (index_id,)
+
+        builder = _QueryBuilder()
+        builder._query = request  # for cross-index Language lookup
+        builder.clauses.append("idx IS NOT NULL")
+        builder._process_index(index_id, request[index_id])
+        result = builder.result()
+        sql = f"SELECT zoid FROM object_state WHERE {result['where']}"
+
+        with conn.cursor() as cur:
+            cur.execute(sql, result["params"])
+            zoids = IITreeSet(row["zoid"] for row in cur.fetchall())
+        return zoids, (index_id,)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/test_pgindex.py::TestPGIndexApplyIndex -v
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/plone/pgcatalog/pgindex.py tests/test_pgindex.py
+git commit -m "feat(pgindex): _apply_index scaffolding + FIELD dispatch (#146)"
+```
+
+### 9b. KEYWORD + PATH
+
+- [ ] **Step 1: Write the failing KEYWORD and PATH tests**
+
+Append to `TestPGIndexApplyIndex`:
+
+```python
+    def test_keyword_index_single_value(self, pg_conn_with_catalog):
+        from plone.pgcatalog.columns import IndexType
+
+        _catalog_keyword_objects(pg_conn_with_catalog)
+        # Fixture: 200={Werkvortrag, Tirol, Aktuelles}, 201={Tirol,
+        # AUSSCHREIBUNG}, 202={Aktuelles}
+        result, info = _apply_pg_index(
+            "Subject",
+            IndexType.KEYWORD,
+            pg_conn_with_catalog,
+            {"Subject": "Tirol"},
+        )
+        assert set(result) == {200, 201}
+
+    def test_keyword_index_or_operator(self, pg_conn_with_catalog):
+        from plone.pgcatalog.columns import IndexType
+
+        _catalog_keyword_objects(pg_conn_with_catalog)
+        result, info = _apply_pg_index(
+            "Subject",
+            IndexType.KEYWORD,
+            pg_conn_with_catalog,
+            {"Subject": {"query": ["Aktuelles", "AUSSCHREIBUNG"],
+                         "operator": "or"}},
+        )
+        assert set(result) == {200, 201, 202}
+
+    def test_path_index_subtree(self, pg_conn_with_catalog):
+        from plone.pgcatalog.columns import IndexType
+
+        _catalog_objects(pg_conn_with_catalog)  # paths /plone/doc1, etc.
+        result, info = _apply_pg_index(
+            "path",
+            IndexType.PATH,
+            pg_conn_with_catalog,
+            {"path": {"query": "/plone", "depth": -1}},
+        )
+        assert 100 in result
+        assert 101 in result
+        assert 102 in result
+```
+
+Note: PATH index uses idx-key=None in the real registry; for unit tests we bypass the `_maybe_wrap_index` logic and instantiate `PGIndex` directly.  The builder's `_handle_path` uses the registered idx_key via the registry; make sure the `path` index is registered in the test's populated registry (check `conftest.py::populated_registry` — `path` is added as `(IndexType.PATH, None)`).
+
+- [ ] **Step 2: Run tests to verify they pass or fail**
+
+```bash
+.venv/bin/python -m pytest "tests/test_pgindex.py::TestPGIndexApplyIndex::test_keyword_index_single_value" "tests/test_pgindex.py::TestPGIndexApplyIndex::test_keyword_index_or_operator" "tests/test_pgindex.py::TestPGIndexApplyIndex::test_path_index_subtree" -v
+```
+
+Expected: all 3 PASS immediately — the `_QueryBuilder` already handles KEYWORD/PATH. This is the reuse-dividend. If any of them fails, the bug is either in the fixture setup or the builder (file a sub-issue; do not inline-fix in this task).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_pgindex.py
+git commit -m "test(pgindex): regression tests for _apply_index KEYWORD/PATH (#146)"
+```
+
+### 9c. DATE / DATE_RANGE / TEXT / UUID / BOOLEAN — smoke coverage
+
+- [ ] **Step 1: Write one smoke test per remaining IndexType**
+
+Append to `TestPGIndexApplyIndex`:
+
+```python
+    def test_date_index_range_query(self, pg_conn_with_catalog):
+        from datetime import datetime, UTC
+        from plone.pgcatalog.columns import IndexType
+
+        insert_object(pg_conn_with_catalog, 300)
+        catalog_object(
+            pg_conn_with_catalog,
+            zoid=300,
+            path="/plone/event-2025",
+            idx={"portal_type": "Event", "start": "2025-06-15T10:00:00+00:00"},
+        )
+        insert_object(pg_conn_with_catalog, 301)
+        catalog_object(
+            pg_conn_with_catalog,
+            zoid=301,
+            path="/plone/event-2026",
+            idx={"portal_type": "Event", "start": "2026-03-15T10:00:00+00:00"},
+        )
+        pg_conn_with_catalog.commit()
+
+        result, info = _apply_pg_index(
+            "start",
+            IndexType.DATE,
+            pg_conn_with_catalog,
+            {"start": {"query": datetime(2026, 1, 1, tzinfo=UTC),
+                       "range": "min"}},
+        )
+        assert 301 in result
+        assert 300 not in result
+
+    def test_boolean_index(self, pg_conn_with_catalog):
+        from plone.pgcatalog.columns import IndexType
+
+        insert_object(pg_conn_with_catalog, 400)
+        catalog_object(
+            pg_conn_with_catalog,
+            zoid=400,
+            path="/plone/default",
+            idx={"portal_type": "Document", "is_default_page": True},
+        )
+        insert_object(pg_conn_with_catalog, 401)
+        catalog_object(
+            pg_conn_with_catalog,
+            zoid=401,
+            path="/plone/non-default",
+            idx={"portal_type": "Document", "is_default_page": False},
+        )
+        pg_conn_with_catalog.commit()
+
+        result, info = _apply_pg_index(
+            "is_default_page",
+            IndexType.BOOLEAN,
+            pg_conn_with_catalog,
+            {"is_default_page": True},
+        )
+        assert 400 in result
+        assert 401 not in result
+
+    def test_uuid_index(self, pg_conn_with_catalog):
+        from plone.pgcatalog.columns import IndexType
+
+        _catalog_objects(pg_conn_with_catalog)
+        result, info = _apply_pg_index(
+            "UID",
+            IndexType.UUID,
+            pg_conn_with_catalog,
+            {"UID": "uid-aaa-100"},
+        )
+        assert set(result) == {100}
+```
+
+- [ ] **Step 2: Run tests — expect all PASS (builder reuse dividend)**
+
+```bash
+.venv/bin/python -m pytest "tests/test_pgindex.py::TestPGIndexApplyIndex::test_date_index_range_query" "tests/test_pgindex.py::TestPGIndexApplyIndex::test_boolean_index" "tests/test_pgindex.py::TestPGIndexApplyIndex::test_uuid_index" -v
+```
+
+Expected: all 3 PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_pgindex.py
+git commit -m "test(pgindex): smoke _apply_index for DATE/BOOLEAN/UUID (#146)"
+```
+
+### 9d. Semantics: no security, resultset ignored, deprecation warning
+
+- [ ] **Step 1: Write the remaining semantic tests**
+
+Append to `TestPGIndexApplyIndex`:
+
+```python
+    def test_no_implicit_security_filter(self, pg_conn_with_catalog):
+        """_apply_index must NOT auto-inject allowed_roles — matches
+        ZCatalog semantics.  Object restricted to Managers still shows
+        up in the result set.
+        """
+        from plone.pgcatalog.columns import IndexType
+
+        insert_object(pg_conn_with_catalog, 500)
+        catalog_object(
+            pg_conn_with_catalog,
+            zoid=500,
+            path="/plone/private-event",
+            idx={
+                "portal_type": "Event",
+                "allowedRolesAndUsers": ["Manager"],
+            },
+        )
+        pg_conn_with_catalog.commit()
+
+        result, info = _apply_pg_index(
+            "portal_type",
+            IndexType.FIELD,
+            pg_conn_with_catalog,
+            {"portal_type": "Event"},
+        )
+        assert 500 in result
+
+    def test_resultset_parameter_ignored(self, pg_conn_with_catalog):
+        """The resultset kwarg is accepted but not yet wired to SQL."""
+        from BTrees.IIBTree import IITreeSet
+        from plone.pgcatalog.columns import IndexType
+        from plone.pgcatalog.pgindex import PGIndex
+
+        _catalog_objects(pg_conn_with_catalog)
+        wrapped = mock.Mock()
+        wrapped.id = "portal_type"
+        idx = PGIndex(
+            wrapped,
+            "portal_type",
+            lambda: pg_conn_with_catalog,
+            index_type=IndexType.FIELD,
+        )
+        base, _ = idx._apply_index({"portal_type": "Document"})
+        with_rs, _ = idx._apply_index(
+            {"portal_type": "Document"},
+            resultset=IITreeSet([100]),  # intentionally wrong
+        )
+        assert set(base) == set(with_rs)  # resultset ignored
+
+    def test_emits_deprecation_warning(self, pg_conn_with_catalog):
+        import pytest
+        from plone.pgcatalog.columns import IndexType
+
+        _catalog_objects(pg_conn_with_catalog)
+        with pytest.warns(DeprecationWarning, match="_apply_index"):
+            _apply_pg_index(
+                "portal_type",
+                IndexType.FIELD,
+                pg_conn_with_catalog,
+                {"portal_type": "Document"},
+            )
+
+    def test_handles_connection_error_returns_empty_set(self):
+        from BTrees.IIBTree import IITreeSet
+        from plone.pgcatalog.columns import IndexType
+        from plone.pgcatalog.pgindex import PGIndex
+
+        def bad_conn():
+            raise RuntimeError("no conn")
+
+        wrapped = mock.Mock()
+        wrapped.id = "portal_type"
+        idx = PGIndex(
+            wrapped, "portal_type", bad_conn, index_type=IndexType.FIELD
+        )
+        result, info = idx._apply_index({"portal_type": "Document"})
+        assert isinstance(result, IITreeSet)
+        assert list(result) == []
+```
+
+- [ ] **Step 2: Run tests — all should PASS**
+
+```bash
+.venv/bin/python -m pytest tests/test_pgindex.py::TestPGIndexApplyIndex -v
+```
+
+Expected: all green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_pgindex.py
+git commit -m "test(pgindex): _apply_index semantics (no security, deprecation, errors) (#146)"
+```
+
+---
+
+## Task 10: Integration test — `KeywordsVocabulary` end-to-end
+
+**Files:**
+- Test: `tests/test_plone_integration.py` — new class `TestKeywordsVocabulary`
+
+- [ ] **Step 1: Write the integration test**
+
+Append to `tests/test_plone_integration.py`:
+
+```python
+# ===========================================================================
+# KeywordsVocabulary — end-to-end tag autocomplete via PGIndex (#146)
+# ===========================================================================
+
+
+class TestKeywordsVocabulary:
+    """Regression for #146: typing into the tag/Schlagwort autocomplete
+    offers individual keywords, not serialized JSON arrays or nothing."""
+
+    def test_keywords_vocabulary_returns_individual_keywords(
+        self, pgcatalog_layer
+    ):
+        from plone.app.testing import setRoles
+        from plone.app.testing import TEST_USER_ID
+        from plone.app.vocabularies.catalog import KeywordsVocabularyFactory
+
+        portal = pgcatalog_layer["portal"]
+        setRoles(portal, TEST_USER_ID, ["Manager"])
+
+        # Create two Documents with distinct Subject keywords.
+        doc1 = portal.invokeFactory(
+            "Document", "doc1", title="D1", subject=("alpha", "beta"),
+        )
+        doc2 = portal.invokeFactory(
+            "Document", "doc2", title="D2", subject=("beta", "gamma"),
+        )
+        portal[doc1].reindexObject()
+        portal[doc2].reindexObject()
+
+        import transaction
+        transaction.commit()
+
+        vocab = KeywordsVocabularyFactory(portal)
+        tokens = {term.value for term in vocab}
+        assert tokens == {"alpha", "beta", "gamma"}
+
+    def test_keywords_vocabulary_survives_missing_parent(
+        self, pgcatalog_layer
+    ):
+        """Regression guard for the __parent__-missing production case:
+        clear __parent__ on the compat, fetch vocabulary — ``getIndex``
+        still finds the tool via ``_resolve_catalog``'s ``getSite``
+        branch and the vocabulary returns correct tokens.
+
+        Persistent self-heal of ``__parent__`` is tested separately
+        against the ``.indexes`` property (Task 2).  The ``getIndex``
+        code path used by the vocabulary doesn't persist via self-heal
+        — it relies on the lookup fallback each time.  Both behaviors
+        are correct and complementary.
+        """
+        from plone.app.testing import setRoles
+        from plone.app.testing import TEST_USER_ID
+        from plone.app.vocabularies.catalog import KeywordsVocabularyFactory
+        import transaction
+
+        portal = pgcatalog_layer["portal"]
+        setRoles(portal, TEST_USER_ID, ["Manager"])
+
+        doc_id = portal.invokeFactory(
+            "Document", "doc-x", title="X", subject=("AT26",),
+        )
+        portal[doc_id].reindexObject()
+        transaction.commit()
+
+        # Simulate production state: wipe __parent__ from the compat.
+        compat = portal.portal_catalog._catalog
+        compat.__dict__.pop("__parent__", None)
+
+        vocab = KeywordsVocabularyFactory(portal)
+        tokens = {term.value for term in vocab}
+        assert "AT26" in tokens
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+.venv/bin/python -m pytest tests/test_plone_integration.py::TestKeywordsVocabulary -v
+```
+
+Expected: both PASS. If `test_keywords_vocabulary_returns_individual_keywords` fails, the wiring between `_resolve_catalog` / self-heal / `_PGIndexMapping.__iter__` has a gap — debug before moving on.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_plone_integration.py
+git commit -m "test(integration): KeywordsVocabulary end-to-end via PGIndex (#146)"
+```
+
+---
+
+## Task 11: Full regression suite
+
+- [ ] **Step 1: Run the full suite**
+
+```bash
+.venv/bin/python -m pytest tests/ --no-header -q
+```
+
+Expected: `~1420 passed, 23 skipped, 0 failed` (roughly 1403 existing + ~17 new tests).
+
+- [ ] **Step 2: If anything red, fix or pause**
+
+If the only failures are pre-existing flakes (check against `main`), note them but don't block. If any failure is in a test we wrote or in code we changed, fix inline before moving to CHANGES.md.
+
+---
+
+## Task 12: CHANGES.md + release notes
+
+**Files:**
+- Modify: `CHANGES.md`
+
+- [ ] **Step 1: Add entry for 1.0.0b61**
+
+Prepend above `## 1.0.0b60` in `CHANGES.md`:
+
+```markdown
+## 1.0.0b61
+
+### Fixed
+
+- `_CatalogCompat.getIndex` and `_CatalogIndexesView.__getitem__` no
+  longer silently fall back to the raw ZCatalog index when they
+  cannot find the catalog tool — that fallback returned empty BTrees
+  and masked #143 / #146 for weeks.  Instead a new private helper
+  ``_resolve_catalog`` tries three paths in order (``__parent__`` →
+  acquisition chain → ``zope.component.hooks.getSite().portal_catalog``)
+  and raises ``RuntimeError`` if all three fail.
+
+- ``_CatalogCompat.indexes`` property now self-heals a missing
+  ``__parent__`` on first access, using the same
+  ``getSite().portal_catalog`` lookup.  The first page render after
+  deploy persists ``__parent__``; no second upgrade-step click is
+  required on sites where the #139 upgrade ran before that fix
+  landed (prod-recovery for aaf-prod).
+
+### Added
+
+- ``PGIndex._apply_index(request, resultset=None)`` — ZCatalog-
+  compatible low-level query entry point.  Returns
+  ``(IITreeSet(zoids), (index_name,))``.  Reuses
+  ``_QueryBuilder._process_index`` so every registered IndexType
+  plus every ``IPGIndexTranslator`` utility works for free.  No
+  implicit security filtering (matches ZCatalog semantics; use
+  ``catalog(**query)`` for secured results).  Emits a
+  ``DeprecationWarning`` once per caller site.
+
+- ``_PGIndexMapping.__getitem__`` / ``__len__`` — round out the
+  PG-backed mapping so Plone core callers
+  (``plone.app.uuid.utils``, ``plone.app.vocabularies.Keywords``)
+  work against ``catalog._catalog.getIndex(name)._index`` without
+  needing ``catalog.Indexes[name]`` acquisition.
+
+- ``_PGIndexMapping.items()`` / ``values()`` raise
+  ``NotImplementedError`` with guidance pointing at ``uniqueValues``,
+  ``_apply_index``, and ``catalog(**query)`` as alternatives.  No
+  Plone-core caller uses them on a wrapped index; a concrete usecase
+  can land in a future issue with server-side-cursor streaming.
+
+- ``PGIndex._index`` property emits a ``DeprecationWarning`` on
+  access — signals callers that the BTree-shaped API is an
+  emulation and suggests the preferred pgcatalog-native
+  alternatives.
+
+Closes #146.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGES.md
+git commit -m "docs: CHANGES entry for 1.0.0b61 (#146)"
+```
+
+---
+
+## Task 13: Push, PR, merge, release
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin fix/pgindex-apply-index-and-parent-resolution
+```
+
+- [ ] **Step 2: Open PR via `gh pr create`**
+
+PR title: `fix(pgindex): _apply_index + robust catalog resolution (#146)`
+
+PR body template (use `gh pr create --body "$(cat <<'EOF' ... EOF)"`):
+
+```markdown
+## Summary
+
+Closes #146. Compound fix for the Schlagwort-autocomplete production bug on aaf-prod:
+
+- **Root cause 1** — `_CatalogCompat` on prod had no `__parent__`; `getIndex` silently fell back to the raw ZCatalog index (empty BTree). Fixed by `_resolve_catalog` three-step lookup that never returns `None`.
+- **Root cause 2** — even with the fallback removed, `PGIndex` delegated `_apply_index` to the raw ZCatalog index for every caller that used the ZCatalog low-level API (`plone.app.vocabularies.KeywordsVocabulary.keywords_of_section` etc.). Fixed by implementing `_apply_index` via `_QueryBuilder._process_index` reuse.
+- **Round-out** — `_PGIndexMapping` gains `__getitem__`, `__len__`, and explicit `NotImplementedError` for `items()`/`values()`. `PGIndex._index` emits a `DeprecationWarning`.
+
+Spec: `docs/superpowers/specs/2026-04-20-pgindex-apply-index-design.md`.
+
+## Test plan
+
+- [x] Unit: ~17 new tests covering `_resolve_catalog`, parent self-heal, getIndex without parent, `_PGIndexMapping.__getitem__`/`__len__`/`items`/`values`, `PGIndex._index` deprecation, `PGIndex._apply_index` for FIELD/KEYWORD/PATH/DATE/BOOLEAN/UUID + semantics (no security, resultset ignored, deprecation, conn errors).
+- [x] Updated legacy `TestViewWithoutCatalog` to match the new no-silent-fallback contract.
+- [x] Integration: `TestKeywordsVocabulary` end-to-end on the Plone layer — verifies tag autocomplete returns individual keywords and survives missing `__parent__` via `getSite` fallback.
+- [x] Full suite: ~1420 passed / 23 skipped / 0 failed.
+- [ ] After deploy on aaf-prod: typing "AT" in the Collection Schlagwort widget offers "AT26"; `SELECT state ? '__parent__' FROM object_state WHERE zoid = <compat_zoid>` flips to `t` after the first request.
+```
+
+- [ ] **Step 3: Wait for review & merge**
+
+Johannes reviews. Address comments inline, re-push, re-request review. Once approved and merged, continue.
+
+- [ ] **Step 4: Tag & release**
+
+```bash
+git switch main
+git pull --ff-only origin main
+git tag -a v1.0.0b61 -m "Release 1.0.0b61"
+git push origin v1.0.0b61
+gh release create v1.0.0b61 --prerelease --title "v1.0.0b61" \
+  --notes "$(sed -n '/^## 1.0.0b61/,/^## 1.0.0b60/p' CHANGES.md | sed '1d;$d')"
+```
+
+- [ ] **Step 5: Deploy verification on aaf-prod**
+
+After the aaf deployment picks up v1.0.0b61:
+
+```bash
+# 1) Hit any page that triggers vocabulary access (e.g. Collection edit view).
+
+# 2) Verify __parent__ self-heal persisted on the compat.
+kubectl -n aaf-prod exec aaf-deployment-db-cluster-c897d15b-1 -c postgres -- \
+  psql -U postgres -d plone -c \
+  "SELECT state ? '__parent__' AS parent_set FROM object_state WHERE zoid=66615937;"
+# expected: t
+
+# 3) Manual check: type "AT" into the Collection Schlagwort field on /Plone/at26/programm/edit — "AT26" must appear as a suggestion.
+
+# 4) Verify no TypeError / Unauthorized / empty-vocab errors in recent logs.
+kubectl -n aaf-prod logs --tail=500 --since=10m \
+  deployment/aaf-deployment-plone-backend-deployment-c8f5cad7 \
+  | grep -cE "keywords must be strings|Unauthorized: You are not allowed to access"
+# expected: 0
+```
+
+- [ ] **Step 6: Close #146**
+
+If prod verification passes, close the GitHub issue referencing the merged PR and the release.
+
+---
+
+## Out-of-scope — open separate follow-up issues (do not implement here)
+
+These surfaced during design but are not part of this plan:
+
+- `items()` / `values()` real implementation with server-side-cursor lazy streaming — only if a concrete caller appears and files an issue.
+- `_apply_index(resultset=...)` SQL-side index-chaining — only if a caller needs it.
+- Security filter on `_apply_index` — explicitly rejected (matches ZCatalog semantics).
+- `object_state`-as-catalog-source architectural concerns (security on `uniqueValues`, scan cost on huge catalogs, separate `catalog_state` view) — own tracking issue.

--- a/docs/superpowers/specs/2026-04-20-pgindex-apply-index-design.md
+++ b/docs/superpowers/specs/2026-04-20-pgindex-apply-index-design.md
@@ -1,0 +1,316 @@
+# PGIndex `_apply_index` + robust catalog resolution
+
+- **Issue**: [bluedynamics/plone-pgcatalog#146](https://github.com/bluedynamics/plone-pgcatalog/issues/146)
+- **Author**: Jens W. Klein (spec drafted with Claude Opus 4.7 via superpowers)
+- **Status**: Draft
+- **Date**: 2026-04-20
+- **Target release**: 1.0.0b61
+
+## Problem
+
+`PGIndex` wraps raw ZCatalog indexes and overrides `uniqueValues()` (#143 / b59). Several widely-used downstream callers reach for **private ZCatalog attributes** that `PGIndex` does not translate:
+
+1. `index._apply_index(query)` — ZCatalog's low-level query entry point returning `(IISet(rids), info)`. `PGIndex.__getattr__` delegates to the wrapped raw index, whose BTree is empty in pgcatalog. Called by `plone.app.vocabularies.KeywordsVocabulary.keywords_of_section`, `plone.app.vocabularies.CatalogSearchSource`, and addon dashboards / filters.
+2. `index._index` — the internal `OOBTree` mapping value → set-of-rids. Partially fixed in b60 via `_PGIndexMapping` (get, `__iter__`, `__contains__`, `keys`), but still missing `__getitem__`, `__len__` and the deprecation-warning envelope that signals "you are on an emulation path".
+
+A second, related problem surfaced during the deep investigation for aaf-prod:
+
+3. **Silent `__parent__`-missing failure**. `_CatalogCompat.getIndex(name)` and `_CatalogIndexesView.__getitem__(name)` both do `aq_parent(aq_inner(self))` to find the catalog tool needed for `_maybe_wrap_index`. On aaf-prod the persisted `_CatalogCompat` has no `__parent__` (the v1→v2 migration ran before the #139 fix, so the `__parent__` half of the migration never executed). Without a reachable catalog, both call sites fall back to returning the **raw** ZCatalog index — whose BTrees are empty, so every caller gets correct-looking-but-zero results. This is not a graceful fallback; it is a silent failure mode that masked other bugs for weeks.
+
+## User-visible breakage
+
+aaf-prod Plone 6 post-b60: typing in the Collection `Schlagwort`/tag autocomplete produces **zero suggestions** even though `uniqueValues()` on the same index returns ~1900 entries and `catalog(Subject="AT26")` returns 131 hits. The vocabulary uses `catalog._catalog.getIndex("Subject")._index`, which hits the raw-index path because `__parent__` is missing; the iterator over the empty OOBTree yields nothing.
+
+Other known-affected callers in a standard Plone 6 stack:
+- `plone.app.vocabularies.KeywordsVocabulary` (both `all_keywords` and `keywords_of_section` branches)
+- `plone.app.vocabularies.CatalogSearchSource`
+- `collective.collectionfilter`, `plone.app.referenceablebehavior`, various dashboards/portlets using `cat._catalog.indexes[x]._apply_index(...)`
+
+## Goals
+
+- Every access to `catalog._catalog.getIndex(name)` / `catalog._catalog.indexes[name]` returns a `PGIndex` wrapper when the catalog is a `PlonePGCatalogTool`. No silent raw-index fallback.
+- `PGIndex._apply_index(query)` returns the same set of zoids as `catalog(**{name: query})` for the same index, minus security filtering. Invariant: "`PGIndex._apply_index(q)` ⇔ `catalog(q)` without `allowed_roles`."
+- `PGIndex._index` continues to return a PG-backed mapping with the methods Plone core actually uses (`get`, `__iter__`, `__contains__`, `keys`, `__getitem__`, `__len__`), plus explicit `NotImplementedError` with a helpful message for `items()` / `values()`.
+- Deprecation warnings on `_apply_index` and `_index` access, each emitted once per caller site via `warnings.warn(..., DeprecationWarning, stacklevel=2)`.
+- Self-heal on aaf-prod without a second upgrade-step click: the compat's `__parent__` gets persisted on first access after deploy.
+- Zero schema changes, zero new DDL, zero data migration. Pure Python / Acquisition plumbing.
+
+## Non-goals
+
+- **`items()` / `values()` implementation**. No Plone-core caller uses them on a wrapped `PGIndex`. A caller that does hit `NotImplementedError` with a helpful message pointing to `uniqueValues()`, `_apply_index`, and `catalog(**query)` as alternatives. If a real usecase surfaces, a future issue can implement it with server-side-cursor lazy streaming.
+- **`_apply_index(resultset=...)`** index-chaining semantics. The `resultset` parameter is accepted for ZCatalog signature compatibility but ignored. Callers that do Python-side `intersection()` (e.g. `KeywordsVocabulary.keywords_of_section`) work unchanged.
+- **Implicit security filtering on `_apply_index`**. Matches ZCatalog semantics: `_apply_index` is the unsecured low-level API. Callers that need secured results must use `catalog(**query)` which injects `allowed_roles` via `apply_security_filters`.
+- **`object_state`-as-catalog-source** architectural discussion. The three tracked concerns (security on `uniqueValues`, scan cost on huge catalogs, separate `catalog_state` view) are independent and get their own tracking issue.
+
+## Design
+
+### 1. Catalog resolution — no more silent raw-index fallback
+
+New module-private helper in `src/plone/pgcatalog/maintenance.py`:
+
+```python
+def _resolve_catalog(compat):
+    """Find the PlonePGCatalogTool that owns this _CatalogCompat.
+
+    Tries three resolution paths in order.  Raises RuntimeError if all
+    three fail — never returns None (that would trigger the silent
+    raw-index-fallback bug that masked #143 / #146 for weeks).
+    """
+    # 1) __parent__ on the bare instance (set by migration / self-heal)
+    parent = compat.__dict__.get("__parent__")
+    if parent is not None:
+        return parent
+    # 2) Acquisition chain (compat reached via AcqWrapper)
+    via_aq = aq_parent(aq_inner(compat))
+    if via_aq is not None:
+        return via_aq
+    # 3) zope.component.hooks.getSite() — works during request handling
+    from zope.component.hooks import getSite
+    site = getSite()
+    if site is not None:
+        tool = getattr(site, "portal_catalog", None)
+        if tool is not None:
+            return tool
+    raise RuntimeError(
+        "plone.pgcatalog._CatalogCompat: cannot find portal_catalog "
+        "(no __parent__, no acquisition context, no getSite). "
+        "_CatalogCompat is not usable outside a Plone site."
+    )
+```
+
+**Call-site changes**:
+- `_CatalogCompat.getIndex(name)` — replace `catalog = aq_parent(aq_inner(self))` with `catalog = _resolve_catalog(self)`. Drop the `if catalog is None: return raw_index` branch.
+- `_CatalogIndexesView.__getitem__(key)` — same replacement. Drop the raw-index fallback.
+
+After these changes, an unreachable catalog raises `RuntimeError` at the call site. A test-only code path that previously relied on the `return raw_index` fallback (one test in `test_catalog_indexes_view.py::TestViewWithoutCatalog`) will need to be updated to match the new contract — that test currently documents the old buggy behavior and needs to either assert `pytest.raises(RuntimeError)` or pass an explicit `__parent__`.
+
+### 2. Self-heal extension — persist `__parent__` on first access
+
+`_CatalogCompat.indexes` property (already self-heals `_raw_indexes` per b60) gains a `__parent__` fixup block:
+
+```python
+@property
+def indexes(self):
+    state = self.__dict__
+    raw = state.get("_raw_indexes")
+    if raw is None:
+        raw = state.pop("indexes", None) or PersistentMapping()
+        state["_raw_indexes"] = raw
+        self._p_changed = True
+    # NEW: also heal missing __parent__ when we can find the tool.
+    if state.get("__parent__") is None:
+        from zope.component.hooks import getSite
+        site = getSite()
+        tool = getattr(site, "portal_catalog", None) if site else None
+        if tool is not None:
+            state["__parent__"] = tool
+            self._p_changed = True
+    return _CatalogIndexesView(self, raw)
+```
+
+Tolerant of `getSite() is None` (Zope startup, unit-test contexts without a site hook). In that case `__parent__` stays unset and later lookups fall back to the `_resolve_catalog` chain.
+
+### 3. `PGIndex._apply_index(request, resultset=None)`
+
+Exact ZCatalog signature. Reuses `QueryBuilder._process_index` from `query.py` — no duplicated dispatch logic.
+
+```python
+from BTrees.IIBTree import IITreeSet
+import warnings
+
+def _apply_index(self, request, resultset=None):
+    """Low-level ZCatalog-compatible query entry point.
+
+    Returns (IITreeSet(zoids), (index_name,)).  Applies no security —
+    matches ZCatalog semantics.  Caller is responsible for injecting
+    allowed_roles into the request if secured results are required.
+
+    The ``resultset`` parameter is accepted for signature compatibility
+    but currently ignored (see non-goals).
+    """
+    from plone.pgcatalog.query import QueryBuilder
+
+    index_id = getattr(self._wrapped, "id", self._idx_key)
+    if index_id not in request:
+        return IITreeSet(), (index_id,)
+
+    warnings.warn(
+        f"PGIndex._apply_index({index_id!r}) called: this is a "
+        f"ZCatalog-compatibility shim; prefer catalog(**query) for "
+        f"the full pgcatalog query pipeline.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    try:
+        conn = self._pg_index._get_conn()
+    except Exception:
+        return IITreeSet(), (index_id,)
+
+    builder = QueryBuilder()
+    builder._query = request  # for cross-index Language lookup in _handle_text
+    builder.clauses.append("idx IS NOT NULL")
+    builder._process_index(index_id, request[index_id])
+    result = builder.result()
+    sql = f"SELECT zoid FROM object_state WHERE {result['where']}"
+
+    with conn.cursor() as cur:
+        cur.execute(sql, result["params"])
+        zoids = IITreeSet(row["zoid"] for row in cur.fetchall())
+    return zoids, (index_id,)
+```
+
+Dispatch is inherited from `QueryBuilder._process_index`, which already handles FIELD, KEYWORD, PATH, DATE, DATE_RANGE, UUID, TEXT, BOOLEAN, GOPIP, plus `IPGIndexTranslator`-utility fallback for custom types (DateRecurringIndex with rrule etc.). Full IndexType coverage comes for free.
+
+### 4. `_PGIndexMapping` — complete the BTree-shaped read surface
+
+| Method | Status | Notes |
+|---|---|---|
+| `get(value, default)` | b60 — present | KEYWORD branch via `idx->key @> to_jsonb(value::text)` |
+| `__contains__(value)` | b60 — present | Delegates to `get()` |
+| `keys()` | b60 — present | UNION ALL for KEYWORD; `SELECT DISTINCT` for scalar |
+| `__iter__()` | b60 — present | `iter(self.keys())` |
+| `__getitem__(value)` | **new** | `v = self.get(value); if v is None: raise KeyError(value); return v` |
+| `__len__()` | **new** | `SELECT COUNT(DISTINCT …)` using same UNION ALL pattern as `keys()` |
+| `items()` | **new — raises** | `NotImplementedError` with guidance |
+| `values()` | **new — raises** | `NotImplementedError` with guidance |
+
+Unified `NotImplementedError` message template (literal braces in the query-dict examples must be doubled so `.format(method=...)` does not try to substitute them):
+
+```python
+_ITEMS_VALUES_NOT_IMPLEMENTED = (
+    "PGIndex._index.{method}() is not implemented in plone.pgcatalog: "
+    "the ZCatalog BTree shape [(value, IITreeSet(rids)), ...] materializes "
+    "all (value, objects)-pairs of the index, which would be prohibitively "
+    "expensive against the PG-backed catalog.  Alternatives:\n"
+    "  * catalog.Indexes[name].uniqueValues()                 — distinct values\n"
+    "  * catalog.Indexes[name]._apply_index({{name: value}})  — zoids per value\n"
+    "  * catalog(**query)                                      — full secured search\n"
+    "If you have a legitimate usecase, please file an issue at "
+    "https://github.com/bluedynamics/plone-pgcatalog/issues with the "
+    "caller and the expected result shape."
+)
+```
+
+### 5. Deprecation warning on `PGIndex._index`
+
+```python
+@property
+def _index(self):
+    warnings.warn(
+        f"PGIndex._index accessed for {self._idx_key!r}: ZCatalog "
+        f"BTree-shaped API is emulated against PostgreSQL; prefer "
+        f"catalog.Indexes[name].uniqueValues() or catalog(**query).",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return self._pg_index
+```
+
+Python's default warning filter shows each unique `(module, lineno, message)` once per process — effectively once per caller site, no log flood, consistent with the Plone deprecation guide.
+
+## Module structure
+
+All changes stay in existing files:
+- `src/plone/pgcatalog/maintenance.py` — add `_resolve_catalog` helper; extend `_CatalogCompat.indexes` property with `__parent__` self-heal; update `_CatalogCompat.getIndex` and `_CatalogIndexesView.__getitem__` to use `_resolve_catalog` instead of inline `aq_parent(aq_inner(...))` with raw-index fallback.
+- `src/plone/pgcatalog/pgindex.py` — add `_apply_index` on `PGIndex`; add `__getitem__` / `__len__` / `items` / `values` on `_PGIndexMapping`; wrap `_index` property in deprecation warning.
+- `src/plone/pgcatalog/query.py` — no changes. `QueryBuilder._process_index` is reused as-is.
+
+## Tests
+
+### Unit (`tests/test_pgindex.py`, `tests/test_catalog_indexes_view.py`)
+
+**`_resolve_catalog`**
+- `test_resolve_catalog_via_explicit_parent`
+- `test_resolve_catalog_via_acquisition`
+- `test_resolve_catalog_via_get_site`
+- `test_resolve_catalog_raises_when_all_fail`
+
+**Self-heal `__parent__`**
+- `test_property_sets_parent_from_get_site` — unmigrated compat + `getSite()` returns tool → `__parent__` set, `_p_changed=True`
+- `test_property_skips_parent_heal_when_no_site` — no site hook → property still works, `__parent__` stays unset
+
+**`PGIndex._apply_index`**
+- `test_apply_index_field_single_value` → correct zoid set
+- `test_apply_index_keyword_single_value` (`{"Subject": "AT26"}`)
+- `test_apply_index_keyword_or` (`{"Subject": {"query": ["a","b"], "operator": "or"}}`)
+- `test_apply_index_path_subtree`
+- `test_apply_index_date_range` — sanity for Date dispatch
+- `test_apply_index_returns_empty_when_index_not_in_request`
+- `test_apply_index_ignores_resultset_kwarg`
+- `test_apply_index_no_implicit_security` — object with `allowed_roles=['Manager']` still returned
+- `test_apply_index_emits_deprecation_warning` — `pytest.warns(DeprecationWarning)`
+
+**`_PGIndexMapping` new methods**
+- `test_getitem_returns_zoid` / `test_getitem_raises_keyerror_on_miss`
+- `test_len_scalar` / `test_len_keyword` (incl. legacy-scalar branch)
+- `test_items_raises_notimplemented_with_guidance`
+- `test_values_raises_notimplemented_with_guidance`
+
+**`PGIndex._index` deprecation**
+- `test_index_property_warns`
+
+**`_CatalogCompat.getIndex` / `_CatalogIndexesView.__getitem__` without `__parent__`**
+- `test_get_index_finds_catalog_via_get_site`
+- `test_get_index_raises_runtimeerror_when_all_fail`
+- `test_get_index_with_parent_still_works` (regression guard)
+
+### Integration (PG-backed layer)
+
+- `test_keywords_vocabulary_returns_individual_keywords` — full `KeywordsVocabulary()(context)` round-trip, assert tag strings
+- `test_keywords_vocabulary_survives_missing_parent` — clear `__parent__` on compat, fetch vocabulary, still works via `getSite` fallback
+
+### Regression
+
+All existing `uniqueValues` / `_PGIndexMapping` / `PGCatalogIndexes` / `_CatalogIndexesView` tests must stay green. Specifically:
+- `TestPGIndexMappingKeyword::test_mapping_iterates_individual_keywords` (b60 guarantee)
+- `TestPGIndexKeyword::test_keyword_unique_values_returns_individual_tags` (b59 guarantee)
+- `TestViewWithoutCatalog::*` — needs updating to match the new `RuntimeError`-or-explicit-parent contract.
+
+**Target**: existing 1403 tests + ~17 new, all green. The one test class `TestViewWithoutCatalog` moves from "passing with buggy raw fallback" to "updated to match new contract" — net-zero count.
+
+## Prod recovery / deployment story
+
+On aaf-prod after deploy of v1.0.0b61:
+
+1. Any page that fetches a vocabulary, renders a tile, or runs a search triggers `_CatalogCompat.indexes` property access.
+2. The b60-extended self-heal renames legacy state (no-op on prod — already done) **and** detects missing `__parent__`, finds the tool via `getSite().portal_catalog`, persists it, marks dirty.
+3. First ZODB commit of that request writes `__parent__` to PG.
+4. Subsequent requests hit the fast path (`__parent__` set, no `getSite` lookup needed).
+5. `KeywordsVocabulary` now finds a real `PGIndex` via `_resolve_catalog`, iterates the `_PGIndexMapping`, and returns individual keywords.
+
+**No manual intervention required**: no re-run of the upgrade step, no SQL patch, no pod restart.
+
+**Verification SQL after deploy + one request**:
+```sql
+SELECT state ? '__parent__' FROM object_state WHERE zoid = <compat_zoid>;
+-- expected: t
+```
+
+**Rollback story**: pure Python code change, no DDL, no data migration. `kubectl rollout undo` returns to b60; the persisted `__parent__` attribute is ignored by b60 (harmless).
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| `QueryBuilder._process_index` expects `self._query` context for `_handle_text` cross-index Language lookup | Set `builder._query = request` before the call |
+| `getSite()` returns `None` during Zope startup before site initialization | Self-heal is tolerant (`if site is not None`); lookup chain falls back to other mechanisms; `RuntimeError` only when **all three** resolution paths fail |
+| `_p_changed = True` on a compat without a Jar (unit tests) | Already solved via `_test_inject_jar` in b59; new self-heal path respects the same escape hatch (tests can construct compat with explicit `__parent__` to bypass the heal) |
+| Deprecation warnings could be noisy in production logs | Python default filter shows each `(module, lineno, message)` once per process; in practice one log line per caller site per deploy |
+| Breaking change on `TestViewWithoutCatalog` | One test file updated to reflect new contract; documented in PR |
+
+## Out of scope — tracking
+
+Independent follow-ups that won't be tackled here:
+
+- `items()` / `values()` real implementation (only if a concrete caller appears)
+- `_apply_index(resultset=...)` index-chaining (only if a caller needs SQL-side intersection)
+- Security filter on `_apply_index` (explicitly rejected — matches ZCatalog semantics)
+- `object_state`-as-source concerns (three separate points: security on `uniqueValues`, scan cost on huge catalogs, `catalog_state` denormalization) — own tracking issue
+
+## Release
+
+- PR on branch `fix/pgindex-apply-index-and-parent-resolution`
+- Branch closes #146
+- Target version: `1.0.0b61`
+- CHANGES.md entry written when the PR lands

--- a/src/plone/pgcatalog/maintenance.py
+++ b/src/plone/pgcatalog/maintenance.py
@@ -14,6 +14,7 @@ from plone.pgcatalog.backends import get_backend
 from plone.pgcatalog.indexing import reindex_object as _sql_reindex
 from plone.pgcatalog.pgindex import _maybe_wrap_index
 from psycopg import sql as pgsql
+from zope.component.hooks import getSite
 
 import logging
 
@@ -89,6 +90,42 @@ def clear_catalog_data(conn):
 # ---------------------------------------------------------------------------
 # _CatalogCompat: minimal shim for ZCatalogIndexes and addons
 # ---------------------------------------------------------------------------
+
+
+def _resolve_catalog(compat):
+    """Find the PlonePGCatalogTool that owns this _CatalogCompat.
+
+    Tries three resolution paths in order:
+
+    1. ``__parent__`` set on the bare instance (by the v1->v2 migration
+       step or by the ``indexes`` property's self-heal).
+    2. Acquisition chain — ``aq_parent(aq_inner(compat))`` — when the
+       compat is reached via an Acquisition wrapper and some parent in
+       the chain is the catalog tool.
+    3. ``zope.component.hooks.getSite().portal_catalog`` — works during
+       request handling and in any code path that sets up the local
+       site hook.
+
+    Raises ``RuntimeError`` if all three fail.  **Never returns
+    ``None``** — a silent ``None`` triggered the raw-index fallback
+    bug that masked #143 / #146 for weeks.
+    """
+    parent = compat.__dict__.get("__parent__")
+    if parent is not None:
+        return parent
+    via_aq = aq_parent(aq_inner(compat))
+    if via_aq is not None:
+        return via_aq
+    site = getSite()
+    if site is not None:
+        tool = getattr(site, "portal_catalog", None)
+        if tool is not None:
+            return tool
+    raise RuntimeError(
+        "plone.pgcatalog._CatalogCompat: cannot find portal_catalog "
+        "(no __parent__, no acquisition context, no getSite). "
+        "_CatalogCompat is not usable outside a Plone site."
+    )
 
 
 class _CatalogIndexesView:

--- a/src/plone/pgcatalog/maintenance.py
+++ b/src/plone/pgcatalog/maintenance.py
@@ -137,10 +137,11 @@ class _CatalogIndexesView:
     unchanged (they write raw ZCatalog index objects, as the upstream
     catalog.py / setuphandlers.py code expects).
 
-    Finds the catalog via acquisition from the _CatalogCompat instance
-    that built the view — no ``api.portal.get_tool`` needed.  When no
-    catalog is reachable (e.g. during tests or bootstrap), falls back
-    to returning the raw index.
+    Finds the catalog via ``_resolve_catalog(self._compat)`` which
+    tries ``__parent__`` → acquisition chain → ``getSite()``.  If
+    none of those three paths yield the catalog tool, a
+    ``RuntimeError`` propagates out of ``__getitem__`` — the old
+    silent raw-index fallback is gone (see #146).
     """
 
     __slots__ = ("_compat", "_raw")
@@ -152,12 +153,17 @@ class _CatalogIndexesView:
     # read-through access → wrapped
     def __getitem__(self, key):
         raw_index = self._raw[key]  # raises KeyError
-        catalog = aq_parent(aq_inner(self._compat))
-        if catalog is None:
-            return raw_index
+        catalog = _resolve_catalog(self._compat)
         return _maybe_wrap_index(catalog, key, raw_index)
 
     def get(self, key, default=None):
+        """Dict-style get with *default* on missing key.
+
+        Catches only ``KeyError`` (missing index name).  A
+        ``RuntimeError`` from an unreachable catalog is a configuration
+        bug and must propagate — suppressing it would recreate the
+        silent-empty-results failure mode #146 set out to eliminate.
+        """
         try:
             return self[key]
         except KeyError:

--- a/src/plone/pgcatalog/maintenance.py
+++ b/src/plone/pgcatalog/maintenance.py
@@ -243,15 +243,15 @@ class _CatalogCompat(Implicit, Persistent):
         profile upgrade step), so the catalog tool is reachable even
         through bare attribute access like ``tool._catalog.indexes``.
 
-        Self-heals an unmigrated persisted state where the legacy
-        ``indexes`` PersistentMapping is still in ``__dict__`` instead of
-        ``_raw_indexes``.  This matters because any AttributeError raised
-        here is swallowed by Acquisition, which then returns the tool's
-        ``indexes()`` method from the parent — producing the
-        "'function' object has no attribute 'keys'" traceback at
-        ``catalog.indexes.keys()`` instead of surfacing the real cause.
-        Fresh-install sites and sites where the v1->v2 upgrade step
-        silently no-op'd (see #139) hit this path.
+        Self-heals two forms of stale persisted state:
+
+        1. Legacy ``indexes`` attribute (pre-b55) is renamed to
+           ``_raw_indexes`` on first access.
+        2. Missing ``__parent__`` attribute (prod sites where the
+           v1->v2 upgrade ran before the #139 fix) is re-populated via
+           ``zope.component.hooks.getSite().portal_catalog`` when
+           available.  This avoids the silent raw-index fallback that
+           masked #143/#146 for weeks.
         """
         state = self.__dict__
         raw = state.get("_raw_indexes")
@@ -261,6 +261,12 @@ class _CatalogCompat(Implicit, Persistent):
                 raw = PersistentMapping()
             state["_raw_indexes"] = raw
             self._p_changed = True
+        if state.get("__parent__") is None:
+            site = getSite()
+            tool = getattr(site, "portal_catalog", None) if site else None
+            if tool is not None:
+                state["__parent__"] = tool
+                self._p_changed = True
         return _CatalogIndexesView(self, raw)
 
     def getIndex(self, name):

--- a/src/plone/pgcatalog/maintenance.py
+++ b/src/plone/pgcatalog/maintenance.py
@@ -273,17 +273,19 @@ class _CatalogCompat(Implicit, Persistent):
         """Return a PG-backed index wrapper for *name*.
 
         Mirrors ``self.indexes[name]`` but implemented directly on the
-        method so that when invoked through the Acquisition wrapper
-        (``tool._catalog.getIndex("x")``), ``self`` is the wrapper and
-        ``aq_parent(aq_inner(self))`` can reach the catalog — useful
-        for legacy objects that don't yet carry ``__parent__``.
+        method so legacy callers (``eea.facetednavigation``,
+        ``plone.app.vocabularies.Keywords``) keep working through the
+        Acquisition wrapper.
 
-        Raises ``KeyError`` if *name* is not a known index.
+        Unlike the pre-#146 implementation, this does **not** fall back
+        to the raw ZCatalog index when the catalog tool is
+        unreachable — a raw index has empty BTrees in pgcatalog and
+        silently returns empty result sets, which masked #143/#146 for
+        weeks.  Instead, ``_resolve_catalog`` raises ``RuntimeError``
+        if none of its three lookup strategies finds the catalog.
         """
         raw_index = self._raw_indexes[name]  # raises KeyError if missing
-        catalog = aq_parent(aq_inner(self))
-        if catalog is None:
-            return raw_index
+        catalog = _resolve_catalog(self)
         return _maybe_wrap_index(catalog, name, raw_index)
 
 

--- a/src/plone/pgcatalog/pgindex.py
+++ b/src/plone/pgcatalog/pgindex.py
@@ -78,6 +78,20 @@ class _PGIndexMapping:
     def __contains__(self, value):
         return self.get(value) is not None
 
+    def __getitem__(self, value):
+        """Dict-style lookup, raising ``KeyError`` on miss.
+
+        For KeywordIndex, returns the zoid of *some* object whose array
+        contains *value* (matches the ``get()`` semantics — not the
+        full IITreeSet that ZCatalog's OOBTree[value] would return).
+        Callers wanting the IITreeSet should use
+        ``PGIndex._apply_index({name: value})``.
+        """
+        zoid = self.get(value)
+        if zoid is None:
+            raise KeyError(value)
+        return zoid
+
     def keys(self):
         try:
             conn = self._get_conn()

--- a/src/plone/pgcatalog/pgindex.py
+++ b/src/plone/pgcatalog/pgindex.py
@@ -132,6 +132,42 @@ class _PGIndexMapping:
         """
         return iter(self.keys())
 
+    def __len__(self):
+        """Count distinct index values.
+
+        For scalar indexes: ``SELECT COUNT(DISTINCT idx->>key)``.
+        For KEYWORD: same ``UNION ALL`` pattern as ``keys()``, wrapped
+        in ``COUNT(DISTINCT val)``.
+        """
+        try:
+            conn = self._get_conn()
+        except Exception:
+            return 0
+        if self._index_type == IndexType.KEYWORD:
+            sql = (
+                "SELECT COUNT(DISTINCT val) AS n FROM ("
+                "  SELECT jsonb_array_elements_text(idx->%(key)s) AS val "
+                "    FROM object_state "
+                "    WHERE idx ? %(key)s "
+                "      AND jsonb_typeof(idx->%(key)s) = 'array' "
+                "  UNION ALL "
+                "  SELECT idx->>%(key)s AS val "
+                "    FROM object_state "
+                "    WHERE idx ? %(key)s "
+                "      AND jsonb_typeof(idx->%(key)s) NOT IN ('array', 'null') "
+                ") u WHERE val IS NOT NULL"
+            )
+        else:
+            sql = (
+                "SELECT COUNT(DISTINCT idx->>%(key)s) AS n "
+                "FROM object_state "
+                "WHERE idx ? %(key)s AND idx->>%(key)s IS NOT NULL"
+            )
+        with conn.cursor() as cur:
+            cur.execute(sql, {"key": self._idx_key})
+            row = cur.fetchone()
+        return int(row["n"]) if row and row["n"] is not None else 0
+
 
 class PGIndex:
     """Proxy wrapping a ZCatalog index with PG-backed data access.

--- a/src/plone/pgcatalog/pgindex.py
+++ b/src/plone/pgcatalog/pgindex.py
@@ -28,6 +28,7 @@ from plone.pgcatalog.query import _bool_to_lower_str
 from Products.ZCatalog.ZCatalogIndexes import ZCatalogIndexes
 
 import logging
+import warnings
 
 
 log = logging.getLogger(__name__)
@@ -204,6 +205,24 @@ class PGIndex:
 
     @property
     def _index(self):
+        """PG-backed mapping that emulates ZCatalog's ``Index._index``
+        OOBTree.
+
+        Emitting a ``DeprecationWarning`` signals callers that they are
+        on an emulation path; the preferred APIs are
+        ``catalog.Indexes[name].uniqueValues()`` for distinct values
+        and ``catalog(**query)`` for full searches.  Python's default
+        warning filter shows each unique ``(module, lineno, message)``
+        once per process, so this amounts to one log line per caller
+        site per deploy — no log flood.
+        """
+        warnings.warn(
+            f"PGIndex._index accessed for {self._idx_key!r}: ZCatalog "
+            f"BTree-shaped API is emulated against PostgreSQL; prefer "
+            f"catalog.Indexes[name].uniqueValues() or catalog(**query).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._pg_index
 
     def uniqueValues(self, name=None, withLengths=False):

--- a/src/plone/pgcatalog/pgindex.py
+++ b/src/plone/pgcatalog/pgindex.py
@@ -21,6 +21,7 @@ matching ``getpath()``/``getrid()`` on the catalog.
 
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from BTrees.IIBTree import IITreeSet
 from plone.pgcatalog.columns import get_registry
 from plone.pgcatalog.columns import IndexType
 from plone.pgcatalog.interfaces import IPGCatalogTool
@@ -297,6 +298,56 @@ class PGIndex:
                 cur.execute(grouped_sql, params)
                 for row in cur.fetchall():
                     yield (row["val"], row["cnt"])
+
+    def _apply_index(self, request, resultset=None):
+        """ZCatalog-compatible low-level query entry point.
+
+        Returns ``(IITreeSet(zoids), (index_name,))``.  Matches
+        ZCatalog semantics:
+
+        * No implicit security filtering.  Callers that need secured
+          results must use ``catalog(**query)``.
+        * Empty set if this index isn't in ``request``.
+        * ``resultset`` is accepted for signature compatibility but
+          currently ignored (see #146 non-goals — index-chaining can
+          land in a follow-up issue if a caller needs SQL-side
+          intersection).
+
+        Implementation reuses ``plone.pgcatalog.query._QueryBuilder``
+        so every registered IndexType and every
+        ``IPGIndexTranslator`` utility works for free — the dispatch
+        table stays in one place.
+        """
+        from plone.pgcatalog.query import _QueryBuilder
+
+        index_id = getattr(self._wrapped, "id", self._idx_key)
+        if index_id not in request:
+            return IITreeSet(), (index_id,)
+
+        warnings.warn(
+            f"PGIndex._apply_index({index_id!r}) called: this is a "
+            f"ZCatalog-compatibility shim; prefer catalog(**query) for "
+            f"the full pgcatalog query pipeline.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        try:
+            conn = self._pg_index._get_conn()
+        except Exception:
+            return IITreeSet(), (index_id,)
+
+        builder = _QueryBuilder()
+        builder._query = request  # for cross-index Language lookup
+        builder.clauses.append("idx IS NOT NULL")
+        builder._process_index(index_id, request[index_id])
+        result = builder.result()
+        sql = f"SELECT zoid FROM object_state WHERE {result['where']}"
+
+        with conn.cursor() as cur:
+            cur.execute(sql, result["params"])
+            zoids = IITreeSet(row["zoid"] for row in cur.fetchall())
+        return zoids, (index_id,)
 
     def __getattr__(self, name):
         return getattr(self._wrapped, name)

--- a/src/plone/pgcatalog/pgindex.py
+++ b/src/plone/pgcatalog/pgindex.py
@@ -34,6 +34,19 @@ log = logging.getLogger(__name__)
 
 _marker = []
 
+_ITEMS_VALUES_NOT_IMPLEMENTED = (
+    "PGIndex._index.{method}() is not implemented in plone.pgcatalog: "
+    "the ZCatalog BTree shape [(value, IITreeSet(rids)), ...] materializes "
+    "all (value, objects)-pairs of the index, which would be prohibitively "
+    "expensive against the PG-backed catalog.  Alternatives:\n"
+    "  * catalog.Indexes[name].uniqueValues()                 — distinct values\n"
+    "  * catalog.Indexes[name]._apply_index({{name: value}})  — zoids per value\n"
+    "  * catalog(**query)                                      — full secured search\n"
+    "If you have a legitimate usecase, please file an issue at "
+    "https://github.com/bluedynamics/plone-pgcatalog/issues with the "
+    "caller and the expected result shape."
+)
+
 
 class _PGIndexMapping:
     """Dict-like object backing ``PGIndex._index``.
@@ -167,6 +180,12 @@ class _PGIndexMapping:
             cur.execute(sql, {"key": self._idx_key})
             row = cur.fetchone()
         return int(row["n"]) if row and row["n"] is not None else 0
+
+    def items(self):
+        raise NotImplementedError(_ITEMS_VALUES_NOT_IMPLEMENTED.format(method="items"))
+
+    def values(self):
+        raise NotImplementedError(_ITEMS_VALUES_NOT_IMPLEMENTED.format(method="values"))
 
 
 class PGIndex:

--- a/tests/test_catalog_indexes_view.py
+++ b/tests/test_catalog_indexes_view.py
@@ -15,17 +15,29 @@ def _fresh_compat():
     return _CatalogCompat()
 
 
-# ── Wrapper contract when no catalog context is reachable ─────────────────
+# ── View with no reachable catalog: must raise, not return raw ───────────
 
 
 class TestViewWithoutCatalog:
-    def test_view_returns_raw_on_getitem_when_no_catalog(self):
-        """Without an acquisition parent, accessing a key returns the raw index."""
+    """Pre-#146 behavior: getitem returned the raw ZCatalog index when
+    aq_parent returned None.  That masked silent "empty results" bugs.
+    New contract: the view raises RuntimeError when no catalog is
+    reachable.  Callers that intentionally work without a catalog now
+    need to set __parent__ explicitly.
+    """
+
+    def test_getitem_raises_when_no_catalog_reachable(self):
+        import pytest
+
         compat = _fresh_compat()
         raw = mock.Mock(id="portal_type", meta_type="FieldIndex")
         compat._raw_indexes["portal_type"] = raw
-        # No acquisition parent — should fall back to raw
-        assert compat.indexes["portal_type"] is raw
+
+        with (
+            mock.patch("plone.pgcatalog.maintenance.getSite", return_value=None),
+            pytest.raises(RuntimeError, match="cannot find portal_catalog"),
+        ):
+            _ = compat.indexes["portal_type"]
 
     def test_view_keys_are_unwrapped_strings(self):
         compat = _fresh_compat()

--- a/tests/test_catalog_indexes_view.py
+++ b/tests/test_catalog_indexes_view.py
@@ -373,3 +373,60 @@ class TestResolveCatalog:
             pytest.raises(RuntimeError, match="cannot find portal_catalog"),
         ):
             _resolve_catalog(compat)
+
+
+# ── Self-heal: __parent__ gets persisted on first indexes access ─────────
+
+
+class TestParentSelfHeal:
+    def test_property_heals_missing_parent_via_get_site(self):
+        from plone.pgcatalog.maintenance import _CatalogCompat
+
+        compat = _CatalogCompat.__new__(_CatalogCompat)
+        compat.__dict__["_raw_indexes"] = PersistentMapping()
+        compat.__dict__["schema"] = PersistentMapping()
+        # no __parent__
+        compat._p_changed = False
+
+        tool = mock.Mock(name="portal_catalog")
+        site = mock.Mock(portal_catalog=tool)
+
+        # Need a fake jar so ``_p_changed = True`` sticks under Persistent.
+        from plone.pgcatalog.upgrades.profile_2 import _NoOpJar
+
+        compat._p_jar = _NoOpJar()
+
+        with mock.patch("plone.pgcatalog.maintenance.getSite", return_value=site):
+            _view = compat.indexes  # trigger property
+
+        assert compat.__dict__.get("__parent__") is tool
+        assert compat._p_changed is True
+
+    def test_property_tolerates_get_site_returning_none(self):
+        from plone.pgcatalog.maintenance import _CatalogCompat
+
+        compat = _CatalogCompat.__new__(_CatalogCompat)
+        compat.__dict__["_raw_indexes"] = PersistentMapping()
+        # no __parent__, no site hook
+
+        with mock.patch("plone.pgcatalog.maintenance.getSite", return_value=None):
+            _view = compat.indexes  # must not raise
+
+        assert "__parent__" not in compat.__dict__
+
+    def test_property_leaves_existing_parent_untouched(self):
+        from plone.pgcatalog.maintenance import _CatalogCompat
+
+        explicit = mock.Mock(name="explicit-parent")
+        other = mock.Mock(name="get-site-tool")
+        site = mock.Mock(portal_catalog=other)
+
+        compat = _CatalogCompat.__new__(_CatalogCompat)
+        compat.__dict__["_raw_indexes"] = PersistentMapping()
+        compat.__dict__["__parent__"] = explicit
+
+        with mock.patch("plone.pgcatalog.maintenance.getSite", return_value=site):
+            _view = compat.indexes
+
+        # Still the explicit parent — self-heal must only set when missing.
+        assert compat.__dict__["__parent__"] is explicit

--- a/tests/test_catalog_indexes_view.py
+++ b/tests/test_catalog_indexes_view.py
@@ -430,3 +430,59 @@ class TestParentSelfHeal:
 
         # Still the explicit parent — self-heal must only set when missing.
         assert compat.__dict__["__parent__"] is explicit
+
+
+# ── getIndex no longer falls back to the raw index silently ─────────────
+
+
+class TestGetIndexWithoutParent:
+    def test_finds_catalog_via_get_site_returns_wrapped(self, pg_conn_with_catalog):
+        from plone.pgcatalog.catalog import PlonePGCatalogTool
+        from plone.pgcatalog.maintenance import _CatalogCompat
+        from plone.pgcatalog.pgindex import PGIndex
+
+        tool = PlonePGCatalogTool.__new__(PlonePGCatalogTool)
+        tool._get_pg_read_connection = lambda: pg_conn_with_catalog
+        compat = _CatalogCompat()
+        tool._catalog = compat
+        raw = mock.Mock(id="portal_type", meta_type="FieldIndex")
+        compat._raw_indexes["portal_type"] = raw
+
+        # no __parent__, no acquisition — only getSite works
+        site = mock.Mock(portal_catalog=tool)
+        with mock.patch("plone.pgcatalog.maintenance.getSite", return_value=site):
+            result = compat.getIndex("portal_type")
+
+        assert isinstance(result, PGIndex)
+        assert result._wrapped is raw
+
+    def test_raises_runtimeerror_when_all_three_fail(self):
+        from plone.pgcatalog.maintenance import _CatalogCompat
+
+        import pytest
+
+        compat = _CatalogCompat()
+        raw = mock.Mock(id="portal_type", meta_type="FieldIndex")
+        compat._raw_indexes["portal_type"] = raw
+
+        with (
+            mock.patch("plone.pgcatalog.maintenance.getSite", return_value=None),
+            pytest.raises(RuntimeError, match="cannot find portal_catalog"),
+        ):
+            compat.getIndex("portal_type")
+
+    def test_explicit_parent_still_works(self, pg_conn_with_catalog):
+        """Regression guard — the happy path remains unchanged."""
+        from plone.pgcatalog.catalog import PlonePGCatalogTool
+        from plone.pgcatalog.maintenance import _CatalogCompat
+        from plone.pgcatalog.pgindex import PGIndex
+
+        tool = PlonePGCatalogTool.__new__(PlonePGCatalogTool)
+        tool._get_pg_read_connection = lambda: pg_conn_with_catalog
+        compat = _CatalogCompat(parent=tool)
+        tool._catalog = compat
+        raw = mock.Mock(id="portal_type", meta_type="FieldIndex")
+        compat._raw_indexes["portal_type"] = raw
+
+        result = compat.getIndex("portal_type")
+        assert isinstance(result, PGIndex)

--- a/tests/test_catalog_indexes_view.py
+++ b/tests/test_catalog_indexes_view.py
@@ -320,3 +320,56 @@ class TestGetIndexMethod:
         result = tool._catalog.getIndex("portal_type")
         assert isinstance(result, PGIndex)
         assert result._wrapped is raw
+
+
+# ── _resolve_catalog: three-step lookup, no silent None ──────────────────
+
+
+class TestResolveCatalog:
+    def test_returns_explicit_parent_first(self):
+        from plone.pgcatalog.maintenance import _CatalogCompat
+        from plone.pgcatalog.maintenance import _resolve_catalog
+
+        compat = _CatalogCompat()
+        tool = mock.Mock(name="tool-via-parent")
+        compat.__dict__["__parent__"] = tool
+
+        assert _resolve_catalog(compat) is tool
+
+    def test_falls_through_to_acquisition_parent(self):
+        from Acquisition import Implicit
+        from plone.pgcatalog.maintenance import _CatalogCompat
+        from plone.pgcatalog.maintenance import _resolve_catalog
+
+        class _ParentHolder(Implicit):
+            pass
+
+        parent = _ParentHolder()
+        compat = _CatalogCompat()
+        wrapped = compat.__of__(parent)  # Acquisition wrapper
+
+        assert _resolve_catalog(wrapped) is parent
+
+    def test_falls_through_to_get_site_portal_catalog(self):
+        from plone.pgcatalog.maintenance import _CatalogCompat
+        from plone.pgcatalog.maintenance import _resolve_catalog
+
+        compat = _CatalogCompat()
+        tool = mock.Mock(name="tool-via-get-site")
+        site = mock.Mock(portal_catalog=tool)
+
+        with mock.patch("plone.pgcatalog.maintenance.getSite", return_value=site):
+            assert _resolve_catalog(compat) is tool
+
+    def test_raises_runtimeerror_when_all_three_fail(self):
+        from plone.pgcatalog.maintenance import _CatalogCompat
+        from plone.pgcatalog.maintenance import _resolve_catalog
+
+        import pytest
+
+        compat = _CatalogCompat()
+        with (
+            mock.patch("plone.pgcatalog.maintenance.getSite", return_value=None),
+            pytest.raises(RuntimeError, match="cannot find portal_catalog"),
+        ):
+            _resolve_catalog(compat)

--- a/tests/test_pg_integration.py
+++ b/tests/test_pg_integration.py
@@ -1444,3 +1444,74 @@ class TestMaintenanceOps:
         )
         # Either no rows with path (path NULLed) or idx is None
         assert not rows or rows[0][0] is None
+
+
+# ===========================================================================
+# KeywordsVocabulary — end-to-end tag autocomplete via PGIndex (#146)
+# ===========================================================================
+
+
+class TestKeywordsVocabulary:
+    """Regression for #146: typing into the tag/Schlagwort autocomplete
+    offers individual keywords, not serialized JSON arrays or nothing."""
+
+    def test_keywords_vocabulary_returns_individual_keywords(self, pg_functional):
+        from plone.app.vocabularies.catalog import KeywordsVocabularyFactory
+
+        portal = pg_functional["portal"]
+        setRoles(portal, TEST_USER_ID, ["Manager"])
+
+        # Create two Documents with distinct Subject keywords.
+        doc1 = portal.invokeFactory(
+            "Document",
+            "kv-doc1",
+            title="D1",
+            subject=("alpha", "beta"),
+        )
+        doc2 = portal.invokeFactory(
+            "Document",
+            "kv-doc2",
+            title="D2",
+            subject=("beta", "gamma"),
+        )
+        portal[doc1].reindexObject()
+        portal[doc2].reindexObject()
+        transaction.commit()
+
+        vocab = KeywordsVocabularyFactory(portal)
+        tokens = {term.value for term in vocab}
+        assert tokens == {"alpha", "beta", "gamma"}
+
+    def test_keywords_vocabulary_survives_missing_parent(self, pg_functional):
+        """Regression guard for the __parent__-missing production case:
+        clear __parent__ on the compat, fetch vocabulary — ``getIndex``
+        still finds the tool via ``_resolve_catalog``'s ``getSite``
+        branch and the vocabulary returns correct tokens.
+
+        Persistent self-heal of ``__parent__`` is tested separately
+        against the ``.indexes`` property (Task 2).  The ``getIndex``
+        code path used by the vocabulary doesn't persist via self-heal
+        — it relies on the lookup fallback each time.  Both behaviors
+        are correct and complementary.
+        """
+        portal = pg_functional["portal"]
+        setRoles(portal, TEST_USER_ID, ["Manager"])
+
+        doc_id = portal.invokeFactory(
+            "Document",
+            "kv-doc-x",
+            title="X",
+            subject=("AT26",),
+        )
+        portal[doc_id].reindexObject()
+        transaction.commit()
+
+        # Simulate production state: wipe __parent__ from the compat.
+        compat = portal.portal_catalog._catalog
+        compat.__dict__.pop("__parent__", None)
+
+        from plone.app.vocabularies.catalog import KeywordsVocabularyFactory
+
+        vocab = KeywordsVocabularyFactory(portal)
+        tokens = {term.value for term in vocab}
+        assert "AT26" in tokens

--- a/tests/test_pgindex.py
+++ b/tests/test_pgindex.py
@@ -810,3 +810,43 @@ class TestPGIndexApplyIndex:
         )
         assert set(result) == {100, 101}
         assert info == ("portal_type",)
+
+    def test_keyword_index_single_value(self, pg_conn_with_catalog):
+        from plone.pgcatalog.columns import IndexType
+
+        _catalog_keyword_objects(pg_conn_with_catalog)
+        # Fixture: 200={Werkvortrag, Tirol, Aktuelles}, 201={Tirol,
+        # AUSSCHREIBUNG}, 202={Aktuelles}
+        result, info = _apply_pg_index(
+            "Subject",
+            IndexType.KEYWORD,
+            pg_conn_with_catalog,
+            {"Subject": "Tirol"},
+        )
+        assert set(result) == {200, 201}
+
+    def test_keyword_index_or_operator(self, pg_conn_with_catalog):
+        from plone.pgcatalog.columns import IndexType
+
+        _catalog_keyword_objects(pg_conn_with_catalog)
+        result, info = _apply_pg_index(
+            "Subject",
+            IndexType.KEYWORD,
+            pg_conn_with_catalog,
+            {"Subject": {"query": ["Aktuelles", "AUSSCHREIBUNG"], "operator": "or"}},
+        )
+        assert set(result) == {200, 201, 202}
+
+    def test_path_index_subtree(self, pg_conn_with_catalog):
+        from plone.pgcatalog.columns import IndexType
+
+        _catalog_objects(pg_conn_with_catalog)  # paths /plone/doc1, etc.
+        result, info = _apply_pg_index(
+            "path",
+            IndexType.PATH,
+            pg_conn_with_catalog,
+            {"path": {"query": "/plone", "depth": -1}},
+        )
+        assert 100 in result
+        assert 101 in result
+        assert 102 in result

--- a/tests/test_pgindex.py
+++ b/tests/test_pgindex.py
@@ -850,3 +850,73 @@ class TestPGIndexApplyIndex:
         assert 100 in result
         assert 101 in result
         assert 102 in result
+
+    def test_date_index_range_query(self, pg_conn_with_catalog):
+        from datetime import datetime
+        from datetime import UTC
+        from plone.pgcatalog.columns import IndexType
+
+        insert_object(pg_conn_with_catalog, 300)
+        catalog_object(
+            pg_conn_with_catalog,
+            zoid=300,
+            path="/plone/event-2025",
+            idx={"portal_type": "Event", "start": "2025-06-15T10:00:00+00:00"},
+        )
+        insert_object(pg_conn_with_catalog, 301)
+        catalog_object(
+            pg_conn_with_catalog,
+            zoid=301,
+            path="/plone/event-2026",
+            idx={"portal_type": "Event", "start": "2026-03-15T10:00:00+00:00"},
+        )
+        pg_conn_with_catalog.commit()
+
+        result, info = _apply_pg_index(
+            "start",
+            IndexType.DATE,
+            pg_conn_with_catalog,
+            {"start": {"query": datetime(2026, 1, 1, tzinfo=UTC), "range": "min"}},
+        )
+        assert 301 in result
+        assert 300 not in result
+
+    def test_boolean_index(self, pg_conn_with_catalog):
+        from plone.pgcatalog.columns import IndexType
+
+        insert_object(pg_conn_with_catalog, 400)
+        catalog_object(
+            pg_conn_with_catalog,
+            zoid=400,
+            path="/plone/default",
+            idx={"portal_type": "Document", "is_default_page": True},
+        )
+        insert_object(pg_conn_with_catalog, 401)
+        catalog_object(
+            pg_conn_with_catalog,
+            zoid=401,
+            path="/plone/non-default",
+            idx={"portal_type": "Document", "is_default_page": False},
+        )
+        pg_conn_with_catalog.commit()
+
+        result, info = _apply_pg_index(
+            "is_default_page",
+            IndexType.BOOLEAN,
+            pg_conn_with_catalog,
+            {"is_default_page": True},
+        )
+        assert 400 in result
+        assert 401 not in result
+
+    def test_uuid_index(self, pg_conn_with_catalog):
+        from plone.pgcatalog.columns import IndexType
+
+        _catalog_objects(pg_conn_with_catalog)
+        result, info = _apply_pg_index(
+            "UID",
+            IndexType.UUID,
+            pg_conn_with_catalog,
+            {"UID": "uid-aaa-100"},
+        )
+        assert set(result) == {100}

--- a/tests/test_pgindex.py
+++ b/tests/test_pgindex.py
@@ -721,3 +721,26 @@ class TestPGIndexMappingNewMethods:
             index_type=IndexType.KEYWORD,
         )
         assert len(mapping) == 5  # 4 array keywords + "Legacy" scalar
+
+    def test_items_raises_notimplemented_with_guidance(self, pg_conn_with_catalog):
+        import pytest
+
+        _catalog_objects(pg_conn_with_catalog)
+        mapping = _PGIndexMapping("UID", lambda: pg_conn_with_catalog)
+        with pytest.raises(NotImplementedError) as excinfo:
+            mapping.items()
+        msg = str(excinfo.value)
+        assert "items()" in msg
+        assert "uniqueValues" in msg
+        assert "_apply_index" in msg
+        assert "catalog(**query)" in msg
+        assert "https://github.com/bluedynamics/plone-pgcatalog/issues" in msg
+
+    def test_values_raises_notimplemented_with_guidance(self, pg_conn_with_catalog):
+        import pytest
+
+        _catalog_objects(pg_conn_with_catalog)
+        mapping = _PGIndexMapping("UID", lambda: pg_conn_with_catalog)
+        with pytest.raises(NotImplementedError) as excinfo:
+            mapping.values()
+        assert "values()" in str(excinfo.value)

--- a/tests/test_pgindex.py
+++ b/tests/test_pgindex.py
@@ -665,3 +665,23 @@ class TestMaybeWrapIndex:
 
         wrapped = _maybe_wrap_index(catalog, "SearchableText", raw_index)
         assert wrapped is raw_index
+
+
+# ---------------------------------------------------------------------------
+# _PGIndexMapping: __getitem__, __len__, items/values NotImplementedError
+# ---------------------------------------------------------------------------
+
+
+class TestPGIndexMappingNewMethods:
+    def test_getitem_returns_zoid_for_existing_value(self, pg_conn_with_catalog):
+        _catalog_objects(pg_conn_with_catalog)
+        mapping = _PGIndexMapping("UID", lambda: pg_conn_with_catalog)
+        assert mapping["uid-aaa-100"] == 100
+
+    def test_getitem_raises_keyerror_on_miss(self, pg_conn_with_catalog):
+        import pytest
+
+        _catalog_objects(pg_conn_with_catalog)
+        mapping = _PGIndexMapping("UID", lambda: pg_conn_with_catalog)
+        with pytest.raises(KeyError, match="nonexistent-uid"):
+            _ = mapping["nonexistent-uid"]

--- a/tests/test_pgindex.py
+++ b/tests/test_pgindex.py
@@ -685,3 +685,39 @@ class TestPGIndexMappingNewMethods:
         mapping = _PGIndexMapping("UID", lambda: pg_conn_with_catalog)
         with pytest.raises(KeyError, match="nonexistent-uid"):
             _ = mapping["nonexistent-uid"]
+
+    def test_len_scalar_index(self, pg_conn_with_catalog):
+        _catalog_objects(pg_conn_with_catalog)  # 2 Documents, 1 Folder
+        mapping = _PGIndexMapping("portal_type", lambda: pg_conn_with_catalog)
+        assert len(mapping) == 2  # distinct values
+
+    def test_len_keyword_index(self, pg_conn_with_catalog):
+        from plone.pgcatalog.columns import IndexType
+
+        _catalog_keyword_objects(pg_conn_with_catalog)
+        mapping = _PGIndexMapping(
+            "Subject",
+            lambda: pg_conn_with_catalog,
+            index_type=IndexType.KEYWORD,
+        )
+        # distinct keywords across the three fixture docs
+        assert len(mapping) == 4
+
+    def test_len_keyword_with_legacy_scalar_row(self, pg_conn_with_catalog):
+        from plone.pgcatalog.columns import IndexType
+
+        _catalog_keyword_objects(pg_conn_with_catalog)
+        insert_object(pg_conn_with_catalog, 299)
+        catalog_object(
+            pg_conn_with_catalog,
+            zoid=299,
+            path="/plone/legacy-scalar",
+            idx={"portal_type": "Document", "Subject": "Legacy"},
+        )
+        pg_conn_with_catalog.commit()
+        mapping = _PGIndexMapping(
+            "Subject",
+            lambda: pg_conn_with_catalog,
+            index_type=IndexType.KEYWORD,
+        )
+        assert len(mapping) == 5  # 4 array keywords + "Legacy" scalar

--- a/tests/test_pgindex.py
+++ b/tests/test_pgindex.py
@@ -920,3 +920,81 @@ class TestPGIndexApplyIndex:
             {"UID": "uid-aaa-100"},
         )
         assert set(result) == {100}
+
+    def test_no_implicit_security_filter(self, pg_conn_with_catalog):
+        """_apply_index must NOT auto-inject allowed_roles — matches
+        ZCatalog semantics.  Object restricted to Managers still shows
+        up in the result set.
+        """
+        from plone.pgcatalog.columns import IndexType
+
+        insert_object(pg_conn_with_catalog, 500)
+        catalog_object(
+            pg_conn_with_catalog,
+            zoid=500,
+            path="/plone/private-event",
+            idx={
+                "portal_type": "Event",
+                "allowedRolesAndUsers": ["Manager"],
+            },
+        )
+        pg_conn_with_catalog.commit()
+
+        result, info = _apply_pg_index(
+            "portal_type",
+            IndexType.FIELD,
+            pg_conn_with_catalog,
+            {"portal_type": "Event"},
+        )
+        assert 500 in result
+
+    def test_resultset_parameter_ignored(self, pg_conn_with_catalog):
+        """The resultset kwarg is accepted but not yet wired to SQL."""
+        from BTrees.IIBTree import IITreeSet
+        from plone.pgcatalog.columns import IndexType
+        from plone.pgcatalog.pgindex import PGIndex
+
+        _catalog_objects(pg_conn_with_catalog)
+        wrapped = mock.Mock()
+        wrapped.id = "portal_type"
+        idx = PGIndex(
+            wrapped,
+            "portal_type",
+            lambda: pg_conn_with_catalog,
+            index_type=IndexType.FIELD,
+        )
+        base, _ = idx._apply_index({"portal_type": "Document"})
+        with_rs, _ = idx._apply_index(
+            {"portal_type": "Document"},
+            resultset=IITreeSet([100]),  # intentionally wrong
+        )
+        assert set(base) == set(with_rs)  # resultset ignored
+
+    def test_emits_deprecation_warning(self, pg_conn_with_catalog):
+        from plone.pgcatalog.columns import IndexType
+
+        import pytest
+
+        _catalog_objects(pg_conn_with_catalog)
+        with pytest.warns(DeprecationWarning, match="_apply_index"):
+            _apply_pg_index(
+                "portal_type",
+                IndexType.FIELD,
+                pg_conn_with_catalog,
+                {"portal_type": "Document"},
+            )
+
+    def test_handles_connection_error_returns_empty_set(self):
+        from BTrees.IIBTree import IITreeSet
+        from plone.pgcatalog.columns import IndexType
+        from plone.pgcatalog.pgindex import PGIndex
+
+        def bad_conn():
+            raise RuntimeError("no conn")
+
+        wrapped = mock.Mock()
+        wrapped.id = "portal_type"
+        idx = PGIndex(wrapped, "portal_type", bad_conn, index_type=IndexType.FIELD)
+        result, info = idx._apply_index({"portal_type": "Document"})
+        assert isinstance(result, IITreeSet)
+        assert list(result) == []

--- a/tests/test_pgindex.py
+++ b/tests/test_pgindex.py
@@ -744,3 +744,25 @@ class TestPGIndexMappingNewMethods:
         with pytest.raises(NotImplementedError) as excinfo:
             mapping.values()
         assert "values()" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# PGIndex._index deprecation warning
+# ---------------------------------------------------------------------------
+
+
+class TestPGIndexIndexDeprecation:
+    def test_index_property_emits_deprecation_warning(self):
+        from plone.pgcatalog.pgindex import PGIndex
+
+        import pytest
+
+        wrapped = mock.Mock()
+        wrapped.id = "portal_type"
+
+        def no_conn():
+            raise RuntimeError("no conn")
+
+        idx = PGIndex(wrapped, "portal_type", no_conn)
+        with pytest.warns(DeprecationWarning, match="PGIndex._index accessed"):
+            _ = idx._index

--- a/tests/test_pgindex.py
+++ b/tests/test_pgindex.py
@@ -766,3 +766,47 @@ class TestPGIndexIndexDeprecation:
         idx = PGIndex(wrapped, "portal_type", no_conn)
         with pytest.warns(DeprecationWarning, match="PGIndex._index accessed"):
             _ = idx._index
+
+
+# ---------------------------------------------------------------------------
+# PGIndex._apply_index (issue #146)
+# ---------------------------------------------------------------------------
+
+
+def _apply_pg_index(idx_key, index_type, pg_conn, request):
+    """Test helper: build a PGIndex and call _apply_index."""
+    from plone.pgcatalog.pgindex import PGIndex
+
+    wrapped = mock.Mock()
+    wrapped.id = idx_key
+    pg_index = PGIndex(wrapped, idx_key, lambda: pg_conn, index_type=index_type)
+    return pg_index._apply_index(request)
+
+
+class TestPGIndexApplyIndex:
+    def test_returns_empty_set_when_index_not_in_request(self, pg_conn_with_catalog):
+        from BTrees.IIBTree import IITreeSet
+        from plone.pgcatalog.columns import IndexType
+
+        result, info = _apply_pg_index(
+            "portal_type",
+            IndexType.FIELD,
+            pg_conn_with_catalog,
+            {"other_index": "whatever"},
+        )
+        assert isinstance(result, IITreeSet)
+        assert list(result) == []
+        assert info == ("portal_type",)
+
+    def test_field_index_single_value(self, pg_conn_with_catalog):
+        from plone.pgcatalog.columns import IndexType
+
+        _catalog_objects(pg_conn_with_catalog)
+        result, info = _apply_pg_index(
+            "portal_type",
+            IndexType.FIELD,
+            pg_conn_with_catalog,
+            {"portal_type": "Document"},
+        )
+        assert set(result) == {100, 101}
+        assert info == ("portal_type",)


### PR DESCRIPTION
## Summary

Closes #146. Compound fix for the Schlagwort-autocomplete production bug on aaf-prod, plus the underlying silent-failure class that masked #143/#146 for weeks.

### Root causes

1. **Silent raw-index fallback.** `_CatalogCompat.getIndex(name)` and `_CatalogIndexesView.__getitem__` used `aq_parent(aq_inner(self))` and fell back to returning the raw ZCatalog index when that came back `None`. In pgcatalog the raw BTrees are empty, so every caller hitting the fallback path silently got zero results.
2. **`PGIndex._apply_index` delegated to the raw ZCatalog index.** Callers using the ZCatalog low-level API (`plone.app.vocabularies.KeywordsVocabulary.keywords_of_section`, `CatalogSearchSource`, addon dashboards) therefore queried empty BTrees.

### Fixes

- New helper `_resolve_catalog(compat)` with three-step lookup (`__parent__` → Acquisition chain → `getSite().portal_catalog`) that raises `RuntimeError` if all three fail — no more silent `None`.
- `_CatalogCompat.indexes` property self-heals missing `__parent__` via `getSite` on first access. First page render after deploy persists the pointer; zero-touch prod recovery.
- `_CatalogCompat.getIndex` and `_CatalogIndexesView.__getitem__` now use `_resolve_catalog` instead of the inline `aq_parent` + raw fallback.
- `PGIndex._apply_index(request, resultset=None)` — ZCatalog-compatible low-level query entry. Reuses `_QueryBuilder._process_index` so every registered `IndexType` plus every `IPGIndexTranslator` works for free. Returns `(IITreeSet(zoids), (index_name,))`. No implicit security (matches ZCatalog semantics). Emits `DeprecationWarning` once per caller site.
- `_PGIndexMapping` gains `__getitem__` + `__len__`; `items()` / `values()` raise `NotImplementedError` with guidance pointing at `uniqueValues`, `_apply_index`, `catalog(**query)` (#147 tracks a real implementation if a caller surfaces).
- `PGIndex._index` property emits `DeprecationWarning` on access — signals callers the BTree-shaped API is an emulation.

## Spec & plan

- Spec: [`docs/superpowers/specs/2026-04-20-pgindex-apply-index-design.md`](https://github.com/bluedynamics/plone-pgcatalog/blob/fix/pgindex-apply-index-and-parent-resolution/docs/superpowers/specs/2026-04-20-pgindex-apply-index-design.md)
- Plan: [`docs/superpowers/plans/2026-04-20-pgindex-apply-index-and-parent-resolution.md`](https://github.com/bluedynamics/plone-pgcatalog/blob/fix/pgindex-apply-index-and-parent-resolution/docs/superpowers/plans/2026-04-20-pgindex-apply-index-and-parent-resolution.md)

Implemented via superpowers subagent-driven development: 13 tasks, each spec-compliance-reviewed and code-quality-reviewed per commit. Final end-to-end review signed off with only minor documentation nits.

## Test plan

- [x] Unit tests across `test_catalog_indexes_view.py` + `test_pgindex.py` — 4 new test classes covering `_resolve_catalog`, parent self-heal, `getIndex` without parent, `_PGIndexMapping` new methods, `_index` deprecation, `_apply_index` for FIELD/KEYWORD/PATH/DATE/BOOLEAN/UUID + semantics (no security, resultset ignored, deprecation, conn errors).
- [x] Rewrote `TestViewWithoutCatalog` to the new no-silent-fallback contract.
- [x] Integration test `TestKeywordsVocabulary` in `tests/test_pg_integration.py` (PG-backed FunctionalTesting layer — IntegrationTesting blocks `transaction.commit()`, which this test needs). Reproduces the aaf-prod tag-autocomplete path and the missing-`__parent__` scenario.
- [x] Full suite: **1435 passed / 23 skipped / 0 failed**.
- [ ] After deploy on aaf-prod: typing `AT` in the Collection Schlagwort widget offers `AT26`; `SELECT state ? '__parent__' FROM object_state WHERE zoid=66615937` flips to `t` after the first request.

## Follow-ups filed

- #147 — `_PGIndexMapping.items()` / `values()` real lazy implementation if a caller surfaces.
- #148 — architectural concerns around `object_state` as query source (security on `uniqueValues`, scan cost, separate `catalog_state` view).

🤖 Generated with [Claude Code](https://claude.com/claude-code)