### PR TITLE
fix(tika-worker): configurable HTTP timeout + correct OCR docs (#183)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,21 @@
   plans; it is populated by the deferred `ANALYZE` (whose version tracks the
   catalog DDL, so it re-runs on the next deploy). #133
 
+### Documentation
+
+- Correct the Tika OCR documentation: the minimal `apache/tika` image bundles
+  no OCR engine, so plain images and scanned (image-only) PDFs index as empty
+  text (the queue row still completes). OCR needs the `-full` image plus
+  server-side `tika-config.xml` (OCR strategy + languages). The how-to now pins
+  an explicit image version, adds an "OCR for images and scanned PDFs" section,
+  and the misleading "includes Tesseract OCR" claims are removed. #183
+
 ### Fixed
+
+- The Tika worker HTTP timeout is now configurable via
+  `TIKA_WORKER_HTTP_TIMEOUT` (default 120 s, was hard-coded). OCR of large
+  multi-page scanned PDFs can exceed 120 s; the request then timed out and the
+  queue row was marked `failed`. #183
 
 - Full-text search now picks up the current site/negotiated language when the
   query has no explicit `Language` parameter, instead of falling back to the

--- a/docs/plans/async-tika-extraction.md
+++ b/docs/plans/async-tika-extraction.md
@@ -8,7 +8,7 @@ using PostgreSQL as the job queue. Default behavior (portal_transforms) is uncha
 Apache Tika runs as a **separate Docker container** — a stateless HTTP service that accepts
 binary files and returns extracted text. It has no storage, no config, no state.
 
-**Official Docker image**: [`apache/tika`](https://hub.docker.com/r/apache/tika) (~400MB, includes Tesseract OCR)
+**Official Docker image**: [`apache/tika`](https://hub.docker.com/r/apache/tika). The minimal image has **no** OCR engine; OCR (Tesseract + ImageMagick) ships only in the `-full` variant. See the how-to for OCR setup.
 
 ```bash
 # Development
@@ -32,9 +32,10 @@ services:
 The Tika server exposes a single relevant endpoint:
 - `PUT /tika` — send binary data, get plain text back
 - Supports 1400+ formats: PDF, DOCX, PPTX, ODT, RTF, etc.
-- **Images**: Tika includes Tesseract OCR — extracts text from scanned documents,
-  photographs of text, and EXIF/IPTC metadata (captions, keywords, descriptions)
-  from any image format (JPEG, PNG, TIFF, WebP, etc.)
+- **Images**: with the `-full` image (Tesseract), Tika runs OCR — extracts text
+  from scanned documents and photographs of text. EXIF/IPTC metadata (captions,
+  keywords, descriptions) is read from any image format (JPEG, PNG, TIFF, WebP,
+  etc.) by the minimal image too; only OCR needs `-full`.
 - Content-Type header hints the format (optional, Tika auto-detects)
 
 **Deployment topology**: Tika only needs to be reachable by the **worker** (not by Plone/Zope).

--- a/docs/sources/how-to/enable-tika-extraction.md
+++ b/docs/sources/how-to/enable-tika-extraction.md
@@ -11,7 +11,10 @@ spreadsheets, images—is not searchable because Plone cannot extract text
 from them.
 
 Apache Tika is a stateless HTTP service that extracts text from over 1400
-file formats, including OCR for images via Tesseract.
+file formats.
+Optical character recognition (OCR) for images and scanned
+PDFs is available only with the `-full` Tika image and additional
+configuration—see [OCR for images and scanned PDFs](#ocr-for-images-and-scanned-pdfs).
 When enabled,
 plone.pgcatalog enqueues binary content for asynchronous extraction via a
 PostgreSQL job queue.
@@ -30,8 +33,15 @@ is unchanged.
 ```bash
 docker run -d --name tika \
   -p 9998:9998 \
-  apache/tika:latest
+  apache/tika:3.2.3.0
 ```
+
+Pin an explicit version rather than `:latest` so extraction behavior is
+reproducible across deploys.
+The minimal image above does **not** include
+an OCR engine; for OCR use the `-full` image (for example
+`apache/tika:3.2.3.0-full`)—see
+[OCR for images and scanned PDFs](#ocr-for-images-and-scanned-pdfs).
 
 Verify it is running:
 
@@ -58,8 +68,10 @@ A single Tika instance handles concurrent requests from
 multiple workers.
 
 Typical resource allocation: 512 MB–1 GB RAM.
-For OCR-heavy workloads
-(images, scanned PDFs), allocate more.
+OCR (the `-full` image) is
+CPU- and memory-heavy and much slower per document; size the Tika service
+accordingly and raise `TIKA_WORKER_HTTP_TIMEOUT` (see below) so large scanned
+PDFs do not time out.
 
 ## Step 2: configure environment variables
 
@@ -137,6 +149,8 @@ The standalone worker:
 - Connects directly to PostgreSQL (no Zope dependency)
 - Uses `LISTEN`/`NOTIFY` for instant wakeup on new jobs
 - Falls back to polling every `TIKA_WORKER_POLL_INTERVAL` seconds (default: 5)
+- Waits up to `TIKA_WORKER_HTTP_TIMEOUT` seconds for each Tika response
+  (default: 120; raise it for OCR of large scanned PDFs)
 - Uses `SELECT ... FOR UPDATE SKIP LOCKED` for safe concurrent dequeuing
 - Handles `SIGTERM`/`SIGINT` for graceful shutdown
 
@@ -157,6 +171,36 @@ standard `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` environment variables,
 
 See {doc}`../reference/configuration` for the full list of worker
 environment variables.
+
+## OCR for images and scanned PDFs
+
+OCR is **not** part of the default Tika image. The minimal `apache/tika`
+image bundles no OCR engine, so plain images, photos, and scanned
+(image-only) PDFs are extracted as **empty text**: the queue row still
+completes as `done`, but no body lexemes are merged into `searchable_text`.
+The full-text index then silently lacks their content.
+
+To enable OCR:
+
+1. **Use the `-full` image**, which ships Tesseract and ImageMagick:
+
+   ```bash
+   docker run -d --name tika -p 9998:9998 apache/tika:3.2.3.0-full
+   ```
+
+2. **Configure OCR server-side.** The worker sends a plain `PUT /tika` with
+   no OCR headers, so the OCR strategy and languages are set on the Tika
+   service via a mounted `tika-config.xml`—for example OCR language
+   `deu+eng`, and a PDF `ocrStrategy` of `auto` (or `ocr_and_text`) so
+   image-only PDFs are run through OCR. See the
+   [Apache Tika OCR documentation](https://cwiki.apache.org/confluence/display/TIKA/TikaOCR).
+
+3. **Budget for it.** OCR is CPU- and memory-heavy and much slower per
+   document. Raise `TIKA_WORKER_HTTP_TIMEOUT` (default 120 s) so large
+   multi-page scans do not time out and get marked `failed`.
+
+If you do not need OCR, the minimal image is the better choice: it is
+smaller, faster, and avoids the resource cost.
 
 ## Step 4: rebuild the catalog
 

--- a/docs/sources/reference/configuration.md
+++ b/docs/sources/reference/configuration.md
@@ -75,6 +75,7 @@ as a standalone process (outside Zope):
 | `TIKA_WORKER_DSN` | (required) | PostgreSQL connection string. |
 | `TIKA_WORKER_URL` | (required) | Tika server URL. |
 | `TIKA_WORKER_POLL_INTERVAL` | `5` | Seconds between polls when idle (LISTEN/NOTIFY provides instant wakeup). |
+| `TIKA_WORKER_HTTP_TIMEOUT` | `120` | Seconds to wait for a Tika HTTP response. Raise it for OCR of large scanned PDFs, which can exceed the default. |
 | `TIKA_WORKER_S3_BUCKET` | (none) | S3 bucket name for S3-tiered blobs. |
 | `TIKA_WORKER_S3_ENDPOINT_URL` | (none) | S3 endpoint URL (for MinIO or compatible). |
 | `TIKA_WORKER_S3_REGION` | (none) | S3 region name. |

--- a/src/plone/pgcatalog/tika_worker.py
+++ b/src/plone/pgcatalog/tika_worker.py
@@ -24,6 +24,9 @@ Environment variables:
                               default credential chain when unset)
     TIKA_WORKER_S3_SECRET_KEY S3 secret access key (optional; see above)
     TIKA_WORKER_POLL_INTERVAL Seconds between polls when idle (default: 5)
+    TIKA_WORKER_HTTP_TIMEOUT  Seconds to wait for a Tika HTTP response
+                              (default: 120; raise it for OCR of large scanned
+                              PDFs, which can exceed the default)
 """
 
 from psycopg.rows import dict_row
@@ -66,11 +69,14 @@ MISSING_EXTRA_HINT = (
 class TikaWorker:
     """PostgreSQL-backed text extraction worker using Apache Tika."""
 
-    def __init__(self, dsn, tika_url, s3_config=None, poll_interval=5):
+    def __init__(
+        self, dsn, tika_url, s3_config=None, poll_interval=5, http_timeout=120.0
+    ):
         self.dsn = dsn
         self.tika_url = tika_url.rstrip("/")
         self.s3_config = s3_config
         self.poll_interval = poll_interval
+        self.http_timeout = http_timeout
         self._shutdown = threading.Event()
         self._s3_client = None
 
@@ -191,7 +197,7 @@ class TikaWorker:
         headers = {"Accept": "text/plain"}
         if content_type:
             headers["Content-Type"] = content_type
-        with httpx.Client(timeout=120.0) as client:
+        with httpx.Client(timeout=self.http_timeout) as client:
             resp = client.put(
                 f"{self.tika_url}/tika",
                 content=blob_data,
@@ -296,12 +302,14 @@ def main():
         }
 
     poll_interval = int(os.environ.get("TIKA_WORKER_POLL_INTERVAL", "5"))
+    http_timeout = float(os.environ.get("TIKA_WORKER_HTTP_TIMEOUT", "120"))
 
     worker = TikaWorker(
         dsn=dsn,
         tika_url=tika_url,
         s3_config=s3_config,
         poll_interval=poll_interval,
+        http_timeout=http_timeout,
     )
 
     def handle_signal(_sig, _frame):

--- a/tests/test_tika_worker_extras.py
+++ b/tests/test_tika_worker_extras.py
@@ -149,3 +149,73 @@ def test_main_reads_s3_credentials_from_env(monkeypatch):
     assert s3["access_key"] == "AKIA"
     assert s3["secret_key"] == "SECRET"
     assert s3["bucket_name"] == "bucket"
+
+
+# ---------------------------------------------------------------------------
+# #183 (B): worker Tika HTTP timeout must be configurable (OCR can exceed 120s).
+# ---------------------------------------------------------------------------
+
+
+def test_extract_uses_configured_http_timeout(monkeypatch):
+    """_extract passes self.http_timeout to the httpx client."""
+    from plone.pgcatalog import tika_worker
+
+    import types
+
+    captured = {}
+
+    class _Resp:
+        text = "extracted text"
+
+        def raise_for_status(self):
+            pass
+
+    class _Client:
+        def __init__(self, *a, **k):
+            captured.update(k)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def put(self, *a, **k):
+            return _Resp()
+
+    monkeypatch.setattr(tika_worker, "httpx", types.SimpleNamespace(Client=_Client))
+    worker = tika_worker.TikaWorker(dsn="x", tika_url="http://t", http_timeout=7.5)
+    monkeypatch.setattr(worker, "_fetch_blob", lambda *a, **k: b"blob")
+    out = worker._extract(conn=None, zoid=1, tid=1, content_type="application/pdf")
+    assert out == "extracted text"
+    assert captured["timeout"] == 7.5
+
+
+def test_http_timeout_defaults_to_120(monkeypatch):
+    from plone.pgcatalog import tika_worker
+
+    worker = tika_worker.TikaWorker(dsn="x", tika_url="http://t")
+    assert worker.http_timeout == 120.0
+
+
+def test_main_reads_http_timeout_from_env(monkeypatch):
+    from plone.pgcatalog import tika_worker
+
+    monkeypatch.setenv("TIKA_WORKER_DSN", "dsn")
+    monkeypatch.setenv("TIKA_WORKER_URL", "http://tika")
+    monkeypatch.setenv("TIKA_WORKER_HTTP_TIMEOUT", "300")
+
+    captured = {}
+
+    class _FakeWorker:
+        def __init__(self, **kw):
+            captured.update(kw)
+
+        def run(self):
+            pass
+
+    monkeypatch.setattr(tika_worker, "TikaWorker", _FakeWorker)
+    monkeypatch.setattr(tika_worker, "httpx", object())
+    tika_worker.main()
+
+    assert captured["http_timeout"] == 300.0


### PR DESCRIPTION
Two related fixes found while enabling Tika OCR on a production deployment.

## A) Docs: OCR needs the `-full` image, not the minimal one

The docs claimed OCR works out of the box (`"including OCR for images via Tesseract"`, `apache/tika:latest`). The minimal `apache/tika` image bundles **no** OCR engine, so plain images and scanned (image-only) PDFs index as **empty text** — the queue row still completes as `done`, so it's silent.

Changes to `docs/sources/how-to/enable-tika-extraction.md` (+ the plan doc):
- Remove the misleading "includes Tesseract OCR" claims.
- Pin an explicit image version instead of `:latest`.
- New **"OCR for images and scanned PDFs"** section: use the `apache/tika:<ver>-full` image, configure OCR server-side via a mounted `tika-config.xml` (strategy + languages), budget for the CPU/RAM/latency cost, and note the empty-text-when-OCR-off behavior.

## B) Configurable worker HTTP timeout

`TikaWorker._extract()` hard-coded `httpx.Client(timeout=120.0)`. OCR of large multi-page scans can exceed 120 s, timing out and marking the row `failed`. Now configurable via **`TIKA_WORKER_HTTP_TIMEOUT`** (default 120), read in `main()` and documented in the configuration reference.

OCR strategy/language stays server-side (`tika-config.xml`, documented in A) rather than per-request headers — cleaner separation.

## Tests

`tests/test_tika_worker_extras.py` — 3 new: `_extract` uses the configured timeout, default is 120, `main()` reads `TIKA_WORKER_HTTP_TIMEOUT`. 8 passed.

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)