### PR TITLE
fix(schema): raise object_provides statistics target to 2000 (#133)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,15 @@
   zodb-pgjsonb supports it, so older releases keep working unchanged.
   bluedynamics/zodb-pgjsonb#78
 
+- Raise the per-column statistics target for `object_provides` to 2000. The
+  planner estimates `TEXT[]` array-containment via element MCEs; at the default
+  target the MCE list is short, so rare / mid-frequency marker interfaces fall
+  below the floor and get badly underestimated — flipping to Bitmap-AND plans
+  that heap-scan hundreds of thousands of rows (queries on rare markers spiked
+  to 20–30 s). The larger target doubles the MCE list and stabilises those
+  plans; it is populated by the deferred `ANALYZE` (whose version tracks the
+  catalog DDL, so it re-runs on the next deploy). #133
+
 ### Fixed
 
 - Full-text search now picks up the current site/negotiated language when the

--- a/src/plone/pgcatalog/schema.py
+++ b/src/plone/pgcatalog/schema.py
@@ -226,6 +226,18 @@ DROP INDEX IF EXISTS idx_os_cat_provides_gin;
 CREATE INDEX IF NOT EXISTS idx_os_object_provides
     ON object_state USING gin (object_provides) WHERE object_provides IS NOT NULL;
 
+-- Raise the per-column statistics target for object_provides (#133).
+-- object_provides is a TEXT[] of marker interfaces; PG estimates array
+-- containment via element MCEs (most_common_elems).  At the default
+-- target the MCE list is short, so rare / mid-frequency interfaces fall
+-- below the floor and the planner badly underestimates their selectivity
+-- — flipping to Bitmap-AND plans that heap-scan hundreds of thousands of
+-- rows instead of leading with the object_provides GIN.  A larger target
+-- doubles the MCE list and stabilises those plans.  Populated by the
+-- deferred ANALYZE (whose version tracks this DDL, so it re-runs on the
+-- next deploy after this change).  Idempotent.
+ALTER TABLE object_state ALTER COLUMN object_provides SET STATISTICS 2000;
+
 -- Subject keywords
 CREATE INDEX IF NOT EXISTS idx_os_cat_subject_gin
     ON object_state USING gin ((idx->'Subject'))

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -70,6 +70,25 @@ class TestSchemaInstallation:
         for stat_name in EXPECTED_STATISTICS:
             assert stat_name in found, f"Statistics {stat_name} not found"
 
+    def test_object_provides_statistics_target_bumped(self, pg_conn_with_catalog):
+        """object_provides carries a raised statistics target (#133).
+
+        Rare/mid-frequency marker interfaces sit below the default
+        array-element MCE floor, so the planner underestimates their
+        selectivity and flips to plans that heap-scan hundreds of
+        thousands of rows.  A higher per-column statistics target
+        doubles the MCV/MCE list and stabilises those plans.
+        """
+        with pg_conn_with_catalog.cursor() as cur:
+            cur.execute(
+                "SELECT attstattarget FROM pg_attribute "
+                "WHERE attrelid = 'object_state'::regclass "
+                "  AND attname = 'object_provides'"
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row["attstattarget"] == 2000
+
     def test_idempotent(self, pg_conn_with_catalog):
         """Running install_catalog_schema twice does not error."""
         # Already installed by the fixture — run again


### PR DESCRIPTION
## Problem

Queries filtering on **rare marker interfaces** in `object_provides` (e.g. `collective.lineage.interfaces.IChildSite` — 15 of 3.9M rows) sporadically spiked to **20–30 s**, even though the same query runs in 5–7 ms when the planner leads with the `object_provides` GIN (#133).

Root cause: the planner estimates `TEXT[]` array-containment via element MCEs (`most_common_elems`). At the default per-column statistics target the MCE list is short, so rare / mid-frequency interfaces fall below the floor (`array_typanalyze` uses a generic lower bound → estimates ~200 rows for the actual 15). On a knife-edge that flips the plan to a Bitmap-AND leading with `allowed_roles` / path-LIKE, heap-scanning hundreds of thousands of rows.

## Fix (issue's Suggestion A — schema-side, by default)

```sql
ALTER TABLE object_state ALTER COLUMN object_provides SET STATISTICS 2000;
```

Added to `CATALOG_INDEXES` right after `idx_os_object_provides`. Doubles the MCE list and stabilises plans for the long tail of behavior/viewlet/layout/marker interfaces. (It can't help interfaces *below* the MCE floor on its own, but it removes the plan-flip instability for everything mid-frequency, and lowers the cost for the rare cases.)

### Populated automatically

`SET STATISTICS` only changes the target — `ANALYZE` must run to populate it. Because the statement ships in `get_schema_sql()`, the deferred `analyze_object_state` action's version (a hash of the catalog DDL, added in #181) changes, so `ANALYZE` re-runs on the next deploy and repopulates. Idempotent, multi-pod safe via the existing schema-version gate.

## Tests

`tests/test_schema.py`: new `test_object_provides_statistics_target_bumped` asserts `pg_attribute.attstattarget == 2000` after install; `test_idempotent` confirms re-running the DDL is safe.

Full suite: **1525 passed, 40 skipped** (the #181 startup version-tag tests still pass — the analyze version is computed dynamically from `get_schema_sql()`).

## Scope note

This is Suggestion A from #133. Suggestion B (engine-side: detect rare array-element filters and propose partial btrees on `zoid`) is the broader follow-up and is **not** in this PR.

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)