### PR TITLE
ci: bump actions to Node.js 24 runtimes + per-version uv cache key

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -55,4 +55,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Download packages built by build-and-inspect-python-package
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: Packages
           path: dist
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Download packages built by build-and-inspect-python-package
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: Packages
           path: dist

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,6 +58,9 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
+          # Per-version cache key — the matrix jobs otherwise race to
+          # reserve one shared key ("Unable to reserve cache …").
+          cache-suffix: ${{ matrix.python-version }}
 
       - name: Install system dependencies
         run: sudo apt-get install -y libxml2-dev libxslt-dev
@@ -77,7 +80,7 @@ jobs:
         run: mv .coverage .coverage.${{ matrix.python-version }}
 
       - name: Upload coverage data
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-data-${{ matrix.python-version }}
           path: .coverage.${{ matrix.python-version }}
@@ -103,7 +106,7 @@ jobs:
           uv venv
           uv pip install -c https://dist.plone.org/release/6.2-latest/constraints.txt -e ".[test]"
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v7
         with:
           pattern: coverage-data-*
           merge-multiple: true
@@ -116,7 +119,7 @@ jobs:
           uv run coverage report
 
       - name: Upload HTML report if check failed
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: html-report
           path: htmlcov


### PR DESCRIPTION
Two CI-hygiene fixes for warnings seen in recent runs.

## Node.js 20 deprecation → bump actions
Several pinned actions still target the deprecated Node.js 20 runtime. Rather than the temporary `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` flag (which only relabels the warning as *"being forced to run on Node 24"*), bump each to its Node.js 24-native major:

| Action | Was | Now | Runtime |
|---|---|---|---|
| `actions/upload-artifact` | v5 | **v7** | node24 |
| `actions/download-artifact` | v5 | **v7** | node24 |
| `actions/setup-python` | v5 | **v6** | node24 |
| `actions/deploy-pages` | v4 | **v5** | node24 |

`actions/checkout@v5` and `astral-sh/setup-uv@v7` already target node24 — left as-is. `qa.yaml` needs no change.

## uv cache reservation race
The `tests` matrix (3.12 / 3.13 / 3.14) shared a single `setup-uv` cache key, so the jobs raced to reserve it:

```
Failed to save: Unable to reserve cache with key setup-uv-… another job may be creating this cache
```

Add `cache-suffix: ${{ matrix.python-version }}` to the test job's `setup-uv` step → one cache key per Python version: no race, better hit rates.

Workflow-only change; all five workflow files validated as parseable YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)