### PR TITLE
fix(tika-worker): pass S3 credentials to boto3 (#178)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,15 @@
 
 ### Fixed
 
+- The async Tika worker now forwards S3 credentials to boto3. New
+  `TIKA_WORKER_S3_ACCESS_KEY` / `TIKA_WORKER_S3_SECRET_KEY` env vars are passed
+  as `aws_access_key_id` / `aws_secret_access_key`. Previously the worker built
+  the boto3 client without any credentials, so every blob tiered to S3 failed
+  extraction with `Unable to locate credentials` (only inline-`bytea` blobs
+  were extracted). When the vars are unset, boto3 still falls back to its
+  default credential chain, so IAM-role / ambient-credential setups are
+  unaffected. #178
+
 - `PGIndex` no longer parametrizes the JSONB key name in its SQL
   (`idx->>%(key)s`). On PostgreSQL the prepared statement flipped to a generic
   plan after 5 executions, which could not match the `idx->>'key'` expression

--- a/docs/sources/how-to/enable-tika-extraction.md
+++ b/docs/sources/how-to/enable-tika-extraction.md
@@ -146,7 +146,14 @@ For S3-tiered blobs:
 export TIKA_WORKER_S3_BUCKET=zodb-blobs
 export TIKA_WORKER_S3_ENDPOINT_URL=http://minio:9000
 export TIKA_WORKER_S3_REGION=us-east-1
+export TIKA_WORKER_S3_ACCESS_KEY=...
+export TIKA_WORKER_S3_SECRET_KEY=...
 ```
+
+If `TIKA_WORKER_S3_ACCESS_KEY` / `TIKA_WORKER_S3_SECRET_KEY` are not set, the
+worker leaves credential resolution to boto3's default provider chain (the
+standard `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` environment variables,
+`~/.aws/credentials`, or an instance/IAM role).
 
 See {doc}`../reference/configuration` for the full list of worker
 environment variables.

--- a/docs/sources/reference/configuration.md
+++ b/docs/sources/reference/configuration.md
@@ -78,6 +78,8 @@ as a standalone process (outside Zope):
 | `TIKA_WORKER_S3_BUCKET` | (none) | S3 bucket name for S3-tiered blobs. |
 | `TIKA_WORKER_S3_ENDPOINT_URL` | (none) | S3 endpoint URL (for MinIO or compatible). |
 | `TIKA_WORKER_S3_REGION` | (none) | S3 region name. |
+| `TIKA_WORKER_S3_ACCESS_KEY` | (none) | S3 access key id. When unset, boto3 falls back to its default credential chain (`AWS_*` environment variables, `~/.aws`, IAM role). |
+| `TIKA_WORKER_S3_SECRET_KEY` | (none) | S3 secret access key. See `TIKA_WORKER_S3_ACCESS_KEY`. |
 
 ## GenericSetup profile
 

--- a/src/plone/pgcatalog/tika_worker.py
+++ b/src/plone/pgcatalog/tika_worker.py
@@ -20,6 +20,9 @@ Environment variables:
     TIKA_WORKER_S3_BUCKET     S3 bucket name (optional, for S3-tiered blobs)
     TIKA_WORKER_S3_ENDPOINT_URL  S3 endpoint (optional)
     TIKA_WORKER_S3_REGION     S3 region (optional)
+    TIKA_WORKER_S3_ACCESS_KEY S3 access key id (optional; falls back to boto3's
+                              default credential chain when unset)
+    TIKA_WORKER_S3_SECRET_KEY S3 secret access key (optional; see above)
     TIKA_WORKER_POLL_INTERVAL Seconds between polls when idle (default: 5)
 """
 
@@ -235,10 +238,16 @@ class TikaWorker:
                     "    pip install plone-pgcatalog[tika-s3]"
                 ) from None
 
+            # aws_access_key_id / aws_secret_access_key default to None when not
+            # configured; boto3 treats None as "not provided" and falls back to
+            # its default credential provider chain (env, ~/.aws, IAM role), so
+            # this stays backward-compatible with ambient-credential setups.
             self._s3_client = boto3.client(
                 "s3",
                 endpoint_url=self.s3_config.get("endpoint_url"),
                 region_name=self.s3_config.get("region_name"),
+                aws_access_key_id=self.s3_config.get("access_key"),
+                aws_secret_access_key=self.s3_config.get("secret_key"),
             )
         return self._s3_client
 
@@ -282,6 +291,8 @@ def main():
             "bucket_name": bucket,
             "endpoint_url": os.environ.get("TIKA_WORKER_S3_ENDPOINT_URL"),
             "region_name": os.environ.get("TIKA_WORKER_S3_REGION"),
+            "access_key": os.environ.get("TIKA_WORKER_S3_ACCESS_KEY"),
+            "secret_key": os.environ.get("TIKA_WORKER_S3_SECRET_KEY"),
         }
 
     poll_interval = int(os.environ.get("TIKA_WORKER_POLL_INTERVAL", "5"))

--- a/tests/test_tika_worker_extras.py
+++ b/tests/test_tika_worker_extras.py
@@ -59,3 +59,93 @@ def test_main_exits_with_clear_hint_without_httpx():
     # ... instead a clear, actionable hint mentioning the extra.
     assert "tika" in combined.lower()
     assert "pip install" in combined.lower()
+
+
+# ---------------------------------------------------------------------------
+# #178: the worker must forward S3 credentials to boto3, otherwise every
+# S3-tiered blob fails extraction with "Unable to locate credentials".
+# ---------------------------------------------------------------------------
+
+
+def test_s3_client_forwards_credentials(monkeypatch):
+    """_get_s3_client passes access/secret key through to boto3.client."""
+    from plone.pgcatalog.tika_worker import TikaWorker
+
+    import types
+
+    captured = {}
+    fake_boto3 = types.SimpleNamespace(
+        client=lambda *a, **k: captured.update(service=a, kwargs=k) or "CLIENT"
+    )
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+
+    worker = TikaWorker(
+        dsn="x",
+        tika_url="y",
+        s3_config={
+            "bucket_name": "b",
+            "endpoint_url": "http://endpoint",
+            "region_name": "eu",
+            "access_key": "AKIA",
+            "secret_key": "SECRET",
+        },
+    )
+    client = worker._get_s3_client()
+    assert client == "CLIENT"
+    kw = captured["kwargs"]
+    assert kw["endpoint_url"] == "http://endpoint"
+    assert kw["region_name"] == "eu"
+    assert kw["aws_access_key_id"] == "AKIA"
+    assert kw["aws_secret_access_key"] == "SECRET"
+
+
+def test_s3_client_without_credentials_passes_none(monkeypatch):
+    """Backward-compatible: no creds → boto3 falls back to its provider chain."""
+    from plone.pgcatalog.tika_worker import TikaWorker
+
+    import types
+
+    captured = {}
+    fake_boto3 = types.SimpleNamespace(
+        client=lambda *a, **k: captured.update(k) or "CLIENT"
+    )
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+
+    worker = TikaWorker(
+        dsn="x",
+        tika_url="y",
+        s3_config={"bucket_name": "b", "endpoint_url": None, "region_name": None},
+    )
+    worker._get_s3_client()
+    # Keys are forwarded as None so boto3 uses its default credential chain.
+    assert captured["aws_access_key_id"] is None
+    assert captured["aws_secret_access_key"] is None
+
+
+def test_main_reads_s3_credentials_from_env(monkeypatch):
+    """main() reads TIKA_WORKER_S3_ACCESS_KEY / _SECRET_KEY into s3_config."""
+    from plone.pgcatalog import tika_worker
+
+    monkeypatch.setenv("TIKA_WORKER_DSN", "dsn")
+    monkeypatch.setenv("TIKA_WORKER_URL", "http://tika")
+    monkeypatch.setenv("TIKA_WORKER_S3_BUCKET", "bucket")
+    monkeypatch.setenv("TIKA_WORKER_S3_ACCESS_KEY", "AKIA")
+    monkeypatch.setenv("TIKA_WORKER_S3_SECRET_KEY", "SECRET")
+
+    captured = {}
+
+    class _FakeWorker:
+        def __init__(self, **kw):
+            captured.update(kw)
+
+        def run(self):
+            pass
+
+    monkeypatch.setattr(tika_worker, "TikaWorker", _FakeWorker)
+    monkeypatch.setattr(tika_worker, "httpx", object())  # pretend extra present
+    tika_worker.main()
+
+    s3 = captured["s3_config"]
+    assert s3["access_key"] == "AKIA"
+    assert s3["secret_key"] == "SECRET"
+    assert s3["bucket_name"] == "bucket"


### PR DESCRIPTION
## Problem

The async Tika worker (`pgcatalog-tika-worker`) built its boto3 S3 client **without credentials**:

```python
self._s3_client = boto3.client(
    "s3",
    endpoint_url=self.s3_config.get("endpoint_url"),
    region_name=self.s3_config.get("region_name"),
)
```

`main()` never read any access/secret key either. So for **every blob tiered to S3**, `download_fileobj` raised `NoCredentialsError: Unable to locate credentials` and extraction failed after exhausting `max_attempts`; only blobs still inline in PG `bytea` got extracted. In the reporter's deployment a full clear-and-rebuild left 3444 `failed` rows with exactly that error (#178).

## Fix

- `main()` reads two new env vars into `s3_config`: `TIKA_WORKER_S3_ACCESS_KEY`, `TIKA_WORKER_S3_SECRET_KEY`.
- `_get_s3_client()` forwards them as `aws_access_key_id` / `aws_secret_access_key`.
- Backward compatible: when unset they pass through as `None`, so boto3 falls back to its default credential chain (`AWS_*` env, `~/.aws`, IAM role) — IAM-role / ambient-credential setups are unaffected.
- Documented in the worker module docstring, `docs/sources/reference/configuration.md`, and `docs/sources/how-to/enable-tika-extraction.md`.

## Tests

`tests/test_tika_worker_extras.py` (3 new): credentials forwarded to `boto3.client`; `None` passed through when unset (provider-chain fallback); `main()` reads the env vars into `s3_config`. All tika tests pass (33 passed, 12 skipped).

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)