### PR TITLE
fix(pgindex): bake JSONB key as literal to avoid generic-plan seq scan (#161)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,18 @@
 
 ### Fixed
 
+- `PGIndex` no longer parametrizes the JSONB key name in its SQL
+  (`idx->>%(key)s`). On PostgreSQL the prepared statement flipped to a generic
+  plan after 5 executions, which could not match the `idx->>'key'` expression
+  indexes and fell back to a sequential scan over `object_state` — on a large
+  catalog this triggered a `LockManager` LWLock storm and a production outage.
+  The validated key is now baked into the SQL text as a `psycopg.sql.Literal`
+  (value stays parameterized), so each key gets its own plan and matches its
+  expression index. All key-bearing sites in `pgindex.py` (`get`, `keys`,
+  `__len__`, `uniqueValues`) are covered; an index whose name is not a safe
+  identifier degrades to the unwrapped ZCatalog index instead of crashing
+  `catalog.Indexes[name]`. #161
+
 - `pgcatalog-tika-worker` no longer crashes with a bare
   `ModuleNotFoundError` when installed without the `tika` / `tika-s3`
   extra. The console script is registered unconditionally, but `httpx`

--- a/src/plone/pgcatalog/pgindex.py
+++ b/src/plone/pgcatalog/pgindex.py
@@ -24,9 +24,11 @@ from Acquisition import aq_parent
 from BTrees.IIBTree import IITreeSet
 from plone.pgcatalog.columns import get_registry
 from plone.pgcatalog.columns import IndexType
+from plone.pgcatalog.columns import validate_identifier
 from plone.pgcatalog.interfaces import IPGCatalogTool
 from plone.pgcatalog.query import _bool_to_lower_str
 from Products.ZCatalog.ZCatalogIndexes import ZCatalogIndexes
+from psycopg import sql as pgsql
 
 import logging
 import warnings
@@ -64,10 +66,17 @@ class _PGIndexMapping:
     of the whole array.
     """
 
-    __slots__ = ("_get_conn", "_idx_key", "_index_type")
+    __slots__ = ("_get_conn", "_idx_key", "_index_type", "_key_lit")
 
     def __init__(self, idx_key, get_conn, index_type=None):
+        # #161: the JSONB key is baked into the SQL text as a literal (not a
+        # %(key)s parameter) so every distinct key gets its own prepared
+        # statement / plan and PG matches the idx->>'key' expression indexes.
+        # validate_identifier pins the key to a safe character set; pgsql.Literal
+        # additionally escapes it, so the interpolation can never inject SQL.
+        validate_identifier(idx_key)
         self._idx_key = idx_key
+        self._key_lit = pgsql.Literal(idx_key)
         self._get_conn = get_conn
         self._index_type = index_type
 
@@ -77,14 +86,16 @@ class _PGIndexMapping:
         except Exception:
             return default
         if self._index_type == IndexType.KEYWORD:
-            sql = (
+            sql = pgsql.SQL(
                 "SELECT zoid FROM object_state "
-                "WHERE idx->%(key)s @> to_jsonb(%(val)s::text) LIMIT 1"
-            )
-            params = {"key": self._idx_key, "val": value}
+                "WHERE idx->{key} @> to_jsonb({val}::text) LIMIT 1"
+            ).format(key=self._key_lit, val=pgsql.Placeholder("val"))
+            params = {"val": value}
         else:
-            sql = "SELECT zoid FROM object_state WHERE idx->>%(key)s = %(val)s LIMIT 1"
-            params = {"key": self._idx_key, "val": _bool_to_lower_str(value)}
+            sql = pgsql.SQL(
+                "SELECT zoid FROM object_state WHERE idx->>{key} = {val} LIMIT 1"
+            ).format(key=self._key_lit, val=pgsql.Placeholder("val"))
+            params = {"val": _bool_to_lower_str(value)}
         with conn.cursor() as cur:
             cur.execute(sql, params)
             row = cur.fetchone()
@@ -114,26 +125,26 @@ class _PGIndexMapping:
             return []
         if self._index_type == IndexType.KEYWORD:
             # See PGIndex.uniqueValues for the ``UNION ALL`` rationale.
-            sql = (
+            sql = pgsql.SQL(
                 "SELECT DISTINCT val FROM ("
-                "  SELECT jsonb_array_elements_text(idx->%(key)s) AS val "
+                "  SELECT jsonb_array_elements_text(idx->{key}) AS val "
                 "    FROM object_state "
-                "    WHERE idx ? %(key)s "
-                "      AND jsonb_typeof(idx->%(key)s) = 'array' "
+                "    WHERE idx ? {key} "
+                "      AND jsonb_typeof(idx->{key}) = 'array' "
                 "  UNION ALL "
-                "  SELECT idx->>%(key)s AS val "
+                "  SELECT idx->>{key} AS val "
                 "    FROM object_state "
-                "    WHERE idx ? %(key)s "
-                "      AND jsonb_typeof(idx->%(key)s) NOT IN ('array', 'null') "
+                "    WHERE idx ? {key} "
+                "      AND jsonb_typeof(idx->{key}) NOT IN ('array', 'null') "
                 ") u WHERE val IS NOT NULL"
-            )
+            ).format(key=self._key_lit)
         else:
-            sql = (
-                "SELECT DISTINCT idx->>%(key)s AS val FROM object_state "
-                "WHERE idx ? %(key)s AND idx->>%(key)s IS NOT NULL"
-            )
+            sql = pgsql.SQL(
+                "SELECT DISTINCT idx->>{key} AS val FROM object_state "
+                "WHERE idx ? {key} AND idx->>{key} IS NOT NULL"
+            ).format(key=self._key_lit)
         with conn.cursor() as cur:
-            cur.execute(sql, {"key": self._idx_key})
+            cur.execute(sql)
             return [row["val"] for row in cur.fetchall()]
 
     def __iter__(self):
@@ -159,27 +170,27 @@ class _PGIndexMapping:
         except Exception:
             return 0
         if self._index_type == IndexType.KEYWORD:
-            sql = (
+            sql = pgsql.SQL(
                 "SELECT COUNT(DISTINCT val) AS n FROM ("
-                "  SELECT jsonb_array_elements_text(idx->%(key)s) AS val "
+                "  SELECT jsonb_array_elements_text(idx->{key}) AS val "
                 "    FROM object_state "
-                "    WHERE idx ? %(key)s "
-                "      AND jsonb_typeof(idx->%(key)s) = 'array' "
+                "    WHERE idx ? {key} "
+                "      AND jsonb_typeof(idx->{key}) = 'array' "
                 "  UNION ALL "
-                "  SELECT idx->>%(key)s AS val "
+                "  SELECT idx->>{key} AS val "
                 "    FROM object_state "
-                "    WHERE idx ? %(key)s "
-                "      AND jsonb_typeof(idx->%(key)s) NOT IN ('array', 'null') "
+                "    WHERE idx ? {key} "
+                "      AND jsonb_typeof(idx->{key}) NOT IN ('array', 'null') "
                 ") u WHERE val IS NOT NULL"
-            )
+            ).format(key=self._key_lit)
         else:
-            sql = (
-                "SELECT COUNT(DISTINCT idx->>%(key)s) AS n "
+            sql = pgsql.SQL(
+                "SELECT COUNT(DISTINCT idx->>{key}) AS n "
                 "FROM object_state "
-                "WHERE idx ? %(key)s AND idx->>%(key)s IS NOT NULL"
-            )
+                "WHERE idx ? {key} AND idx->>{key} IS NOT NULL"
+            ).format(key=self._key_lit)
         with conn.cursor() as cur:
-            cur.execute(sql, {"key": self._idx_key})
+            cur.execute(sql)
             row = cur.fetchone()
         return int(row["n"]) if row and row["n"] is not None else 0
 
@@ -199,8 +210,11 @@ class PGIndex:
     """
 
     def __init__(self, wrapped, idx_key, get_conn, index_type=None):
+        # #161: validate + bake the key as a literal (see _PGIndexMapping).
+        validate_identifier(idx_key)
         self._wrapped = wrapped
         self._idx_key = idx_key
+        self._key_lit = pgsql.Literal(idx_key)
         self._index_type = index_type
         self._pg_index = _PGIndexMapping(idx_key, get_conn, index_type=index_type)
 
@@ -251,8 +265,7 @@ class PGIndex:
         except Exception:
             return
 
-        key = self._idx_key
-        params = {"key": key}
+        key = self._key_lit
 
         if self._index_type == IndexType.KEYWORD:
             # ``jsonb_array_elements_text`` is a set-returning function
@@ -260,42 +273,44 @@ class PGIndex:
             # raises 0A000), so the defensive array/scalar split is
             # expressed as a ``UNION ALL`` subquery.  Array rows expand
             # one row per element; a legacy scalar row yields itself.
-            inner = (
-                "SELECT jsonb_array_elements_text(idx->%(key)s) AS val "
+            inner = pgsql.SQL(
+                "SELECT jsonb_array_elements_text(idx->{key}) AS val "
                 "  FROM object_state "
-                "  WHERE idx ? %(key)s "
-                "    AND jsonb_typeof(idx->%(key)s) = 'array' "
+                "  WHERE idx ? {key} "
+                "    AND jsonb_typeof(idx->{key}) = 'array' "
                 "UNION ALL "
-                "SELECT idx->>%(key)s AS val "
+                "SELECT idx->>{key} AS val "
                 "  FROM object_state "
-                "  WHERE idx ? %(key)s "
-                "    AND jsonb_typeof(idx->%(key)s) NOT IN ('array', 'null')"
-            )
-            distinct_sql = f"SELECT DISTINCT val FROM ({inner}) u WHERE val IS NOT NULL"
-            grouped_sql = (
-                f"SELECT val, COUNT(*) AS cnt FROM ({inner}) u "
+                "  WHERE idx ? {key} "
+                "    AND jsonb_typeof(idx->{key}) NOT IN ('array', 'null')"
+            ).format(key=key)
+            distinct_sql = pgsql.SQL(
+                "SELECT DISTINCT val FROM ({inner}) u WHERE val IS NOT NULL"
+            ).format(inner=inner)
+            grouped_sql = pgsql.SQL(
+                "SELECT val, COUNT(*) AS cnt FROM ({inner}) u "
                 "WHERE val IS NOT NULL GROUP BY val"
-            )
+            ).format(inner=inner)
         else:
-            distinct_sql = (
-                "SELECT DISTINCT idx->>%(key)s AS val "
+            distinct_sql = pgsql.SQL(
+                "SELECT DISTINCT idx->>{key} AS val "
                 "FROM object_state "
-                "WHERE idx ? %(key)s AND idx->>%(key)s IS NOT NULL"
-            )
-            grouped_sql = (
-                "SELECT idx->>%(key)s AS val, COUNT(*) AS cnt "
+                "WHERE idx ? {key} AND idx->>{key} IS NOT NULL"
+            ).format(key=key)
+            grouped_sql = pgsql.SQL(
+                "SELECT idx->>{key} AS val, COUNT(*) AS cnt "
                 "FROM object_state "
-                "WHERE idx ? %(key)s AND idx->>%(key)s IS NOT NULL "
+                "WHERE idx ? {key} AND idx->>{key} IS NOT NULL "
                 "GROUP BY 1"
-            )
+            ).format(key=key)
 
         with conn.cursor() as cur:
             if not withLengths:
-                cur.execute(distinct_sql, params)
+                cur.execute(distinct_sql)
                 for row in cur.fetchall():
                     yield row["val"]
             else:
-                cur.execute(grouped_sql, params)
+                cur.execute(grouped_sql)
                 for row in cur.fetchall():
                     yield (row["val"], row["cnt"])
 
@@ -384,12 +399,26 @@ def _maybe_wrap_index(catalog, name, raw_index):
     else:
         idx_key = name  # Fallback: use index name as JSONB key
 
-    return PGIndex(
-        raw_index,
-        idx_key,
-        catalog._get_pg_read_connection,
-        index_type=index_type,
-    )
+    # #161: PGIndex bakes idx_key into the SQL text, so it must be a safe
+    # identifier.  Registry keys are validated at registration time, but the
+    # fallback above uses an arbitrary index name — guard against an exotic
+    # name crashing catalog.Indexes[name] access by degrading to the raw
+    # (unwrapped) ZCatalog index instead of raising.
+    try:
+        return PGIndex(
+            raw_index,
+            idx_key,
+            catalog._get_pg_read_connection,
+            index_type=index_type,
+        )
+    except ValueError:
+        log.warning(
+            "Index %r has a key %r that is not a safe SQL identifier; "
+            "returning the unwrapped ZCatalog index (no PG-backed lookups).",
+            name,
+            idx_key,
+        )
+        return raw_index
 
 
 class PGCatalogIndexes(ZCatalogIndexes):

--- a/tests/test_pgindex.py
+++ b/tests/test_pgindex.py
@@ -611,6 +611,24 @@ class TestMaybeWrapIndex:
         wrapped = _maybe_wrap_index(catalog, "portal_type", raw_index)
         assert isinstance(wrapped, PGIndex)
 
+    def test_unsafe_index_name_degrades_to_raw(self, pg_conn_with_catalog):
+        """#161: an index whose (fallback) key is not a safe identifier must
+        not crash catalog.Indexes[name] — it degrades to the raw index."""
+        from plone.pgcatalog.interfaces import IPGCatalogTool
+        from plone.pgcatalog.pgindex import _maybe_wrap_index
+        from unittest import mock
+        from zope.interface import directlyProvides
+
+        catalog = mock.Mock()
+        directlyProvides(catalog, IPGCatalogTool)
+        catalog._get_pg_read_connection = lambda: pg_conn_with_catalog
+        raw_index = mock.Mock()
+        raw_index.id = "weird-name"
+        raw_index.meta_type = "FieldIndex"
+
+        wrapped = _maybe_wrap_index(catalog, "weird-name", raw_index)
+        assert wrapped is raw_index
+
     def test_returns_raw_for_non_pg_catalog(self):
         """Non-IPGCatalogTool catalogs get the raw index back."""
         from plone.pgcatalog.pgindex import _maybe_wrap_index
@@ -998,3 +1016,155 @@ class TestPGIndexApplyIndex:
         result, info = idx._apply_index({"portal_type": "Document"})
         assert isinstance(result, IITreeSet)
         assert list(result) == []
+
+
+# ---------------------------------------------------------------------------
+# #161: JSONB key must be baked into the SQL text (literal), not a %(key)s
+# parameter — otherwise PG switches to a generic plan after 5 executions,
+# can't match the idx->>'key' expression indexes, and seq-scans object_state
+# (LockManager LWLock storm / production outage).
+# ---------------------------------------------------------------------------
+
+
+class _CapCursor:
+    """Cursor proxy that records the rendered SQL of every execute()."""
+
+    def __init__(self, real, sink):
+        self._c = real
+        self._sink = sink
+
+    def execute(self, query, params=None, *a, **k):
+        rendered = query.as_string(self._c) if hasattr(query, "as_string") else query
+        self._sink.append(rendered)
+        return self._c.execute(query, params, *a, **k)
+
+    def __enter__(self):
+        self._c.__enter__()
+        return self
+
+    def __exit__(self, *a):
+        return self._c.__exit__(*a)
+
+    def __getattr__(self, name):
+        return getattr(self._c, name)
+
+
+def _capture_sql(real_conn):
+    """Wrap *real_conn* so executed statements are recorded as rendered SQL.
+
+    Returns ``(fake_conn, executed)``; everything delegates to *real_conn*.
+    """
+    executed = []
+    real_cursor = real_conn.cursor
+
+    def cursor(*a, **k):
+        return _CapCursor(real_cursor(*a, **k), executed)
+
+    fake = mock.Mock(wraps=real_conn)
+    fake.cursor = cursor
+    return fake, executed
+
+
+class TestKeyNeverParametrized:
+    """Regression guard for #161 across every key-bearing query site."""
+
+    def test_get_scalar_bakes_key_keeps_value_param(self, pg_conn_with_catalog):
+        _catalog_objects(pg_conn_with_catalog)
+        fake, executed = _capture_sql(pg_conn_with_catalog)
+        m = _PGIndexMapping("UID", lambda: fake)
+        assert m.get("uid-aaa-100") == 100
+        sql = executed[-1]
+        assert "'UID'" in sql, sql
+        assert "%(key)s" not in sql, sql
+        assert "%(val)s" in sql, sql  # value stays parameterized
+
+    def test_get_keyword_bakes_key(self, pg_conn_with_catalog):
+        from plone.pgcatalog.columns import IndexType
+
+        _catalog_objects(pg_conn_with_catalog)
+        fake, executed = _capture_sql(pg_conn_with_catalog)
+        m = _PGIndexMapping("Subject", lambda: fake, index_type=IndexType.KEYWORD)
+        m.get("anything")
+        sql = executed[-1]
+        assert "'Subject'" in sql, sql
+        assert "%(key)s" not in sql, sql
+
+    def test_keys_scalar_bakes_key(self, pg_conn_with_catalog):
+        _catalog_objects(pg_conn_with_catalog)
+        fake, executed = _capture_sql(pg_conn_with_catalog)
+        m = _PGIndexMapping("portal_type", lambda: fake)
+        m.keys()
+        sql = executed[-1]
+        assert "'portal_type'" in sql, sql
+        assert "%(key)s" not in sql, sql
+
+    def test_keys_keyword_bakes_key(self, pg_conn_with_catalog):
+        from plone.pgcatalog.columns import IndexType
+
+        _catalog_objects(pg_conn_with_catalog)
+        fake, executed = _capture_sql(pg_conn_with_catalog)
+        m = _PGIndexMapping("Subject", lambda: fake, index_type=IndexType.KEYWORD)
+        m.keys()
+        sql = executed[-1]
+        assert "'Subject'" in sql, sql
+        assert "%(key)s" not in sql, sql
+
+    def test_len_scalar_bakes_key(self, pg_conn_with_catalog):
+        _catalog_objects(pg_conn_with_catalog)
+        fake, executed = _capture_sql(pg_conn_with_catalog)
+        m = _PGIndexMapping("portal_type", lambda: fake)
+        len(m)
+        sql = executed[-1]
+        assert "'portal_type'" in sql, sql
+        assert "%(key)s" not in sql, sql
+
+    def test_len_keyword_bakes_key(self, pg_conn_with_catalog):
+        from plone.pgcatalog.columns import IndexType
+
+        _catalog_objects(pg_conn_with_catalog)
+        fake, executed = _capture_sql(pg_conn_with_catalog)
+        m = _PGIndexMapping("Subject", lambda: fake, index_type=IndexType.KEYWORD)
+        len(m)
+        sql = executed[-1]
+        assert "'Subject'" in sql, sql
+        assert "%(key)s" not in sql, sql
+
+    def test_unique_values_scalar_bakes_key(self, pg_conn_with_catalog):
+        _catalog_objects(pg_conn_with_catalog)
+        fake, executed = _capture_sql(pg_conn_with_catalog)
+        wrapped = mock.Mock()
+        wrapped.id = "portal_type"
+        idx = PGIndex(wrapped, "portal_type", lambda: fake)
+        list(idx.uniqueValues())
+        sql = executed[-1]
+        assert "'portal_type'" in sql, sql
+        assert "%(key)s" not in sql, sql
+
+    def test_unique_values_with_lengths_bakes_key(self, pg_conn_with_catalog):
+        _catalog_objects(pg_conn_with_catalog)
+        fake, executed = _capture_sql(pg_conn_with_catalog)
+        wrapped = mock.Mock()
+        wrapped.id = "portal_type"
+        idx = PGIndex(wrapped, "portal_type", lambda: fake)
+        list(idx.uniqueValues(withLengths=True))
+        sql = executed[-1]
+        assert "'portal_type'" in sql, sql
+        assert "%(key)s" not in sql, sql
+
+    def test_invalid_key_rejected_at_construction(self):
+        with pytest.raises(ValueError):
+            _PGIndexMapping("UID; DROP TABLE object_state; --", lambda: None)
+
+    def test_pgindex_invalid_key_rejected_at_construction(self):
+        with pytest.raises(ValueError):
+            PGIndex(mock.Mock(), "bad key", lambda: None)
+
+    def test_distinct_keys_resolve_independently(self, pg_conn_with_catalog):
+        """Different keys must each resolve correctly (baked key per call)."""
+        _catalog_objects(pg_conn_with_catalog)
+        uid = _PGIndexMapping("UID", lambda: pg_conn_with_catalog)
+        ptype = _PGIndexMapping("portal_type", lambda: pg_conn_with_catalog)
+        # Reuse each several times — past the generic-plan flip at #5.
+        for _ in range(7):
+            assert uid.get("uid-ccc-102") == 102
+            assert ptype.get("Folder") == 102


### PR DESCRIPTION
## Problem

`PGIndex` emitted SQL that **parametrized the JSONB key name**:

```sql
SELECT zoid FROM object_state WHERE idx->>%(key)s = %(val)s LIMIT 1
```

On PostgreSQL the prepared statement flips to a **generic plan** after 5 executions. With the key still a parameter at plan time, the planner cannot match any of the `idx->>'key'` expression indexes and falls back to a **sequential scan** over `object_state`.

On a 3.9M-row production catalog this caused a **`LockManager` LWLock storm and a ~30 min outage** (9/10 sessions waiting on the LWLock, `/ok` probes timing out, Varnish marking backends sick → 503 cascade). Originally reported as zodb-pgjsonb#60, root-caused to this repo.

## Fix

Bake the validated key into the SQL text as a `psycopg.sql.Literal` (the established pattern from `startup.py`), keeping **only the value** parameterized:

```python
sql = pgsql.SQL(
    "SELECT zoid FROM object_state WHERE idx->>{key} = {val} LIMIT 1"
).format(key=self._key_lit, val=pgsql.Placeholder("val"))
```

Each distinct key now gets its own prepared-statement plan and matches its expression index. Plan-cache size stays bounded by the small set of ZCatalog index names.

### Scope

All key-bearing sites in `pgindex.py`:
- `_PGIndexMapping.get()` (scalar + KEYWORD — the hot-path outage query)
- `_PGIndexMapping.keys()` / `__iter__`
- `_PGIndexMapping.__len__()`
- `PGIndex.uniqueValues()` (distinct + grouped, scalar + KEYWORD)

`_apply_index()` already builds its WHERE via `query._QueryBuilder`, which bakes keys as literals — out of scope, unchanged.

### Safety

- `validate_identifier(idx_key)` is pinned at construction of both `PGIndex` and `_PGIndexMapping` (`^[a-zA-Z_][a-zA-Z0-9_]*$`); `pgsql.Literal` additionally escapes, so the interpolation cannot inject SQL.
- The `_maybe_wrap_index()` fallback uses an arbitrary index *name* as the key; an exotic name now **degrades to the unwrapped ZCatalog index** (logged warning) instead of crashing `catalog.Indexes[name]`.

## Tests

New `TestKeyNeverParametrized` (11 tests) asserts, per method, that the rendered SQL **bakes the key literal** (`'UID'`) and **keeps the value parameterized** (`%(val)s`), never `%(key)s`; plus an injection-rejection test and a functional "distinct keys resolve independently across 7 executions" test. `TestMaybeWrapIndex` gains a graceful-degradation case.

- `tests/test_pgindex.py`: **73 passed**
- Full suite: **1503 passed, 40 skipped**

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)