### PR TITLE
docs(ecosystem): add cdk8s-plone to the Ecosystem nav dropdown

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## 1.0.0b66 (unreleased)
 
+### Documentation
+
+- Add `cdk8s-plone` to the ecosystem navigation dropdown.
+
 ### Fixed
 
 - `pgcatalog-tika-worker` no longer crashes with a bare

--- a/docs/sources/conf.py
+++ b/docs/sources/conf.py
@@ -69,6 +69,11 @@ html_theme_options = {
                     "url": "https://bluedynamics.github.io/plone-pgthumbor/",
                     "summary": "Thumbor image scaling",
                 },
+                {
+                    "title": "cdk8s-plone",
+                    "url": "https://bluedynamics.github.io/cdk8s-plone/",
+                    "summary": "Deploy Plone to Kubernetes",
+                },
             ],
         },
         {


### PR DESCRIPTION
Adds cdk8s-plone to the `Ecosystem` navigation dropdown so the menu stays symmetric across all ecosystem packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)