### PR TITLE
feat(schema): partial idx_os_navtree for navigation listing pattern (#130)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,16 @@
 
 ### Added
 
+- Ship a partial `idx_os_navtree` index for the navigation-tree / navigation-
+  portlet listing pattern (`Language` + `portal_type` + path filter +
+  effectiveRange + nav-visibility flags). The index bakes the two highly
+  selective boolean nav flags (`is_default_page`, `exclude_from_nav`) into its
+  partial predicate and `INCLUDE`s the result/security columns, shrinking the
+  candidate set to the nav-visible subtree before any JSONB heap filter. On a
+  ~4M-row production catalog this navigation shape was the single biggest
+  contributor to the slow-query log. Adapted to the current schema: references
+  the typed `path_depth` column (no longer in `idx` JSONB). #130
+
 - Ship a `plone.observability` `IMetricProvider` (`pgcontent`) that produces
   `plone_content_total` / `plone_content_by_state` content-count metrics via SQL
   for pg-catalog sites. Registered only when `plone.observability` is installed

--- a/src/plone/pgcatalog/schema.py
+++ b/src/plone/pgcatalog/schema.py
@@ -184,6 +184,33 @@ CREATE INDEX IF NOT EXISTS idx_os_cat_events_upcoming
       AND (idx->>'portal_type') = 'Event'
       AND (idx->>'show_in_sidecalendar')::boolean = true;
 
+-- Partial index for the navigation-tree / navigation-portlet listing pattern
+-- (#130).  Plone navigation queries combine
+--   Language = ? AND portal_type = ? AND <path filter>
+--   AND effectiveRange AND allowed_roles
+-- and only ever want nav-visible objects.  The two boolean nav flags are
+-- highly selective (nav-visible content is a small fraction of the catalog),
+-- so baking them into the partial predicate shrinks the candidate set to a
+-- few thousand rows before any heap filter for the JSONB-only predicates
+-- (effective/expires, path prefix).  INCLUDE carries the columns the result
+-- and security filter need so the scan stays index-only for the hot path.
+--
+-- NOTE: path_depth is a typed column (idx JSONB no longer carries it, see
+-- the path-strip migration / #132), so it is referenced directly rather than
+-- via (idx->>'path_depth').  parent_path is INCLUDEd so the navtree=True
+-- shape (parent_path = ANY(...)) is also served from this index.
+CREATE INDEX IF NOT EXISTS idx_os_navtree
+    ON object_state (
+        (idx->>'Language'),
+        (idx->>'portal_type'),
+        path_depth,
+        ((idx->>'getObjPositionInParent')::integer)
+    )
+    INCLUDE (zoid, path, parent_path, allowed_roles)
+    WHERE idx IS NOT NULL
+      AND (idx->>'is_default_page')::boolean = false
+      AND (idx->>'exclude_from_nav')::boolean = false;
+
 -- Dedicated GIN indexes for high-cardinality keyword fields.
 -- The full-idx GIN index (idx_os_catalog) is too broad for these — PG
 -- must scan all JSONB keys across all objects.  Dedicated indexes on
@@ -325,6 +352,7 @@ EXPECTED_INDEXES = [
     "idx_os_cat_uid",
     "idx_os_cat_nav_visible",
     "idx_os_cat_events_upcoming",
+    "idx_os_navtree",
     "idx_os_searchable_text",
     "idx_os_cat_title_tsv",
     "idx_os_cat_description_tsv",


### PR DESCRIPTION
## What

Adds a partial index `idx_os_navtree` for the navigation-tree / navigation-portlet listing pattern, the single biggest contributor to the slow-query log on a ~4M-row production catalog (see #130).

```sql
CREATE INDEX IF NOT EXISTS idx_os_navtree
    ON object_state (
        (idx->>'Language'),
        (idx->>'portal_type'),
        path_depth,
        ((idx->>'getObjPositionInParent')::integer)
    )
    INCLUDE (zoid, path, parent_path, allowed_roles)
    WHERE idx IS NOT NULL
      AND (idx->>'is_default_page')::boolean = false
      AND (idx->>'exclude_from_nav')::boolean = false;
```

The two boolean nav flags are highly selective (nav-visible content is a small fraction of the catalog), so baking them into the partial predicate shrinks the candidate set to a few thousand rows before any heap filter for the JSONB-only predicates (effective/expires, path prefix). `INCLUDE` carries the result + security columns so the hot path stays index-only.

## Adaptation vs. the issue's prod-verified DDL

The DDL in #130 was diagnosed on prod (b54 era). Since then **schema and query builder both moved**, so I adapted rather than pasted verbatim:

- `path_depth` is now a **typed column** — `idx` JSONB no longer carries it (path-strip migration, #132). The original `(idx->>'path_depth')::integer` would be `NULL` for every row on current code, making the index degenerate. Now references the typed column directly.
- `parent_path` added to `INCLUDE` so the `navtree=True` query shape (`parent_path = ANY(...)`, the current builder's form) is also served from this index, not just the path-prefix listing shape.
- Boolean predicate form `(idx->>'flag')::boolean = false` matches exactly what the query builder emits (verified against `query.py` `_handle_boolean`), consistent with the sibling `idx_os_cat_nav_visible`.

## Verification

- `tests/test_schema.py` (all 7 pass): `idx_os_navtree` added to `EXPECTED_INDEXES`, so `test_indexes_created` + `test_idempotent` now cover its creation.
- Manual check against the test DB with seeded nav-visible/-hidden rows: the index **builds** (the `getObjPositionInParent` cast is valid) and the planner **picks `idx_os_navtree`** for the navtree-shaped query.

⚠️ **Still to confirm on prod:** the original 670× / ~3.75h-per-day saving was measured against the *older* query+schema shape. Recommend an `EXPLAIN (ANALYZE, BUFFERS)` re-check on aaf-prod against the current query builder before treating the magnitude as confirmed. The change itself is low-risk (tiny partial index, `IF NOT EXISTS`, additive).

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)