### PR TITLE
fix(indexers): Tika-aware NamedfileFieldConverter implementation (#114)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,16 @@
 
 ### Fixed
 
+- Skip `portal_transforms` for searchable `NamedBlobFile` fields when Tika is
+  active. `plone.app.dexterity.textindexer`'s dynamic `SearchableText` indexer
+  runs `NamedfileFieldConverter` (a synchronous `portal_transforms` call) on
+  every field marked *searchable*; only the `IFile` indexer was overridden
+  before (#41). A new `TikaAwareNamedfileFieldConverter` returns the filename
+  and defers body-text extraction to the async Tika worker when
+  `PGCATALOG_TIKA_URL` is set, and delegates to the stock converter otherwise.
+  Registered only when `plone.app.dexterity` is installed. (The secondary-blob
+  enqueue-coverage gap this surfaces is tracked in #184.) #114
+
 - Full-text search now picks up the current site/negotiated language when the
   query has no explicit `Language` parameter, instead of falling back to the
   `simple` text-search configuration. On multilingual sites this means BM25 /

--- a/src/plone/pgcatalog/indexers.py
+++ b/src/plone/pgcatalog/indexers.py
@@ -1,14 +1,22 @@
-"""Conditional SearchableText indexer for IFile.
+"""Conditional SearchableText indexers that skip portal_transforms for Tika.
 
-When ``PGCATALOG_TIKA_URL`` is configured, skips the expensive
-``portal_transforms`` pipeline (pdftotext, wv, BFS graph traversal)
-and returns only Title + Description.  The Tika async worker
-extracts blob text and merges it into ``searchable_text`` as
-tsvector weight 'C'.
+When ``PGCATALOG_TIKA_URL`` is configured, blob text extraction is handled
+asynchronously by the Tika worker (merged into ``searchable_text`` as tsvector
+weight 'C').  The synchronous ``portal_transforms`` pipeline (pdftotext, wv, …)
+is then skipped to avoid duplicate work and ``BROKEN transform`` log spam when
+the transform binaries are deliberately absent.
 
-When ``PGCATALOG_TIKA_URL`` is NOT set, delegates to the original
-``plone.app.contenttypes.indexers.SearchableText_file`` so the
-full transform pipeline runs as before.
+Two indexing paths read blobs and are overridden here:
+
+* ``SearchableText_file`` (stock ``plone.app.contenttypes``, bound to ``IFile``)
+  — replaced by :func:`SearchableText_file_override` (#41).
+* the per-field ``NamedfileFieldConverter`` used by
+  ``plone.app.dexterity.textindexer``'s dynamic SearchableText indexer for
+  fields marked *searchable* — replaced by
+  :class:`TikaAwareNamedfileFieldConverter` (#114).
+
+When ``PGCATALOG_TIKA_URL`` is NOT set, both delegate to the original
+implementation so the full transform pipeline runs as before.
 """
 
 from plone.app.contenttypes.indexers import SearchableText
@@ -34,3 +42,37 @@ def SearchableText_file_override(obj):
 
 
 indexer_SearchableText_file_override = indexer(IFile)(SearchableText_file_override)
+
+
+# ── textindexer NamedBlobFile converter override (#114) ─────────────────────
+# plone.app.dexterity.textindexer is an optional path; import defensively so
+# plone.pgcatalog stays importable without it.  The overrides.zcml registration
+# is gated on ``installed plone.app.dexterity`` so the adapter is only wired up
+# where the stock converter exists.
+try:
+    from plone.app.dexterity.textindexer.converters import NamedfileFieldConverter
+    from plone.base.utils import safe_text
+except ImportError:  # pragma: no cover - minimal installs without textindexer
+    NamedfileFieldConverter = None
+
+if NamedfileFieldConverter is not None:
+
+    class TikaAwareNamedfileFieldConverter(NamedfileFieldConverter):
+        """NamedBlobFile field converter that defers to Tika when active.
+
+        The stock converter runs ``portal_transforms`` on the blob to produce
+        indexable text.  When ``PGCATALOG_TIKA_URL`` is set the async worker
+        already extracts that text, so we skip the transform and return only
+        the filename (kept searchable immediately).  Body text is merged later
+        by the worker.  See #114; the secondary-blob enqueue gap is #184.
+        """
+
+        def convert(self):
+            tika_url = os.environ.get("PGCATALOG_TIKA_URL", "").strip()
+            if not tika_url:
+                return super().convert()
+            storage = self.field.interface(self.context)
+            data = self.field.get(storage)
+            if not data or data.getSize() == 0:
+                return ""
+            return safe_text(data.filename or "")

--- a/src/plone/pgcatalog/overrides.zcml
+++ b/src/plone/pgcatalog/overrides.zcml
@@ -28,4 +28,15 @@
       name="SearchableText"
       />
 
+  <!-- Skip portal_transforms for searchable NamedBlobFile fields when Tika
+       is active (#114).  plone.app.dexterity.textindexer's dynamic
+       SearchableText indexer runs NamedfileFieldConverter on every field
+       marked 'searchable'; the override returns the filename and lets the
+       async Tika worker extract the body text.  Delegates to the stock
+       converter when PGCATALOG_TIKA_URL is unset. -->
+  <adapter
+      zcml:condition="installed plone.app.dexterity"
+      factory=".indexers.TikaAwareNamedfileFieldConverter"
+      />
+
 </configure>

--- a/tests/test_indexers.py
+++ b/tests/test_indexers.py
@@ -87,3 +87,98 @@ class TestSearchableTextFileOverride:
         ):
             result = SearchableText_file_override(obj)
         assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# #114: Tika-aware NamedfileFieldConverter — skips portal_transforms for
+# searchable NamedBlobFile fields when Tika is active (textindexer behavior).
+# ---------------------------------------------------------------------------
+
+
+class _FakeBlob:
+    def __init__(
+        self, filename="report.pdf", size=1234, content_type="application/pdf"
+    ):
+        self.filename = filename
+        self.contentType = content_type
+        self._size = size
+        self.data = b"%PDF-1.4 fake"
+
+    def getSize(self):
+        return self._size
+
+
+class _FakeField:
+    """Minimal stand-in for a zope schema field used by the converter."""
+
+    def __init__(self, value):
+        self._value = value
+
+    def interface(self, context):
+        return context  # storage == context for the test
+
+    def get(self, storage):
+        return self._value
+
+
+class TestTikaAwareNamedfileFieldConverter:
+    def _converter(self, value):
+        from plone.pgcatalog.indexers import TikaAwareNamedfileFieldConverter
+
+        return TikaAwareNamedfileFieldConverter(
+            mock.Mock(), _FakeField(value), mock.Mock()
+        )
+
+    def test_with_tika_returns_filename(self):
+        conv = self._converter(_FakeBlob(filename="quarterly.pdf"))
+        with mock.patch.dict(os.environ, {"PGCATALOG_TIKA_URL": "http://tika:9998"}):
+            result = conv.convert()
+        assert result == "quarterly.pdf"
+
+    def test_with_tika_does_not_call_transforms(self):
+        conv = self._converter(_FakeBlob())
+        with (
+            mock.patch.dict(os.environ, {"PGCATALOG_TIKA_URL": "http://tika:9998"}),
+            mock.patch(
+                "plone.app.dexterity.textindexer.converters.getToolByName"
+            ) as gtbn,
+        ):
+            conv.convert()
+        gtbn.assert_not_called()
+
+    def test_with_tika_empty_blob_returns_empty(self):
+        conv = self._converter(_FakeBlob(filename="x.pdf", size=0))
+        with mock.patch.dict(os.environ, {"PGCATALOG_TIKA_URL": "http://tika:9998"}):
+            assert conv.convert() == ""
+
+    def test_with_tika_missing_filename_returns_empty_string(self):
+        conv = self._converter(_FakeBlob(filename=None))
+        with mock.patch.dict(os.environ, {"PGCATALOG_TIKA_URL": "http://tika:9998"}):
+            assert conv.convert() == ""
+
+    def test_without_tika_delegates_to_parent(self):
+        conv = self._converter(_FakeBlob())
+        with (
+            mock.patch.dict(os.environ, {}, clear=False),
+            mock.patch(
+                "plone.app.dexterity.textindexer.converters."
+                "NamedfileFieldConverter.convert",
+                return_value="ORIGINAL",
+            ) as parent,
+        ):
+            os.environ.pop("PGCATALOG_TIKA_URL", None)
+            result = conv.convert()
+        parent.assert_called_once()
+        assert result == "ORIGINAL"
+
+    def test_empty_tika_url_delegates_to_parent(self):
+        conv = self._converter(_FakeBlob())
+        with (
+            mock.patch.dict(os.environ, {"PGCATALOG_TIKA_URL": "  "}),
+            mock.patch(
+                "plone.app.dexterity.textindexer.converters."
+                "NamedfileFieldConverter.convert",
+                return_value="ORIGINAL",
+            ),
+        ):
+            assert conv.convert() == "ORIGINAL"


### PR DESCRIPTION
Lands the **implementation** for #114. The design doc was merged via #185, but that PR accidentally contained only the design doc — the implementation commit was dropped (a pre-commit autofix aborted the commit unnoticed), so the fix never reached `main` and #114 was closed prematurely. This PR adds the actual code + tests.

## Fix

`TikaAwareNamedfileFieldConverter(NamedfileFieldConverter)` in `indexers.py`:
- `PGCATALOG_TIKA_URL` set → return `safe_text(data.filename)` (filename stays searchable; the async worker extracts the body), no `portal_transforms` call.
- unset → `super().convert()` (stock behavior).
- empty / zero-size / no filename → `""`.

Registered in `overrides.zcml`, gated on `installed plone.app.dexterity`; inherits the stock `@adapter(IDexterityContent, INamedFileField, IWidget)` registration. The converter is consumed in core only by the dynamic SearchableText indexer, so there are no other side effects.

Background, full diagnosis and scope (incl. the secondary-blob enqueue gap tracked in #184) are in the design doc already on main: `docs/plans/2026-06-29-tika-skip-namedfile-converter-114.md`.

## Tests

`tests/test_indexers.py` — `TestTikaAwareNamedfileFieldConverter` (6 tests). `tests/test_indexers.py`: 11 passed.

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)