### PR TITLE
use current language if Language is not passed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.0b65
+
+### Fixed
+
+Use site language to mark the search language if `Language` parameter is not used #166
+
 ## 1.0.0b64
 
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixed
+
+- Use site language to mark the search language if `Language` parameter is not used #166
+
+
 ## 1.0.0b65
 
 ### Added
@@ -41,8 +48,6 @@
   that imports this function from outside the package.
 
 ### Fixed
-
-- Use site language to mark the search language if `Language` parameter is not used #166
 
 - Fix automatic language detection for BM25 ranking #164
 

--- a/src/plone/pgcatalog/query.py
+++ b/src/plone/pgcatalog/query.py
@@ -20,7 +20,6 @@ from typing import ClassVar
 import logging
 import re
 
-
 log = logging.getLogger(__name__)
 
 # Keys in the query dict that are NOT index names
@@ -570,7 +569,9 @@ class _QueryBuilder:
                 lang_val = lang_val.get("query", "")
             if not lang_val:
                 # Try getting the current language from the environment
-                lang_val = get_current_language()
+                current_language = get_current_language()
+                if current_language is not None:
+                    lang_val = current_language
 
             lang_val = _bool_to_lower_str(lang_val) if lang_val else ""
 

--- a/src/plone/pgcatalog/query.py
+++ b/src/plone/pgcatalog/query.py
@@ -20,6 +20,7 @@ from typing import ClassVar
 import logging
 import re
 
+
 log = logging.getLogger(__name__)
 
 # Keys in the query dict that are NOT index names

--- a/src/plone/pgcatalog/query.py
+++ b/src/plone/pgcatalog/query.py
@@ -13,7 +13,7 @@ from plone.pgcatalog.columns import ensure_date_param as _ensure_date_param
 from plone.pgcatalog.columns import get_registry
 from plone.pgcatalog.columns import IndexType
 from plone.pgcatalog.columns import validate_identifier
-from plone import api
+from plone.pgcatalog.utils import get_current_language
 from psycopg.types.json import Json
 from typing import ClassVar
 
@@ -569,7 +569,7 @@ class _QueryBuilder:
                 lang_val = lang_val.get("query", "")
             if not lang_val:
                 # Try getting the current language from the environment
-                lang_val = api.portal.get_current_language()
+                lang_val = get_current_language()
 
             lang_val = _bool_to_lower_str(lang_val) if lang_val else ""
 

--- a/src/plone/pgcatalog/query.py
+++ b/src/plone/pgcatalog/query.py
@@ -13,12 +13,12 @@ from plone.pgcatalog.columns import ensure_date_param as _ensure_date_param
 from plone.pgcatalog.columns import get_registry
 from plone.pgcatalog.columns import IndexType
 from plone.pgcatalog.columns import validate_identifier
+from plone import api
 from psycopg.types.json import Json
 from typing import ClassVar
 
 import logging
 import re
-
 
 log = logging.getLogger(__name__)
 
@@ -567,6 +567,10 @@ class _QueryBuilder:
             lang_val = self._query.get("Language")
             if isinstance(lang_val, dict):
                 lang_val = lang_val.get("query", "")
+            if not lang_val:
+                # Try getting the current language from the environment
+                lang_val = api.portal.get_current_language()
+
             lang_val = _bool_to_lower_str(lang_val) if lang_val else ""
 
             clause, params, rank_expr = get_backend().build_search_clause(

--- a/src/plone/pgcatalog/utils.py
+++ b/src/plone/pgcatalog/utils.py
@@ -31,8 +31,11 @@ def get_current_language(context=None):
     :Example: :ref:`portal-get-current-language-example`
     """
     request = getRequest()
-    return (
-        request.get("LANGUAGE", None)
-        or (context and aq_inner(context).Language())
-        or get_default_language()
-    )
+    if request is not None:
+        return (
+            request.get("LANGUAGE", None)
+            or (context and aq_inner(context).Language())
+            or get_default_language()
+        )
+
+    return None

--- a/src/plone/pgcatalog/utils.py
+++ b/src/plone/pgcatalog/utils.py
@@ -1,0 +1,38 @@
+# Implementation taken from plone.api.portal to avoid
+# having plone.api as a dependency
+
+from Acquisition import aq_inner
+from zope.globalrequest import getRequest
+from zope.component import getUtility
+from plone.registry.interfaces import IRegistry
+
+
+def get_default_language():
+    """Return the default language.
+
+    :returns: language identifier
+    :rtype: string
+    :Example: :ref:`portal-get-default-language-example`
+    """
+    from plone.i18n.interfaces import ILanguageSchema
+
+    registry = getUtility(IRegistry)
+    settings = registry.forInterface(ILanguageSchema, prefix="plone")
+    return settings.default_language
+
+
+def get_current_language(context=None):
+    """Return the current negotiated language.
+
+    :param context: context object
+    :type context: object
+    :returns: language identifier
+    :rtype: string
+    :Example: :ref:`portal-get-current-language-example`
+    """
+    request = getRequest()
+    return (
+        request.get("LANGUAGE", None)
+        or (context and aq_inner(context).Language())
+        or get_default_language()
+    )

--- a/src/plone/pgcatalog/utils.py
+++ b/src/plone/pgcatalog/utils.py
@@ -2,9 +2,9 @@
 # having plone.api as a dependency
 
 from Acquisition import aq_inner
-from zope.globalrequest import getRequest
-from zope.component import getUtility
 from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
+from zope.globalrequest import getRequest
 
 
 def get_default_language():

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1378,3 +1378,47 @@ class TestStripNonIndexKeys:
         assert (
             strip_non_index_keys({"metadata_fields": ["Title"]}, ["portal_type"]) == {}
         )
+
+
+class TestSearchableTextCurrentLanguage:
+    """#166: when the query has no Language, fall back to the current/site
+    language for the search text-search configuration instead of 'simple'."""
+
+    def test_uses_current_language_when_language_absent(self, monkeypatch):
+        import plone.pgcatalog.query as q
+
+        monkeypatch.setattr(q, "get_current_language", lambda *a, **k: "de")
+        qr = build_query({"SearchableText": "hallo"})
+        assert [v for v in qr["params"].values() if v == "de"], qr["params"]
+
+    def test_explicit_language_wins_over_current_language(self, monkeypatch):
+        import plone.pgcatalog.query as q
+
+        monkeypatch.setattr(q, "get_current_language", lambda *a, **k: "de")
+        qr = build_query({"SearchableText": "bonjour", "Language": "fr"})
+        assert [v for v in qr["params"].values() if v == "fr"], qr["params"]
+        assert not [v for v in qr["params"].values() if v == "de"], qr["params"]
+
+    def test_no_request_falls_back_to_simple(self, monkeypatch):
+        """No current language available → empty string ('simple' config)."""
+        import plone.pgcatalog.query as q
+
+        monkeypatch.setattr(q, "get_current_language", lambda *a, **k: None)
+        qr = build_query({"SearchableText": "hello"})
+        assert [v for v in qr["params"].values() if v == ""], qr["params"]
+
+
+class TestGetCurrentLanguage:
+    """Unit tests for the vendored get_current_language helper (#166)."""
+
+    def test_returns_none_without_request(self, monkeypatch):
+        import plone.pgcatalog.utils as u
+
+        monkeypatch.setattr(u, "getRequest", lambda: None)
+        assert u.get_current_language() is None
+
+    def test_returns_request_language(self, monkeypatch):
+        import plone.pgcatalog.utils as u
+
+        monkeypatch.setattr(u, "getRequest", lambda: {"LANGUAGE": "eu"})
+        assert u.get_current_language() == "eu"


### PR DESCRIPTION
Fixes #166 

I introduce here a dependency on plone.api, but we can remove it and use the implementation that plone.api uses to get the current language.