### PR TITLE
fix: guard tika worker imports when extra is missing (#171)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.0.0b66 (unreleased)
+
+### Fixed
+
+- `pgcatalog-tika-worker` no longer crashes with a bare
+  `ModuleNotFoundError` when installed without the `tika` / `tika-s3`
+  extra. The console script is registered unconditionally, but `httpx`
+  (and `boto3` for the S3 blob path) ship only via those extras. The
+  worker module now imports `httpx` defensively and the script fails
+  fast with a clear hint pointing at the required extra; the S3 path
+  raises an actionable error too. #171
+
 ## 1.0.0b65
 
 ### Added

--- a/src/plone/pgcatalog/tika_worker.py
+++ b/src/plone/pgcatalog/tika_worker.py
@@ -25,7 +25,6 @@ Environment variables:
 
 from psycopg.rows import dict_row
 
-import httpx
 import logging
 import os
 import psycopg
@@ -35,10 +34,30 @@ import threading
 import time
 
 
+# ``httpx`` (and ``boto3``, imported lazily in ``_get_s3_client``) ship only
+# via the optional ``tika`` / ``tika-s3`` extras, but the
+# ``pgcatalog-tika-worker`` console script is registered unconditionally.
+# Import httpx defensively so the module stays importable without the extra;
+# the worker fails fast with a clear hint instead of a bare
+# ModuleNotFoundError.  See https://github.com/bluedynamics/plone-pgcatalog/issues/171
+try:
+    import httpx
+except ModuleNotFoundError:  # pragma: no cover - exercised in a subprocess
+    httpx = None
+
+
 __all__ = ["TikaWorker", "main"]
 
 
 log = logging.getLogger(__name__)
+
+
+MISSING_EXTRA_HINT = (
+    "pgcatalog-tika-worker requires extra dependencies that are not "
+    "installed. Install the worker extra:\n"
+    "    pip install plone-pgcatalog[tika]      # PG bytea blobs\n"
+    "    pip install plone-pgcatalog[tika-s3]   # + S3-tiered blobs"
+)
 
 
 class TikaWorker:
@@ -164,6 +183,8 @@ class TikaWorker:
     def _extract(self, conn, zoid, tid, content_type):
         """Fetch blob and send to Tika, return extracted text."""
         blob_data = self._fetch_blob(conn, zoid, tid)
+        if httpx is None:
+            raise RuntimeError(MISSING_EXTRA_HINT)
         headers = {"Accept": "text/plain"}
         if content_type:
             headers["Content-Type"] = content_type
@@ -206,7 +227,13 @@ class TikaWorker:
         if self._s3_client is None:
             if not self.s3_config:
                 raise ValueError("S3 blob requested but no S3 config provided")
-            import boto3
+            try:
+                import boto3
+            except ModuleNotFoundError:
+                raise RuntimeError(
+                    "S3-tiered blobs require the 'tika-s3' extra:\n"
+                    "    pip install plone-pgcatalog[tika-s3]"
+                ) from None
 
             self._s3_client = boto3.client(
                 "s3",
@@ -235,6 +262,10 @@ def main():
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
+
+    if httpx is None:
+        logging.error(MISSING_EXTRA_HINT)
+        sys.exit(1)
 
     dsn = os.environ.get("TIKA_WORKER_DSN")
     tika_url = os.environ.get("TIKA_WORKER_URL")

--- a/tests/test_tika_worker_extras.py
+++ b/tests/test_tika_worker_extras.py
@@ -1,0 +1,61 @@
+"""Tests for graceful behaviour when the tika/tika-s3 extras are missing.
+
+The ``pgcatalog-tika-worker`` console script is registered unconditionally,
+but ``httpx`` (and ``boto3`` for the S3 path) ship only via the optional
+``tika`` / ``tika-s3`` extras. Importing the worker module or running the
+script without the extra must not crash with a bare ``ModuleNotFoundError``;
+it must give a clear hint pointing at the extra. See issue #171.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+
+def _run_without_httpx(body):
+    """Run ``body`` in a subprocess where importing httpx fails."""
+    script = textwrap.dedent(
+        """
+            import sys
+            # Make `import httpx` raise ModuleNotFoundError, simulating an
+            # install without the [tika] / [tika-s3] extra.
+            sys.modules["httpx"] = None
+            """
+    ) + textwrap.dedent(body)
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_module_imports_without_httpx():
+    """The worker module imports cleanly even when httpx is absent."""
+    result = _run_without_httpx(
+        """
+        from plone.pgcatalog import tika_worker
+        assert tika_worker.httpx is None
+        print("IMPORT_OK")
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert "IMPORT_OK" in result.stdout
+    assert "ModuleNotFoundError" not in result.stderr
+
+
+def test_main_exits_with_clear_hint_without_httpx():
+    """Running the worker without the extra exits cleanly with a hint."""
+    result = _run_without_httpx(
+        """
+        from plone.pgcatalog import tika_worker
+        tika_worker.main()
+        """
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode == 1, combined
+    # No bare traceback leaking the internal import failure ...
+    assert "ModuleNotFoundError" not in combined
+    assert "Traceback" not in combined
+    # ... instead a clear, actionable hint mentioning the extra.
+    assert "tika" in combined.lower()
+    assert "pip install" in combined.lower()


### PR DESCRIPTION
Fixes #171.

## Problem
The `pgcatalog-tika-worker` console script is registered unconditionally (core `[project.scripts]`), but `plone/pgcatalog/tika_worker.py` hard-imported `httpx` at module top (and uses `boto3` for the S3 blob path). Both ship only as optional extras (`tika` → httpx, `tika-s3` → httpx + boto3). Installing without the extra therefore shipped a runnable script that crashed immediately with a bare `ModuleNotFoundError`, leaving the worker stuck in CrashLoopBackOff with no hint that an extra is required.

## Fix
Keep `httpx`/`boto3` optional, but fail gracefully (suggested fix #2 from the issue):

- Import `httpx` defensively at module top (`httpx = None` when absent) so the module — and the unconditionally registered script — stays importable without the extra.
- `main()` fails fast with `sys.exit(1)` and a clear, actionable hint pointing at `pip install plone-pgcatalog[tika]` / `[tika-s3]`.
- `_extract()` raises the same hint defensively for programmatic use.
- The lazy `boto3` import in `_get_s3_client()` now raises a clear `tika-s3`-extra error instead of `ModuleNotFoundError`.

`httpx` remains a real module attribute when installed, so existing `@patch(".../httpx.Client")` mocks keep working.

## Tests
New `tests/test_tika_worker_extras.py` runs in a subprocess with `httpx` blocked and asserts the module still imports and that `main()` exits 1 with an actionable hint (no `ModuleNotFoundError` / `Traceback` leaking). Existing worker tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)