### PR TITLE
feat: SQL-based plone.observability content-count metric provider (#174)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,14 @@
 
 ## 1.0.0b66 (unreleased)
 
+### Added
+
+- Ship a `plone.observability` `IMetricProvider` (`pgcontent`) that produces
+  `plone_content_total` / `plone_content_by_state` content-count metrics via SQL
+  for pg-catalog sites. Registered only when `plone.observability` is installed
+  (`zcml:condition`) and emits only for sites backed by `IPGCatalogTool`
+  (migration safe). #174
+
 ### Documentation
 
 - Add `cdk8s-plone` to the ecosystem navigation dropdown.

--- a/docs/superpowers/plans/2026-06-25-pgcontent-metric-provider.md
+++ b/docs/superpowers/plans/2026-06-25-pgcontent-metric-provider.md
@@ -1,0 +1,548 @@
+# pgcontent IMetricProvider Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a `plone.observability` `IMetricProvider` (`pgcontent`) in plone.pgcatalog that produces `plone_content_total` / `plone_content_by_state` content-count metrics via SQL, only for `IPGCatalogTool`-backed sites, registered only when `plone.observability` is installed.
+
+**Architecture:** A new module `observability.py` with a pure `_aggregate(conn, site_ids)` SQL helper (two `GROUP BY` queries over `object_state`), a `_pg_site_ids(context)` discovery helper (filters Plone sites to those whose `portal_catalog` provides `IPGCatalogTool`), and a thin `PGContentMetricProvider` adapter that wires them together with a process-global TTL cache. Registered via a conditional ZCML `<adapter>` on `OFS.interfaces.IApplication`.
+
+**Tech Stack:** Python 3, psycopg (dict_row), zope.component/zope.interface ZCML, pytest, the repo's `pg_conn_with_catalog` DB fixture and `pgcatalog_layer` integration layer.
+
+## Global Constraints
+
+- Soft dependency: **no** hard `install_requires` on plone.observability. Adapter registers only via `zcml:condition="installed plone.observability"`.
+- Migration-safe: emit **only** for sites whose `portal_catalog` provides `IPGCatalogTool`; leave ZCatalog sites to plone.observability's generic provider.
+- Metric parity with the generic provider: names `plone_content_total` / `plone_content_by_state`, `type="gauge"`, `scope="global"`, help strings `"Number of content objects by portal type"` / `"Number of content objects by workflow state"`, labels include `site=<site-id>`.
+- TTL cache must be **process-global** (the `@@metrics` view builds a fresh provider instance per request via `getAdapters`). TTL from `PLONE_OBSERVABILITY_METRICS_CACHE_TTL` (default `60`).
+- `collect()` must never raise; degrade silently (debug log) on missing pool / DB error / per-site traversal failure.
+- Commit messages end with:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+- Tests run against the `zodb_test` DB (zodb-pgjsonb-dev container). Run command:
+  `env -u ZODB_TEST_DSN .venv/bin/pytest <path> -v`
+
+## Verified facts (from the codebase, b6)
+
+- `Metric` is `@dataclass Metric(name, value, type, scope, help, labels={})` in `plone.observability.metric`.
+- `IMetricProvider` in `plone.observability.interfaces` declares `name`, `scope`, `collect()`. The `@@metrics` view iterates `getAdapters((app,), IMetricProvider)`.
+- Generic `ContentMetricProvider` emits `plone_content_total{portal_type,site}` and `plone_content_by_state{state,site}` and steps aside (`except Exception` → debug log) on non-ZCatalog backends.
+- `PlonePGCatalogTool` `@implementer(IPGCatalogTool, IZCatalog)`; `IPGCatalogTool` is in `plone.pgcatalog.interfaces`.
+- Connection pool: `plone.pgcatalog.pool.get_pool(context)` returns a `psycopg_pool.ConnectionPool` (has `.connection()` context manager); raises `RuntimeError` if none found.
+- `object_state` columns include `idx JSONB` and `path TEXT`; paths look like `/<siteid>/...` so `split_part(path,'/',2)` is the site id.
+- Test helpers: `plone.pgcatalog.indexing.catalog_object(conn, zoid, path, idx)` writes `path`+`idx`; fixture `pg_conn_with_catalog` yields a `dict_row` connection with the catalog schema installed. The `pgcatalog_layer` fixture loads the package `configure.zcml` (`testing.py` `PGCatalogLayer.setUpZope`).
+- `ANY(%(param)s)` with a Python list is the established parametrization (e.g. `WHERE zoid = ANY(%(zoids)s)`).
+
+---
+
+### Task 1: SQL aggregation helper `_aggregate`
+
+**Files:**
+- Create: `src/plone/pgcatalog/observability.py`
+- Modify: `pyproject.toml` (add `plone.observability` to the `test` extra)
+- Test: `tests/test_observability.py`
+
+**Interfaces:**
+- Produces: `_aggregate(conn, site_ids: list[str]) -> list[Metric]` — runs two `GROUP BY` queries restricted to `site_ids`, returns `plone_content_total` and `plone_content_by_state` `Metric` objects. Consumed by `PGContentMetricProvider.collect()` (Task 2).
+
+- [ ] **Step 1: Add plone.observability to the test extra**
+
+In `pyproject.toml`, locate the `test` optional-dependencies list (contains `pytest`, `pytest-cov`, `zope.pytestlayer`) and add a line:
+
+```toml
+    "plone.observability",
+```
+
+- [ ] **Step 2: Install it into the test venv**
+
+Run: `env -u ZODB_TEST_DSN .venv/bin/python -m pip install plone.observability`
+Expected: `Successfully installed plone.observability-…` (b6 or newer).
+
+- [ ] **Step 3: Write the failing test**
+
+Create `tests/test_observability.py`:
+
+```python
+"""Tests for the pgcontent plone.observability metric provider."""
+
+from plone.pgcatalog.indexing import catalog_object
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_metric_cache():
+    """The provider caches process-globally; reset around each test."""
+    from plone.pgcatalog import observability
+
+    observability._cache.clear()
+    yield
+    observability._cache.clear()
+
+
+class TestAggregate:
+    def test_counts_by_type_and_state_for_given_site(self, pg_conn_with_catalog):
+        from plone.pgcatalog.observability import _aggregate
+
+        conn = pg_conn_with_catalog
+        catalog_object(conn, zoid=1, path="/sitea/d1",
+                       idx={"portal_type": "Document", "review_state": "published"})
+        catalog_object(conn, zoid=2, path="/sitea/d2",
+                       idx={"portal_type": "Document", "review_state": "private"})
+        catalog_object(conn, zoid=3, path="/sitea/n1",
+                       idx={"portal_type": "News Item", "review_state": "published"})
+        catalog_object(conn, zoid=4, path="/siteb/d3",
+                       idx={"portal_type": "Document", "review_state": "published"})
+        conn.commit()
+
+        metrics = _aggregate(conn, ["sitea"])
+
+        totals = {
+            (m.labels["portal_type"], m.labels["site"]): m.value
+            for m in metrics if m.name == "plone_content_total"
+        }
+        states = {
+            (m.labels["state"], m.labels["site"]): m.value
+            for m in metrics if m.name == "plone_content_by_state"
+        }
+        assert totals == {("Document", "sitea"): 2, ("News Item", "sitea"): 1}
+        assert states == {("published", "sitea"): 2, ("private", "sitea"): 1}
+        assert all(m.type == "gauge" and m.scope == "global" for m in metrics)
+        assert all(m.labels["site"] == "sitea" for m in metrics)
+
+    def test_excludes_null_index_values_and_other_sites(self, pg_conn_with_catalog):
+        from plone.pgcatalog.observability import _aggregate
+
+        conn = pg_conn_with_catalog
+        # no portal_type / review_state in idx → excluded
+        catalog_object(conn, zoid=10, path="/sitea/x", idx={"Title": "no type"})
+        # different site → excluded by the site filter
+        catalog_object(conn, zoid=11, path="/siteb/y",
+                       idx={"portal_type": "Document", "review_state": "published"})
+        conn.commit()
+
+        assert _aggregate(conn, ["sitea"]) == []
+```
+
+- [ ] **Step 4: Run the test to verify it fails**
+
+Run: `env -u ZODB_TEST_DSN .venv/bin/pytest tests/test_observability.py::TestAggregate -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'plone.pgcatalog.observability'`.
+
+- [ ] **Step 5: Write the module with `_aggregate`**
+
+Create `src/plone/pgcatalog/observability.py`:
+
+```python
+"""plone.observability IMetricProvider producing content counts via SQL.
+
+This module is imported only when the conditional ZCML registration fires
+(``zcml:condition="installed plone.observability"``), so importing
+plone.observability at module top level is safe.
+"""
+
+from plone.observability.interfaces import IMetricProvider
+from plone.observability.metric import Metric
+from plone.pgcatalog.pool import get_pool
+from zope.interface import implementer
+
+import logging
+import os
+import threading
+import time
+
+
+logger = logging.getLogger(__name__)
+
+# Process-global TTL cache. Key: tuple(sorted(site_ids)) -> (timestamp, [Metric]).
+# Must be module-level: the @@metrics view builds a fresh provider instance per
+# request via getAdapters(), so an instance cache would never hit across scrapes.
+_cache = {}
+_cache_lock = threading.Lock()
+
+
+def _ttl():
+    return int(os.environ.get("PLONE_OBSERVABILITY_METRICS_CACHE_TTL", "60"))
+
+
+_TOTAL_SQL = (
+    "SELECT split_part(path, '/', 2) AS site, idx->>'portal_type' AS pt, "
+    "count(*) AS n FROM object_state "
+    "WHERE idx->>'portal_type' IS NOT NULL "
+    "AND split_part(path, '/', 2) = ANY(%(sites)s) "
+    "GROUP BY site, pt"
+)
+
+_STATE_SQL = (
+    "SELECT split_part(path, '/', 2) AS site, idx->>'review_state' AS rs, "
+    "count(*) AS n FROM object_state "
+    "WHERE idx->>'review_state' IS NOT NULL "
+    "AND split_part(path, '/', 2) = ANY(%(sites)s) "
+    "GROUP BY site, rs"
+)
+
+
+def _aggregate(conn, site_ids):
+    """Run the two GROUP BY queries restricted to site_ids; return list[Metric]."""
+    params = {"sites": list(site_ids)}
+    metrics = []
+    with conn.cursor() as cur:
+        cur.execute(_TOTAL_SQL, params)
+        for row in cur.fetchall():
+            metrics.append(
+                Metric(
+                    name="plone_content_total",
+                    value=row["n"],
+                    type="gauge",
+                    scope="global",
+                    help="Number of content objects by portal type",
+                    labels={"portal_type": row["pt"], "site": row["site"]},
+                )
+            )
+        cur.execute(_STATE_SQL, params)
+        for row in cur.fetchall():
+            metrics.append(
+                Metric(
+                    name="plone_content_by_state",
+                    value=row["n"],
+                    type="gauge",
+                    scope="global",
+                    help="Number of content objects by workflow state",
+                    labels={"state": row["rs"], "site": row["site"]},
+                )
+            )
+    return metrics
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `env -u ZODB_TEST_DSN .venv/bin/pytest tests/test_observability.py::TestAggregate -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/plone/pgcatalog/observability.py tests/test_observability.py pyproject.toml
+git commit -m "feat(observability): SQL content-count aggregation helper (#174)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Site discovery, provider class, TTL cache
+
+**Files:**
+- Modify: `src/plone/pgcatalog/observability.py`
+- Test: `tests/test_observability.py`
+
+**Interfaces:**
+- Consumes: `_aggregate(conn, site_ids)` (Task 1), `get_pool(context)`.
+- Produces:
+  - `_pg_site_ids(context) -> list[str]` — ids of Plone sites whose `portal_catalog` provides `IPGCatalogTool`.
+  - `PGContentMetricProvider(context)` — `@implementer(IMetricProvider)`, `name="pgcontent"`, `scope="global"`, generator `collect()`. Registered as the named adapter in Task 3.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_observability.py`:
+
+```python
+class _FakeCatalog:
+    pass
+
+
+class _FakeSite:
+    def __init__(self, site_id, catalog):
+        self._id = site_id
+        self._catalog = catalog
+
+    def getId(self):
+        return self._id
+
+    def unrestrictedTraverse(self, name, default=None):
+        if name == "portal_catalog":
+            return self._catalog
+        return default
+
+
+class _FakeApp:
+    def __init__(self, sites):
+        self._sites = sites
+
+    def objectValues(self):
+        return self._sites
+
+
+class TestSiteSelection:
+    def test_only_ipgcatalogtool_sites(self):
+        from plone.pgcatalog.interfaces import IPGCatalogTool
+        from plone.pgcatalog.observability import _pg_site_ids
+        from Products.CMFPlone.interfaces import IPloneSiteRoot
+        from zope.interface import alsoProvides
+
+        pg_catalog = _FakeCatalog()
+        alsoProvides(pg_catalog, IPGCatalogTool)
+        zcatalog = _FakeCatalog()  # not IPGCatalogTool
+
+        pg_site = _FakeSite("sitea", pg_catalog)
+        alsoProvides(pg_site, IPloneSiteRoot)
+        z_site = _FakeSite("siteb", zcatalog)
+        alsoProvides(z_site, IPloneSiteRoot)
+
+        assert _pg_site_ids(_FakeApp([pg_site, z_site])) == ["sitea"]
+
+
+class _SpyPool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def connection(self):
+        import contextlib
+
+        @contextlib.contextmanager
+        def _cm():
+            yield self._conn
+
+        return _cm()
+
+
+class TestCollect:
+    def test_yields_nothing_without_pg_sites(self, monkeypatch):
+        from plone.pgcatalog import observability
+
+        monkeypatch.setattr(observability, "_pg_site_ids", lambda ctx: [])
+        provider = observability.PGContentMetricProvider(object())
+        assert list(provider.collect()) == []
+
+    def test_caches_within_ttl(self, monkeypatch):
+        from plone.pgcatalog import observability
+        from plone.observability.metric import Metric
+
+        calls = {"n": 0}
+        sample = [Metric(name="plone_content_total", value=1, type="gauge",
+                         scope="global", help="h", labels={"portal_type": "Document",
+                                                            "site": "sitea"})]
+
+        def fake_aggregate(conn, site_ids):
+            calls["n"] += 1
+            return sample
+
+        monkeypatch.setattr(observability, "_pg_site_ids", lambda ctx: ["sitea"])
+        monkeypatch.setattr(observability, "get_pool",
+                            lambda ctx: _SpyPool(conn=object()))
+        monkeypatch.setattr(observability, "_aggregate", fake_aggregate)
+        monkeypatch.setenv("PLONE_OBSERVABILITY_METRICS_CACHE_TTL", "300")
+
+        provider = observability.PGContentMetricProvider(object())
+        first = list(provider.collect())
+        second = list(observability.PGContentMetricProvider(object()).collect())
+
+        assert first == second == sample
+        assert calls["n"] == 1  # second call served from the process-global cache
+
+    def test_degrades_silently_without_pool(self, monkeypatch):
+        from plone.pgcatalog import observability
+
+        monkeypatch.setattr(observability, "_pg_site_ids", lambda ctx: ["sitea"])
+
+        def boom(ctx):
+            raise RuntimeError("no pool")
+
+        monkeypatch.setattr(observability, "get_pool", boom)
+        provider = observability.PGContentMetricProvider(object())
+        assert list(provider.collect()) == []
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `env -u ZODB_TEST_DSN .venv/bin/pytest tests/test_observability.py::TestSiteSelection tests/test_observability.py::TestCollect -v`
+Expected: FAIL — `AttributeError: module 'plone.pgcatalog.observability' has no attribute '_pg_site_ids'` / `PGContentMetricProvider`.
+
+- [ ] **Step 3: Add `_pg_site_ids` and `PGContentMetricProvider`**
+
+Append to `src/plone/pgcatalog/observability.py`:
+
+```python
+def _pg_site_ids(context):
+    """Return ids of Plone sites whose portal_catalog provides IPGCatalogTool.
+
+    During a migration pgcatalog may be installed while a site still uses a
+    ZCatalog; such sites are left to plone.observability's generic provider.
+    """
+    try:
+        from Products.CMFPlone.interfaces import IPloneSiteRoot
+    except ImportError:
+        return []
+    from plone.pgcatalog.interfaces import IPGCatalogTool
+
+    site_ids = []
+    for obj in context.objectValues():
+        if not IPloneSiteRoot.providedBy(obj):
+            continue
+        try:
+            catalog = obj.unrestrictedTraverse("portal_catalog", None)
+        except Exception:
+            catalog = None
+        if catalog is not None and IPGCatalogTool.providedBy(catalog):
+            site_ids.append(obj.getId())
+    return site_ids
+
+
+@implementer(IMetricProvider)
+class PGContentMetricProvider:
+    """Content-count metrics via SQL for IPGCatalogTool-backed sites."""
+
+    name = "pgcontent"
+    scope = "global"
+
+    def __init__(self, context):
+        self.context = context
+
+    def collect(self):
+        site_ids = _pg_site_ids(self.context)
+        if not site_ids:
+            return
+        key = tuple(sorted(site_ids))
+        now = time.time()
+        with _cache_lock:
+            entry = _cache.get(key)
+            if entry is not None and (now - entry[0]) < _ttl():
+                yield from entry[1]
+                return
+        try:
+            pool = get_pool(self.context)
+            with pool.connection() as conn:
+                metrics = _aggregate(conn, list(key))
+        except Exception:
+            logger.debug("pgcontent metrics unavailable", exc_info=True)
+            return
+        with _cache_lock:
+            _cache[key] = (now, metrics)
+        yield from metrics
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `env -u ZODB_TEST_DSN .venv/bin/pytest tests/test_observability.py -v`
+Expected: PASS (all of TestAggregate, TestSiteSelection, TestCollect).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/plone/pgcatalog/observability.py tests/test_observability.py
+git commit -m "feat(observability): pgcontent provider with site discovery + TTL cache (#174)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Conditional ZCML registration + CHANGES + registration test
+
+**Files:**
+- Modify: `src/plone/pgcatalog/configure.zcml`
+- Modify: `CHANGES.md`
+- Test: `tests/test_observability.py`
+
+**Interfaces:**
+- Consumes: `PGContentMetricProvider` (Task 2), `IMetricProvider`.
+- Produces: a named adapter `pgcontent` providing `IMetricProvider` for `OFS.interfaces.IApplication`, registered only when plone.observability is installed.
+
+- [ ] **Step 1: Add `xmlns:zcml` to configure.zcml root**
+
+In `src/plone/pgcatalog/configure.zcml`, change the opening `<configure>` element to add the zcml namespace:
+
+```xml
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
+    >
+```
+
+- [ ] **Step 2: Register the conditional adapter**
+
+In `src/plone/pgcatalog/configure.zcml`, before the closing `</configure>`, add:
+
+```xml
+  <!-- plone.observability content-count metric provider (soft dependency).
+       Registered only when plone.observability is installed; the provider
+       itself emits only for IPGCatalogTool-backed sites. -->
+  <adapter
+      factory=".observability.PGContentMetricProvider"
+      provides="plone.observability.interfaces.IMetricProvider"
+      for="OFS.interfaces.IApplication"
+      name="pgcontent"
+      zcml:condition="installed plone.observability"
+      />
+```
+
+- [ ] **Step 3: Write the failing registration test**
+
+Append to `tests/test_observability.py`:
+
+```python
+class TestRegistration:
+    def test_pgcontent_adapter_registered(self, pgcatalog_layer):
+        from plone.observability.interfaces import IMetricProvider
+        from zope.component import getGlobalSiteManager
+
+        gsm = getGlobalSiteManager()
+        names = {
+            reg.name
+            for reg in gsm.registeredAdapters()
+            if reg.provided is IMetricProvider
+        }
+        assert "pgcontent" in names
+```
+
+- [ ] **Step 4: Run the registration test to verify it passes**
+
+(The `pgcatalog_layer` fixture loads `configure.zcml`; with plone.observability installed, the conditional adapter registers.)
+
+Run: `env -u ZODB_TEST_DSN .venv/bin/pytest tests/test_observability.py::TestRegistration -v`
+Expected: PASS (1 passed). If it fails with the adapter absent, confirm Step 1/Step 2 edits and that plone.observability is importable in the venv (Task 1 Step 2).
+
+- [ ] **Step 5: Add the CHANGES entry**
+
+In `CHANGES.md`, under `## 1.0.0b66 (unreleased)`, add an `### Added` section (create it above `### Fixed` if not present):
+
+```markdown
+### Added
+
+- Ship a `plone.observability` `IMetricProvider` (`pgcontent`) that produces
+  `plone_content_total` / `plone_content_by_state` content-count metrics via SQL
+  for pg-catalog sites. Registered only when `plone.observability` is installed
+  (`zcml:condition`) and emits only for sites backed by `IPGCatalogTool`
+  (migration safe). #174
+```
+
+- [ ] **Step 6: Run the full observability test module**
+
+Run: `env -u ZODB_TEST_DSN .venv/bin/pytest tests/test_observability.py -v`
+Expected: PASS (TestAggregate, TestSiteSelection, TestCollect, TestRegistration).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/plone/pgcatalog/configure.zcml tests/test_observability.py CHANGES.md
+git commit -m "feat(observability): register pgcontent provider conditionally (#174)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Soft dependency / conditional ZCML → Task 3. ✓
+- Migration-safe site selection (`IPGCatalogTool`) → Task 2 (`_pg_site_ids`) + test. ✓
+- SQL aggregation, labels incl. `site`, NULL filtering → Task 1 (`_aggregate`) + tests. ✓
+- Metric parity (names/type/scope/help/labels) → Task 1 code + assertions. ✓
+- Process-global TTL cache → Task 2 (`_cache` + `collect`) + cache test. ✓
+- Silent degradation → Task 2 (`except Exception`) + degradation test. ✓
+- `plone.observability` in test extra → Task 1. ✓
+- CHANGES entry → Task 3. ✓
+
+**Placeholder scan:** none.
+
+**Type consistency:** `_aggregate(conn, site_ids) -> list[Metric]`, `_pg_site_ids(context) -> list[str]`, `PGContentMetricProvider.name == "pgcontent"`, cache keyed by `tuple(sorted(site_ids))` — used consistently across Tasks 1–3 and the tests.

--- a/docs/superpowers/specs/2026-06-25-pgcontent-metric-provider-design.md
+++ b/docs/superpowers/specs/2026-06-25-pgcontent-metric-provider-design.md
@@ -1,0 +1,175 @@
+# SQL-based plone.observability IMetricProvider (content counts)
+
+**Date:** 2026-06-25
+**Issue:** [#174](https://github.com/bluedynamics/plone-pgcatalog/issues/174)
+**Status:** Approved (design)
+
+## Summary
+
+Ship a `plone.observability` `IMetricProvider` in plone.pgcatalog that produces the
+**content count metrics** (`plone_content_total` by `portal_type`,
+`plone_content_by_state` by `review_state`) via SQL `GROUP BY` over the
+`object_state` table, for deployments using the pg-based catalog.
+
+The generic provider in plone.observability uses the ZCatalog index API
+(`Indexes["portal_type"].uniqueValues(...)`), which `PlonePGCatalogTool` does not
+implement, so those metrics are silently absent on pg-catalog sites. pgcatalog owns
+the `object_state.idx JSONB` schema and can answer this with two aggregate queries
+instead of loading all brains.
+
+## Constraints
+
+- **Soft dependency on plone.observability.** No hard `install_requires`. The adapter
+  registers only via `zcml:condition="installed plone.observability"` (same pattern as
+  the existing `installed eea.facetednavigation` in `overrides.zcml`). If the package is
+  absent, nothing is registered and the provider module is never imported.
+- **Migration-safe.** pgcatalog may be installed and loaded while a given Plone site
+  still uses a ZCatalog (migration pending). For such a site `object_state.idx` is not
+  maintained, so the provider MUST emit **only for sites whose `portal_catalog` actually
+  provides `IPGCatalogTool`**. ZCatalog sites are left to the generic provider (whose
+  `uniqueValues()` works there). This prevents double-counting and stale/wrong numbers.
+- **Label parity** with the generic provider: same metric names, `gauge` type,
+  `scope="global"`, same help strings, and the `{..., site=<site-id>}` label.
+
+## Components
+
+### New module `src/plone/pgcatalog/observability.py`
+
+Imports (only loaded when the conditional ZCML fires):
+```python
+from plone.observability.interfaces import IMetricProvider
+from plone.observability.metric import Metric
+```
+
+**`_aggregate(conn, site_ids)` — pure helper (testable in isolation).**
+Runs the two queries on a psycopg connection, restricted to the given site ids, and
+returns a list of `Metric`:
+
+```sql
+SELECT split_part(path,'/',2) AS site, idx->>'portal_type' AS pt, count(*) AS n
+  FROM object_state
+ WHERE idx->>'portal_type' IS NOT NULL
+   AND split_part(path,'/',2) = ANY(%(sites)s)
+ GROUP BY site, pt;
+
+SELECT split_part(path,'/',2) AS site, idx->>'review_state' AS rs, count(*) AS n
+  FROM object_state
+ WHERE idx->>'review_state' IS NOT NULL
+   AND split_part(path,'/',2) = ANY(%(sites)s)
+ GROUP BY site, rs;
+```
+
+Emits:
+- `plone_content_total{portal_type=<pt>, site=<site>}` — gauge, scope `global`,
+  help `"Number of content objects by portal type"`
+- `plone_content_by_state{state=<rs>, site=<site>}` — gauge, scope `global`,
+  help `"Number of content objects by workflow state"`
+
+**`PGContentMetricProvider` — `@implementer(IMetricProvider)`.**
+- `name = "pgcontent"`, `scope = "global"`, `__init__(self, context)`.
+- `collect()` (generator):
+  1. **Site discovery:** find `IPloneSiteRoot` objects under `self.context` (the app
+     root); for each, traverse `portal_catalog` and keep `site.id` only when
+     `IPGCatalogTool.providedBy(catalog)`.
+  2. If no pg sites → yield nothing.
+  3. **TTL cache check** (process-global, see below). On hit, yield cached metrics.
+  4. On miss: get the pool via `get_pool(self.context)`, take a connection
+     (`with pool.connection() as conn:`), call `_aggregate(conn, pg_site_ids)`, store in
+     cache, yield.
+  5. Wrap pool/SQL access in try/except: on `RuntimeError` (no pool) or psycopg/DB error,
+     `logger.debug(...)` and yield nothing (degrade silently, like the generic provider).
+
+**Process-global TTL cache.** Module-level `_cache` (list|None) + `_cache_ts` (float)
+guarded by a `threading.Lock`; TTL from `PLONE_OBSERVABILITY_METRICS_CACHE_TTL`
+(default `60`). Cache must be module-level, not instance-level: the `@@metrics` view
+calls `getAdapters((app,), IMetricProvider)`, which constructs a fresh provider instance
+per request, so an instance cache would never hit across scrapes. Cache key is the sorted
+tuple of pg site ids (so it is correct if the set of pg sites changes mid-process, e.g.
+after a migration).
+
+### ZCML registration (`configure.zcml`)
+
+Add `xmlns:zcml="http://namespaces.zope.org/zcml"` to the root element and register:
+
+```xml
+<adapter
+    factory=".observability.PGContentMetricProvider"
+    provides="plone.observability.interfaces.IMetricProvider"
+    for="OFS.interfaces.IApplication"
+    name="pgcontent"
+    zcml:condition="installed plone.observability" />
+```
+
+### pyproject.toml
+
+Add `plone.observability` to the `test` optional-dependencies (needed so the imports
+resolve in the test environment). No change to runtime dependencies.
+
+## Data flow
+
+```
+@@metrics request
+  → MetricsView calls getAdapters((app,), IMetricProvider)
+  → PGContentMetricProvider.collect()
+      → discover IPGCatalogTool-backed sites
+      → TTL cache (process-global) check
+      → get_pool(app).connection() → _aggregate(conn, site_ids)
+      → yield Metric(...)
+  → PrometheusFormatter renders plone_content_total / plone_content_by_state
+```
+
+On a mixed (migrating) deployment:
+
+| Site state | Emitting provider | Mechanism |
+|---|---|---|
+| migrated (`PlonePGCatalogTool`) | **pgcontent (this)** | SQL, restricted to that site id |
+| still ZCatalog | generic content provider | `Indexes[...].uniqueValues()` |
+
+No double counting: the generic provider's `uniqueValues()` raises on pg sites (it steps
+aside, plone/plone.observability#25), and this provider restricts its SQL to pg sites
+only.
+
+## Error handling
+
+- No pool (`get_pool` raises `RuntimeError`) → debug log, no metrics.
+- `object_state` missing / SQL error → debug log, no metrics.
+- `portal_catalog` traversal/`providedBy` failure per site → skip that site.
+
+All degrade silently; a metrics endpoint must never raise.
+
+## Testing
+
+`tests/test_observability.py`:
+
+1. **Aggregation (DB fixture `pg_conn_with_catalog`).** Insert objects (via the existing
+   `insert_object` helper) with known `path` / `idx.portal_type` / `idx.review_state`
+   across two site ids (`/sitea/...`, `/siteb/...`). Call `_aggregate(conn, ["sitea"])`
+   and assert: correct `plone_content_total` / `plone_content_by_state` Metric objects
+   (names, `gauge`, scope `global`, `{portal_type|state, site}` labels, counts); objects
+   under `siteb` and rows with NULL `portal_type`/`review_state` are excluded.
+2. **Site selection.** `collect()` yields nothing when no site provides `IPGCatalogTool`
+   (stub/empty app context). With a pg-backed site present, only its id is passed to the
+   aggregation. (Integration-level via `pgcatalog_layer` where a real pg site exists.)
+3. **Degradation.** Monkeypatch `get_pool` to raise `RuntimeError` → `collect()` yields
+   nothing, no exception.
+4. **Cache.** Two `collect()` cycles within the TTL run the SQL once (assert via a
+   call-count spy on `_aggregate` / the connection); past the TTL it re-queries.
+
+`plone.observability` added to the `test` extra so imports resolve.
+
+## Out of scope
+
+- System / ZODB / request metrics (owned by plone.observability's other providers).
+- Adding the `z3c.autoinclude` entry point to plone.observability (tracked separately as
+  plone/plone.observability#21).
+- Any change to the generic provider's step-aside behavior (plone/plone.observability#25).
+
+## CHANGES.md
+
+Add under `## 1.0.0b66 (unreleased)`, section `### Added`:
+
+> - Ship a `plone.observability` `IMetricProvider` (`pgcontent`) that produces
+>   `plone_content_total` / `plone_content_by_state` content-count metrics via SQL for
+>   pg-catalog sites. Registered only when `plone.observability` is installed
+>   (`zcml:condition`) and emits only for sites backed by `IPGCatalogTool` (migration
+>   safe). #174

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ test = [
     "plone.app.testing",
     "zope.pytestlayer",
     "horse-with-no-namespace",
+    "plone.observability",
 ]
 
 [tool.hatch.build.targets.sdist]

--- a/src/plone/pgcatalog/configure.zcml
+++ b/src/plone/pgcatalog/configure.zcml
@@ -1,6 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     >
 
   <!-- GenericSetup extension profile -->
@@ -51,5 +52,16 @@
 
   <!-- GenericSetup profile upgrade steps -->
   <include package=".upgrades" />
+
+  <!-- plone.observability content-count metric provider (soft dependency).
+       Registered only when plone.observability is installed; the provider
+       itself emits only for IPGCatalogTool-backed sites. -->
+  <adapter
+      factory=".observability.PGContentMetricProvider"
+      provides="plone.observability.interfaces.IMetricProvider"
+      for="OFS.interfaces.IApplication"
+      name="pgcontent"
+      zcml:condition="installed plone.observability"
+      />
 
 </configure>

--- a/src/plone/pgcatalog/observability.py
+++ b/src/plone/pgcatalog/observability.py
@@ -5,11 +5,15 @@ This module is imported only when the conditional ZCML registration fires
 plone.observability at module top level is safe.
 """
 
+from plone.observability.interfaces import IMetricProvider
 from plone.observability.metric import Metric
+from plone.pgcatalog.pool import get_pool
+from zope.interface import implementer
 
 import logging
 import os
 import threading
+import time
 
 
 logger = logging.getLogger(__name__)
@@ -72,3 +76,61 @@ def _aggregate(conn, site_ids):
                 )
             )
     return metrics
+
+
+def _pg_site_ids(context):
+    """Return ids of Plone sites whose portal_catalog provides IPGCatalogTool.
+
+    During a migration pgcatalog may be installed while a site still uses a
+    ZCatalog; such sites are left to plone.observability's generic provider.
+    """
+    try:
+        from plone.base.interfaces import IPloneSiteRoot
+    except ImportError:
+        return []
+    from plone.pgcatalog.interfaces import IPGCatalogTool
+
+    site_ids = []
+    for obj in context.objectValues():
+        if not IPloneSiteRoot.providedBy(obj):
+            continue
+        try:
+            catalog = obj.unrestrictedTraverse("portal_catalog", None)
+        except Exception:
+            catalog = None
+        if catalog is not None and IPGCatalogTool.providedBy(catalog):
+            site_ids.append(obj.getId())
+    return site_ids
+
+
+@implementer(IMetricProvider)
+class PGContentMetricProvider:
+    """Content-count metrics via SQL for IPGCatalogTool-backed sites."""
+
+    name = "pgcontent"
+    scope = "global"
+
+    def __init__(self, context):
+        self.context = context
+
+    def collect(self):
+        site_ids = _pg_site_ids(self.context)
+        if not site_ids:
+            return
+        key = tuple(sorted(site_ids))
+        now = time.time()
+        with _cache_lock:
+            entry = _cache.get(key)
+            if entry is not None and (now - entry[0]) < _ttl():
+                yield from entry[1]
+                return
+        try:
+            pool = get_pool(self.context)
+            with pool.connection() as conn:
+                metrics = _aggregate(conn, list(key))
+        except Exception:
+            logger.debug("pgcontent metrics unavailable", exc_info=True)
+            return
+        with _cache_lock:
+            _cache[key] = (now, metrics)
+        yield from metrics

--- a/src/plone/pgcatalog/observability.py
+++ b/src/plone/pgcatalog/observability.py
@@ -1,0 +1,74 @@
+"""plone.observability IMetricProvider producing content counts via SQL.
+
+This module is imported only when the conditional ZCML registration fires
+(``zcml:condition="installed plone.observability"``), so importing
+plone.observability at module top level is safe.
+"""
+
+from plone.observability.metric import Metric
+
+import logging
+import os
+import threading
+
+
+logger = logging.getLogger(__name__)
+
+# Process-global TTL cache. Key: tuple(sorted(site_ids)) -> (timestamp, [Metric]).
+# Must be module-level: the @@metrics view builds a fresh provider instance per
+# request via getAdapters(), so an instance cache would never hit across scrapes.
+_cache = {}
+_cache_lock = threading.Lock()
+
+
+def _ttl():
+    return int(os.environ.get("PLONE_OBSERVABILITY_METRICS_CACHE_TTL", "60"))
+
+
+_TOTAL_SQL = (
+    "SELECT split_part(path, '/', 2) AS site, idx->>'portal_type' AS pt, "
+    "count(*) AS n FROM object_state "
+    "WHERE idx->>'portal_type' IS NOT NULL "
+    "AND split_part(path, '/', 2) = ANY(%(sites)s) "
+    "GROUP BY site, pt"
+)
+
+_STATE_SQL = (
+    "SELECT split_part(path, '/', 2) AS site, idx->>'review_state' AS rs, "
+    "count(*) AS n FROM object_state "
+    "WHERE idx->>'review_state' IS NOT NULL "
+    "AND split_part(path, '/', 2) = ANY(%(sites)s) "
+    "GROUP BY site, rs"
+)
+
+
+def _aggregate(conn, site_ids):
+    """Run the two GROUP BY queries restricted to site_ids; return list[Metric]."""
+    params = {"sites": list(site_ids)}
+    metrics = []
+    with conn.cursor() as cur:
+        cur.execute(_TOTAL_SQL, params)
+        for row in cur.fetchall():
+            metrics.append(
+                Metric(
+                    name="plone_content_total",
+                    value=row["n"],
+                    type="gauge",
+                    scope="global",
+                    help="Number of content objects by portal type",
+                    labels={"portal_type": row["pt"], "site": row["site"]},
+                )
+            )
+        cur.execute(_STATE_SQL, params)
+        for row in cur.fetchall():
+            metrics.append(
+                Metric(
+                    name="plone_content_by_state",
+                    value=row["n"],
+                    type="gauge",
+                    scope="global",
+                    help="Number of content objects by workflow state",
+                    labels={"state": row["rs"], "site": row["site"]},
+                )
+            )
+    return metrics

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,86 @@
+"""Tests for the pgcontent plone.observability metric provider."""
+
+from plone.pgcatalog.indexing import catalog_object
+from tests.conftest import insert_object
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_metric_cache():
+    """The provider caches process-globally; reset around each test."""
+    from plone.pgcatalog import observability
+
+    observability._cache.clear()
+    yield
+    observability._cache.clear()
+
+
+class TestAggregate:
+    def test_counts_by_type_and_state_for_given_site(self, pg_conn_with_catalog):
+        from plone.pgcatalog.observability import _aggregate
+
+        conn = pg_conn_with_catalog
+        for zoid in (1, 2, 3, 4):
+            insert_object(conn, zoid=zoid)
+        catalog_object(
+            conn,
+            zoid=1,
+            path="/sitea/d1",
+            idx={"portal_type": "Document", "review_state": "published"},
+        )
+        catalog_object(
+            conn,
+            zoid=2,
+            path="/sitea/d2",
+            idx={"portal_type": "Document", "review_state": "private"},
+        )
+        catalog_object(
+            conn,
+            zoid=3,
+            path="/sitea/n1",
+            idx={"portal_type": "News Item", "review_state": "published"},
+        )
+        catalog_object(
+            conn,
+            zoid=4,
+            path="/siteb/d3",
+            idx={"portal_type": "Document", "review_state": "published"},
+        )
+        conn.commit()
+
+        metrics = _aggregate(conn, ["sitea"])
+
+        totals = {
+            (m.labels["portal_type"], m.labels["site"]): m.value
+            for m in metrics
+            if m.name == "plone_content_total"
+        }
+        states = {
+            (m.labels["state"], m.labels["site"]): m.value
+            for m in metrics
+            if m.name == "plone_content_by_state"
+        }
+        assert totals == {("Document", "sitea"): 2, ("News Item", "sitea"): 1}
+        assert states == {("published", "sitea"): 2, ("private", "sitea"): 1}
+        assert all(m.type == "gauge" and m.scope == "global" for m in metrics)
+        assert all(m.labels["site"] == "sitea" for m in metrics)
+
+    def test_excludes_null_index_values_and_other_sites(self, pg_conn_with_catalog):
+        from plone.pgcatalog.observability import _aggregate
+
+        conn = pg_conn_with_catalog
+        for zoid in (10, 11):
+            insert_object(conn, zoid=zoid)
+        # no portal_type / review_state in idx → excluded
+        catalog_object(conn, zoid=10, path="/sitea/x", idx={"Title": "no type"})
+        # different site → excluded by the site filter
+        catalog_object(
+            conn,
+            zoid=11,
+            path="/siteb/y",
+            idx={"portal_type": "Document", "review_state": "published"},
+        )
+        conn.commit()
+
+        assert _aggregate(conn, ["sitea"]) == []

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -198,3 +198,17 @@ class TestCollect:
         monkeypatch.setattr(observability, "get_pool", boom)
         provider = observability.PGContentMetricProvider(object())
         assert list(provider.collect()) == []
+
+
+class TestRegistration:
+    def test_pgcontent_adapter_registered(self, pgcatalog_layer):
+        from plone.observability.interfaces import IMetricProvider
+        from zope.component import getGlobalSiteManager
+
+        gsm = getGlobalSiteManager()
+        names = {
+            reg.name
+            for reg in gsm.registeredAdapters()
+            if reg.provided is IMetricProvider
+        }
+        assert "pgcontent" in names

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -84,3 +84,117 @@ class TestAggregate:
         conn.commit()
 
         assert _aggregate(conn, ["sitea"]) == []
+
+
+class _FakeCatalog:
+    pass
+
+
+class _FakeSite:
+    def __init__(self, site_id, catalog):
+        self._id = site_id
+        self._catalog = catalog
+
+    def getId(self):
+        return self._id
+
+    def unrestrictedTraverse(self, name, default=None):
+        if name == "portal_catalog":
+            return self._catalog
+        return default
+
+
+class _FakeApp:
+    def __init__(self, sites):
+        self._sites = sites
+
+    def objectValues(self):
+        return self._sites
+
+
+class TestSiteSelection:
+    def test_only_ipgcatalogtool_sites(self):
+        from plone.base.interfaces import IPloneSiteRoot
+        from plone.pgcatalog.interfaces import IPGCatalogTool
+        from plone.pgcatalog.observability import _pg_site_ids
+        from zope.interface import alsoProvides
+
+        pg_catalog = _FakeCatalog()
+        alsoProvides(pg_catalog, IPGCatalogTool)
+        zcatalog = _FakeCatalog()  # not IPGCatalogTool
+
+        pg_site = _FakeSite("sitea", pg_catalog)
+        alsoProvides(pg_site, IPloneSiteRoot)
+        z_site = _FakeSite("siteb", zcatalog)
+        alsoProvides(z_site, IPloneSiteRoot)
+
+        assert _pg_site_ids(_FakeApp([pg_site, z_site])) == ["sitea"]
+
+
+class _SpyPool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def connection(self):
+        import contextlib
+
+        @contextlib.contextmanager
+        def _cm():
+            yield self._conn
+
+        return _cm()
+
+
+class TestCollect:
+    def test_yields_nothing_without_pg_sites(self, monkeypatch):
+        from plone.pgcatalog import observability
+
+        monkeypatch.setattr(observability, "_pg_site_ids", lambda ctx: [])
+        provider = observability.PGContentMetricProvider(object())
+        assert list(provider.collect()) == []
+
+    def test_caches_within_ttl(self, monkeypatch):
+        from plone.observability.metric import Metric
+        from plone.pgcatalog import observability
+
+        calls = {"n": 0}
+        sample = [
+            Metric(
+                name="plone_content_total",
+                value=1,
+                type="gauge",
+                scope="global",
+                help="h",
+                labels={"portal_type": "Document", "site": "sitea"},
+            )
+        ]
+
+        def fake_aggregate(conn, site_ids):
+            calls["n"] += 1
+            return sample
+
+        monkeypatch.setattr(observability, "_pg_site_ids", lambda ctx: ["sitea"])
+        monkeypatch.setattr(
+            observability, "get_pool", lambda ctx: _SpyPool(conn=object())
+        )
+        monkeypatch.setattr(observability, "_aggregate", fake_aggregate)
+        monkeypatch.setenv("PLONE_OBSERVABILITY_METRICS_CACHE_TTL", "300")
+
+        provider = observability.PGContentMetricProvider(object())
+        first = list(provider.collect())
+        second = list(observability.PGContentMetricProvider(object()).collect())
+
+        assert first == second == sample
+        assert calls["n"] == 1  # second call served from the process-global cache
+
+    def test_degrades_silently_without_pool(self, monkeypatch):
+        from plone.pgcatalog import observability
+
+        monkeypatch.setattr(observability, "_pg_site_ids", lambda ctx: ["sitea"])
+
+        def boom(ctx):
+            raise RuntimeError("no pool")
+
+        monkeypatch.setattr(observability, "get_pool", boom)
+        provider = observability.PGContentMetricProvider(object())
+        assert list(provider.collect()) == []


### PR DESCRIPTION
Closes #174.

## What

A `plone.observability` `IMetricProvider` (`pgcontent`) that produces the content-count
metrics (`plone_content_total` by `portal_type`, `plone_content_by_state` by
`review_state`) efficiently via SQL `GROUP BY` over `object_state` — instead of the
ZCatalog index API, which `PlonePGCatalogTool` does not implement.

- **Soft dependency:** the adapter registers only via
  `zcml:condition="installed plone.observability"`. If the package is absent, nothing is
  registered and the module is never imported.
- **Migration-safe:** emits only for sites whose `portal_catalog` provides
  `IPGCatalogTool`. Sites still on a ZCatalog (migration pending) are left to the generic
  provider — no double counting, no stale numbers from an `idx` that is not maintained
  there.
- **Label parity** with the generic provider, including `site` (derived from
  `split_part(path,'/',2)`).
- **Process-global TTL cache** (`PLONE_OBSERVABILITY_METRICS_CACHE_TTL`, default 60s): the
  `@@metrics` view builds a fresh provider instance per request, so the cache is
  module-level.
- Degrades silently on missing pool / DB error.

## Structure

- `_aggregate(conn, site_ids)` — pure SQL helper (two `GROUP BY` queries, `IS NOT NULL`
  filter).
- `_pg_site_ids(context)` — site discovery via `IPGCatalogTool`.
- `PGContentMetricProvider` — thin adapter (discovery + pool + cache).
- Conditional `<adapter>` in `configure.zcml`.

## Tests

`tests/test_observability.py` — 7 tests: aggregation (types/states/labels/values, NULL and
foreign-site exclusion), site selection (only `IPGCatalogTool`), cache hit, silent
degradation, and conditional registration via the `pgcatalog_layer`. Full suite: 1492
passed, 40 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
