### PR TITLE
fix(query): ignore non-index query keys instead of emptying results (#168)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,15 @@
 
 ### Fixed
 
+- Catalog searches now ignore query keys that do not match any catalog index,
+  matching ZCatalog semantics. `plone.restapi`'s `@search` forwards its whole
+  request dict to the catalog — including control parameters like
+  `metadata_fields` (e.g. from Volto's `ObjectBrowserWidget`) — which are not
+  indexes. Previously any such unmapped key fell through to a JSONB
+  `idx->>'key'` filter that matched no row and returned an **empty result set**;
+  these keys are now silently dropped before query building (and before the
+  cache key is computed). #168
+
 - `PGIndex` no longer parametrizes the JSONB key name in its SQL
   (`idx->>%(key)s`). On PostgreSQL the prepared statement flipped to a generic
   plan after 5 executions, which could not match the `idx->>'key'` expression

--- a/src/plone/pgcatalog/query.py
+++ b/src/plone/pgcatalog/query.py
@@ -131,6 +131,48 @@ def _is_numeric_range(values):
     return all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in values)
 
 
+def strip_non_index_keys(query_dict, index_names):
+    """Drop query keys that do not correspond to any catalog index.
+
+    ZCatalog's ``searchResults`` only honors query keys matching a registered
+    index and silently ignores the rest.  plone.restapi's ``@search`` passes
+    its whole request dict to the catalog (including control parameters like
+    ``metadata_fields``, ``fullobjects``, ``b_size`` …); without this filter an
+    unknown key falls through to a JSONB ``idx->>'key'`` filter that matches no
+    row and turns the whole result set empty (#168).
+
+    A key is kept when it is a pagination/sort meta key, a real catalog index
+    (``index_names``), a Plone-native built-in (``path``/``effectiveRange``/
+    ``SearchableText``/TEXT[] extra columns), or has an ``IPGIndexTranslator``.
+
+    Args:
+        query_dict: the (already security-filtered) ZCatalog query dict.
+        index_names: iterable of the catalog's actual index names.
+
+    Returns:
+        A new dict containing only the honored keys.
+    """
+    valid = set(index_names)
+    cleaned = {}
+    dropped = []
+    for key, value in query_dict.items():
+        if (
+            key in _QUERY_META_KEYS
+            or key in valid
+            or _builtin_index_type(key) is not None
+            or _lookup_translator(key) is not None
+        ):
+            cleaned[key] = value
+        else:
+            dropped.append(key)
+    if dropped:
+        log.debug(
+            "pgcatalog: ignoring non-index query keys %r (ZCatalog-compat, #168)",
+            sorted(dropped),
+        )
+    return cleaned
+
+
 def build_query(query_dict):
     """Translate a ZCatalog query dict into SQL components.
 

--- a/src/plone/pgcatalog/search.py
+++ b/src/plone/pgcatalog/search.py
@@ -146,6 +146,21 @@ def _run_search(conn, query, catalog=None, lazy_conn=None):
     from plone.pgcatalog.cache import _normalize_query as normalize_query
     from plone.pgcatalog.cache import get_query_cache
 
+    # #168: ignore query keys that aren't catalog indexes (ZCatalog-compat).
+    # plone.restapi @search forwards control params (metadata_fields, …) that
+    # would otherwise become JSONB filters matching nothing → empty results.
+    # Done before the cache key is computed so equivalent queries share a slot.
+    if catalog is not None:
+        try:
+            from plone.pgcatalog.query import strip_non_index_keys
+
+            query = strip_non_index_keys(query, catalog.indexes())
+        except Exception:
+            log.warning(
+                "Could not filter non-index query keys; passing query through",
+                exc_info=True,
+            )
+
     cache = get_query_cache()
 
     # Get catalog change counter for cache validation.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -434,3 +434,35 @@ class TestCatalogFullText:
             },
         )
         assert len(results) == 2
+
+
+class TestNonIndexQueryKeysIgnored:
+    """#168: restapi/control params (e.g. metadata_fields) must not empty results."""
+
+    class _Cat:
+        def indexes(self):
+            return ["portal_type", "review_state", "Subject", "SearchableText"]
+
+    def test_metadata_fields_does_not_empty_results(self, pg_conn_with_catalog):
+        conn = pg_conn_with_catalog
+        _setup_objects(conn)
+        cat = self._Cat()
+        baseline = _run_search(conn, {"portal_type": "Document"}, catalog=cat)
+        with_meta = _run_search(
+            conn,
+            {"portal_type": "Document", "metadata_fields": ["Title", "Creator"]},
+            catalog=cat,
+        )
+        assert len(baseline) > 0
+        assert len(with_meta) == len(baseline)
+
+    def test_only_unknown_key_matches_everything_not_nothing(
+        self, pg_conn_with_catalog
+    ):
+        conn = pg_conn_with_catalog
+        _setup_objects(conn)
+        cat = self._Cat()
+        # A query of only a non-index key reduces to "all cataloged objects"
+        # (ZCatalog ignores it), not an empty set.
+        res = _run_search(conn, {"metadata_fields": ["Title"]}, catalog=cat)
+        assert len(res) > 0

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1325,3 +1325,56 @@ class TestBuiltinIndexFallbackDispatch:
             assert "idx->>'object_provides'" not in qr["where"]
         finally:
             restore()
+
+
+class TestStripNonIndexKeys:
+    """#168: query keys that don't match any catalog index are ignored,
+    mirroring ZCatalog.searchResults, instead of being turned into a JSONB
+    ``idx->>'key'`` filter that matches nothing and empties the result set.
+    """
+
+    def test_drops_unknown_non_index_key(self):
+        from plone.pgcatalog.query import strip_non_index_keys
+
+        cleaned = strip_non_index_keys(
+            {"portal_type": "Document", "metadata_fields": ["Title", "Creator"]},
+            ["portal_type", "review_state"],
+        )
+        assert cleaned == {"portal_type": "Document"}
+
+    def test_keeps_meta_keys(self):
+        from plone.pgcatalog.query import strip_non_index_keys
+
+        q = {
+            "sort_on": "effective",
+            "sort_order": "descending",
+            "sort_limit": 10,
+            "b_start": 0,
+            "b_size": 30,
+            "portal_type": "Document",
+        }
+        assert strip_non_index_keys(q, ["portal_type"]) == q
+
+    def test_keeps_known_index(self):
+        from plone.pgcatalog.query import strip_non_index_keys
+
+        cleaned = strip_non_index_keys({"Subject": "Python"}, ["Subject"])
+        assert cleaned == {"Subject": "Python"}
+
+    def test_keeps_builtin_index_absent_from_list(self):
+        from plone.pgcatalog.query import strip_non_index_keys
+
+        # path / effectiveRange / SearchableText resolve via _builtin_index_type
+        # even when the passed index-name list doesn't contain them.
+        cleaned = strip_non_index_keys(
+            {"path": "/plone", "SearchableText": "x", "effectiveRange": "now"},
+            [],
+        )
+        assert set(cleaned) == {"path", "SearchableText", "effectiveRange"}
+
+    def test_empty_when_only_unknown_keys(self):
+        from plone.pgcatalog.query import strip_non_index_keys
+
+        assert (
+            strip_non_index_keys({"metadata_fields": ["Title"]}, ["portal_type"]) == {}
+        )


### PR DESCRIPTION
## Problem

`plone.restapi`'s `@search` passes the **entire** request dict to the catalog ([handler.py#L102](https://github.com/plone/plone.restapi/blob/main/src/plone/restapi/search/handler.py#L102)), including control parameters such as `metadata_fields` (e.g. every request from Volto's `ObjectBrowserWidget`). These are not catalog indexes.

In pgcatalog, an unmapped key falls through `_process_index()` to the JSONB fallback `idx->>'metadata_fields' = …`, which matches no row → the **whole result set comes back empty**. ZCatalog instead silently ignores query keys that don't match a registered index.

Confirmed in a failing regression test before the fix:

```python
_run_search(conn, {"portal_type": "Document", "metadata_fields": ["Title"]}, catalog=cat)
# → 0 results (should equal the {"portal_type": "Document"} result)
```

## Fix

`_run_search()` now strips keys that are **not** one of:
- a pagination/sort meta key (`sort_on`, `b_start`, …),
- a real catalog index (`catalog.indexes()`),
- a Plone-native builtin (`path` / `effectiveRange` / `SearchableText` / TEXT[] extra columns like `allowedRolesAndUsers`, `object_provides`),
- or backed by an `IPGIndexTranslator`.

Stripping happens **before** the query is built and **before** the cache key is computed (so equivalent queries share a cache slot). New helper `query.strip_non_index_keys(query_dict, index_names)`.

### Why not just add `metadata_fields` to the meta-key set?

That's whack-a-mole — `fullobjects`, `_authenticator`, and any future control param would still empty results. Filtering against the catalog's actual index set is the ZCatalog-faithful, general fix.

### Scope / safety

- Only the catalog-driven path (`searchResults`/`unrestrictedSearchResults` → `_run_search` with `catalog=self`) filters. The builder's JSONB fallback for genuinely custom `idx`-stored indexes is **unchanged**; direct `build_query()` callers keep today's behavior (the two existing fallback tests still pass).
- If `catalog.indexes()` is unavailable, the query passes through unchanged (permissive).

## Tests

- `TestStripNonIndexKeys` (5 unit tests): drops unknown keys, keeps meta keys / known indexes / builtins.
- `TestNonIndexQueryKeysIgnored` (2 integration tests): `metadata_fields` no longer empties results; an only-unknown-key query reduces to "all cataloged objects", not empty.
- Full suite: **1511 passed, 40 skipped**.

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)