### PR TITLE
feat(startup): version-tag deferred index/ANALYZE actions for the schema-version gate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,19 @@
 
 ## 1.0.0b67 (unreleased)
 
+### Changed
+
+- Version-tag the three deferred startup actions (`ensure_text_indexes`,
+  `ensure_field_indexes`, `analyze_object_state`) so zodb-pgjsonb's
+  double-checked schema-version gate lets replicas skip the startup advisory
+  lock when their work is already current. On a rolling deploy this stops every
+  pod from queuing behind the lock — catalog indexes and `ANALYZE` now run once
+  per schema- or registry-changing deploy instead of on every pod start. The
+  index versions track the live `IndexRegistry`; the `ANALYZE` version tracks
+  the catalog DDL. The `version=` argument is passed only when the installed
+  zodb-pgjsonb supports it, so older releases keep working unchanged.
+  bluedynamics/zodb-pgjsonb#78
+
 ### Fixed
 
 - Full-text search now picks up the current site/negotiated language when the

--- a/docs/sources/explanation/architecture.md
+++ b/docs/sources/explanation/architecture.md
@@ -313,6 +313,27 @@ The registry is a module-level singleton.
 Once populated, it is used by both the
 write path (`_extract_idx()`) and the read path (`build_query()`).
 
+### Rolling deploys and the schema-version gate
+
+The GIN text indexes, btree field indexes, and the one-shot `ANALYZE` are not
+applied inline at startup.
+They would need an `ACCESS EXCLUSIVE` lock that deadlocks against the
+`REPEATABLE READ` snapshot the startup connection still holds, so the subscriber
+hands them to `storage.defer_startup_action()` to run from the first write
+transaction instead.
+
+On a rolling deploy every replica queues this same work, and the storage
+serializes it behind a single advisory lock.
+To keep the losing replicas from all waiting on that lock, plone-pgcatalog tags
+each deferred action with a version: the index actions hash the live
+`IndexRegistry`, and the `ANALYZE` hashes the catalog DDL.
+The storage's schema-version gate then lets a replica skip the lock entirely
+when its tagged work is already current.
+The observable effect is that catalog indexes and `ANALYZE` run once per
+schema- or registry-changing deploy, not on every pod start.
+See the zodb-pgjsonb explanation of the startup schema-version gate for how the
+gate itself works.
+
 ### Runtime registration
 
 Addons can register new indexes after startup -- either by calling

--- a/src/plone/pgcatalog/startup.py
+++ b/src/plone/pgcatalog/startup.py
@@ -19,6 +19,8 @@ from plone.pgcatalog.interfaces import IPGIndexTranslator
 from plone.pgcatalog.processor import CatalogStateProcessor
 from zope.component import provideUtility
 
+import hashlib
+import inspect
 import logging
 import os
 import psycopg
@@ -131,21 +133,7 @@ def register_catalog_processor(event):
         # snapshot (ACCESS SHARE), which would block CREATE INDEX (needs
         # ACCESS EXCLUSIVE).  defer_startup_action() queues the work for
         # tpc_begin() when the read snapshot has been committed.
-        if hasattr(storage, "defer_startup_action"):
-            storage.defer_startup_action(
-                _make_ensure_text_indexes_action(), "ensure_text_indexes"
-            )
-            storage.defer_startup_action(
-                _make_ensure_field_indexes_action(), "ensure_field_indexes"
-            )
-            storage.defer_startup_action(
-                _make_analyze_object_state_action(),
-                "analyze_object_state",
-            )
-        else:
-            # Fallback for older zodb-pgjsonb without defer_startup_action
-            _ensure_text_indexes(storage)
-            _ensure_field_indexes(storage)
+        _defer_index_actions(storage, processor)
         _backfill_extra_idx_columns(storage)
 
         # Enable refs prefetch for cataloged content objects only.
@@ -170,6 +158,108 @@ def register_catalog_processor(event):
         log.debug("Storage %s does not support state processors", storage)
 
 
+def _text_index_targets():
+    """Return ``[(name, idx_key), ...]`` for dynamic TEXT indexes.
+
+    These are the GIN expression indexes ``_make_ensure_text_indexes_action``
+    would create (SearchableText, with ``idx_key=None``, is excluded).
+    """
+    registry = get_registry()
+    return [
+        (name, idx_key)
+        for name, (idx_type, idx_key, _) in registry.items()
+        if idx_type == IndexType.TEXT and idx_key is not None
+    ]
+
+
+def _field_index_targets():
+    """Return ``[(name, idx_type, idx_key), ...]`` for dynamic btree indexes."""
+    registry = get_registry()
+    return [
+        (name, idx_type, idx_key)
+        for name, (idx_type, idx_key, _) in registry.items()
+        if idx_type in _BTREE_INDEX_TYPES
+        and idx_key is not None
+        and idx_key not in _HARDCODED_IDX_KEYS
+    ]
+
+
+def _index_set_version(targets):
+    """Return a stable ``sha256:`` version for a set of index targets.
+
+    The hash is order-independent and changes whenever the set of indexes
+    (names, types, keys) changes, so the startup schema-version gate
+    re-runs the deferred index action only when the registry changed (#78).
+    """
+    payload = "\n".join(sorted("|".join(str(part) for part in t) for t in targets))
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _schema_sql_version(processor):
+    """Return a ``sha256:`` version of the processor's catalog DDL.
+
+    Used to tag the deferred ANALYZE: the extended statistics it populates
+    are defined in ``get_schema_sql()``, so the ANALYZE should re-run exactly
+    when that DDL changes.
+    """
+    sql = processor.get_schema_sql() or ""
+    return "sha256:" + hashlib.sha256(sql.encode("utf-8")).hexdigest()
+
+
+def _defer_supports_version(func):
+    """Return True if *func* accepts a ``version`` keyword argument.
+
+    Lets us tag deferred actions when running against a zodb-pgjsonb that
+    supports the schema-version gate, while staying compatible with older
+    releases whose ``defer_startup_action`` has no ``version`` parameter.
+    """
+    try:
+        return "version" in inspect.signature(func).parameters
+    except (TypeError, ValueError):
+        return False
+
+
+def _defer_index_actions(storage, processor):
+    """Queue the deferred index/ANALYZE startup actions, version-tagged.
+
+    Each action carries a version so the storage's double-checked
+    schema-version gate (#78) lets replicas whose work is already current
+    skip the startup advisory lock entirely.  Text/field index versions
+    track the live IndexRegistry; the ANALYZE version tracks the catalog
+    DDL.  Falls back to immediate creation when the storage has no
+    ``defer_startup_action`` at all.
+    """
+    if not hasattr(storage, "defer_startup_action"):
+        # Fallback for older zodb-pgjsonb without defer_startup_action.
+        _ensure_text_indexes(storage)
+        _ensure_field_indexes(storage)
+        return
+
+    use_version = _defer_supports_version(storage.defer_startup_action)
+
+    def _defer(action, name, version):
+        if use_version:
+            storage.defer_startup_action(action, name, version=version)
+        else:
+            storage.defer_startup_action(action, name)
+
+    _defer(
+        _make_ensure_text_indexes_action(),
+        "ensure_text_indexes",
+        _index_set_version(_text_index_targets()),
+    )
+    _defer(
+        _make_ensure_field_indexes_action(),
+        "ensure_field_indexes",
+        _index_set_version(_field_index_targets()),
+    )
+    _defer(
+        _make_analyze_object_state_action(),
+        "analyze_object_state",
+        _schema_sql_version(processor),
+    )
+
+
 def _make_ensure_text_indexes_action():
     """Return a callable(dsn) that creates text indexes when invoked.
 
@@ -177,12 +267,7 @@ def _make_ensure_text_indexes_action():
     to ``storage.defer_startup_action()`` and executed during the first
     write transaction when REPEATABLE READ locks are released.
     """
-    registry = get_registry()
-    text_indexes = [
-        (name, idx_key)
-        for name, (idx_type, idx_key, _) in registry.items()
-        if idx_type == IndexType.TEXT and idx_key is not None
-    ]
+    text_indexes = _text_index_targets()
     if not text_indexes:
         return lambda dsn: None
 
@@ -226,14 +311,7 @@ def _make_ensure_field_indexes_action():
     to ``storage.defer_startup_action()`` and executed during the first
     write transaction when REPEATABLE READ locks are released.
     """
-    registry = get_registry()
-    candidates = [
-        (name, idx_type, idx_key)
-        for name, (idx_type, idx_key, _) in registry.items()
-        if idx_type in _BTREE_INDEX_TYPES
-        and idx_key is not None
-        and idx_key not in _HARDCODED_IDX_KEYS
-    ]
+    candidates = _field_index_targets()
     if not candidates:
         return lambda dsn: None
 

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -1,8 +1,17 @@
 """Tests for plone.pgcatalog startup hooks."""
 
+from plone.pgcatalog.columns import get_registry
+from plone.pgcatalog.columns import IndexType
+from plone.pgcatalog.processor import CatalogStateProcessor
+from plone.pgcatalog.startup import _defer_index_actions
+from plone.pgcatalog.startup import _index_set_version
 from plone.pgcatalog.startup import _make_analyze_object_state_action
+from plone.pgcatalog.startup import _schema_sql_version
+from plone.pgcatalog.startup import _text_index_targets
 from psycopg.types.json import Json
 from tests.conftest import DSN
+
+import hashlib
 
 
 def _insert_catalog_rows(conn, count=5):
@@ -77,3 +86,76 @@ class TestAnalyzeObjectStateAction:
         action = _make_analyze_object_state_action()
         action(DSN)
         action(DSN)
+
+
+class _RecordingStorage:
+    """Fake storage recording defer_startup_action calls (version-aware)."""
+
+    def __init__(self):
+        self.calls = []  # (name, version)
+
+    def defer_startup_action(self, action, name, version=None):
+        self.calls.append((name, version))
+
+
+class _LegacyRecordingStorage:
+    """Fake storage whose defer_startup_action predates the version kwarg."""
+
+    def __init__(self):
+        self.calls = []  # (name,)
+
+    def defer_startup_action(self, action, name):
+        self.calls.append((name,))
+
+
+class TestVersionTaggedDeferral:
+    """The three deferred startup actions must be version-tagged (#78)."""
+
+    def test_all_actions_tagged_with_non_none_version(self):
+        storage = _RecordingStorage()
+        _defer_index_actions(storage, CatalogStateProcessor())
+
+        names = [name for name, _ in storage.calls]
+        assert names == [
+            "ensure_text_indexes",
+            "ensure_field_indexes",
+            "analyze_object_state",
+        ]
+        assert all(version is not None for _, version in storage.calls)
+
+    def test_analyze_version_tracks_schema_sql(self):
+        processor = CatalogStateProcessor()
+        storage = _RecordingStorage()
+        _defer_index_actions(storage, processor)
+
+        versions = dict(storage.calls)
+        assert versions["analyze_object_state"] == _schema_sql_version(processor)
+
+    def test_text_version_changes_when_registry_changes(self):
+        before = _index_set_version(_text_index_targets())
+        registry = get_registry()
+        registry.register("GateExtraText", IndexType.TEXT, "GateExtraText")
+        try:
+            after = _index_set_version(_text_index_targets())
+        finally:
+            del registry._indexes["GateExtraText"]
+        assert before != after
+
+    def test_legacy_storage_without_version_kwarg_still_works(self):
+        storage = _LegacyRecordingStorage()
+        _defer_index_actions(storage, CatalogStateProcessor())
+
+        names = [name for (name,) in storage.calls]
+        assert names == [
+            "ensure_text_indexes",
+            "ensure_field_indexes",
+            "analyze_object_state",
+        ]
+
+    def test_index_set_version_is_deterministic_and_order_independent(self):
+        targets_a = [("b", "B"), ("a", "A")]
+        targets_b = [("a", "A"), ("b", "B")]
+        assert _index_set_version(targets_a) == _index_set_version(targets_b)
+        assert _index_set_version([]).startswith("sha256:")
+        expected_empty = "sha256:" + hashlib.sha256(b"").hexdigest()
+        assert _index_set_version([]) == expected_empty


### PR DESCRIPTION
## Why

plone-pgcatalog defers three startup actions to the first write transaction — `ensure_text_indexes`, `ensure_field_indexes`, and `analyze_object_state` — via `storage.defer_startup_action()`. They used to run on **every** pod start, so on a rolling deploy every replica queued them behind zodb-pgjsonb's startup advisory lock. The losers held idle-in-transaction connections waiting on the lock, contributing to the DB saturation described in bluedynamics/zodb-pgjsonb#78.

zodb-pgjsonb #78 added a double-checked schema-version gate: a deferred action carrying a `version` lets a replica skip the lock entirely when its work is already current. This PR makes pgcatalog's three actions participate, so loser pods bail **completely** instead of only skipping the static DDL block.

## What

- Each deferred action is now tagged with a version:
  - `ensure_text_indexes` / `ensure_field_indexes` → an order-independent `sha256` of the live `IndexRegistry` targets, so the action re-runs exactly when the set of indexes changes.
  - `analyze_object_state` → `sha256` of the catalog DDL (`get_schema_sql()`), since the extended statistics it populates are defined there.
- The deferral wiring is extracted into `_defer_index_actions(storage, processor)`, and the index/target filtering is shared with the `_make_ensure_*` builders (`_text_index_targets` / `_field_index_targets`) — no duplicated registry queries.
- **Backward compatible:** `version=` is passed only when the installed `defer_startup_action` accepts it (detected with `inspect.signature`). Older zodb-pgjsonb releases keep working unchanged, and the no-`defer_startup_action` fallback (immediate creation) is preserved.

Net effect: catalog indexes and `ANALYZE` run **once per schema- or registry-changing deploy**, not on every pod start.

## Dependency floor

Intentionally left at `zodb-pgjsonb>=1.13.0`. The gate ships in an as-yet-unreleased zodb-pgjsonb (bluedynamics/zodb-pgjsonb#79, merged to `main`); bumping the floor now would require an unreleased version. The feature-detection makes the floor bump a no-rush follow-up once that release is cut.

## Tests

New `TestVersionTaggedDeferral` in `tests/test_startup.py` (5 tests): all three actions tagged non-None, analyze version tracks `get_schema_sql()`, text version changes when the registry changes, legacy storage without the `version` kwarg still works, and `_index_set_version` is deterministic/order-independent.

Full suite: **1524 passed, 40 skipped**. Pre-commit (ruff, ruff-format, Vale) clean. Docs build with zero new warnings.

## Docs

Added a "Rolling deploys and the schema-version gate" subsection to `explanation/architecture.md`, cross-referencing the zodb-pgjsonb explanation rather than duplicating the mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)