### PR TITLE
fix(zmi): POST for Advanced-tab Update/Rebuild forms (#188)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.0.0b68 (unreleased)
+
+### Fixed
+
+- The Advanced-tab *Update Catalog* and *Clear and Rebuild* buttons now submit
+  via `POST` instead of `GET`. The forms in `catalogAdvanced.dtml` had no
+  `method`, so the (destructive) action stayed in the URL bar and a reload /
+  Back / prefetch silently re-ran it — observed on production as a second full
+  clear+rebuild kicked off by a browser reload. The handlers already redirect,
+  so this yields a clean Post/Redirect/Get flow. #188
+
 ## 1.0.0b67 (2026-06-29)
 
 ### Changed

--- a/src/plone/pgcatalog/www/catalogAdvanced.dtml
+++ b/src/plone/pgcatalog/www/catalogAdvanced.dtml
@@ -15,7 +15,7 @@
           Re-catalog all currently indexed objects in PostgreSQL.
         </p>
       </div>
-      <form action="&dtml-URL1;" class="ml-3">
+      <form method="post" action="&dtml-URL1;" class="ml-3">
         <button class="btn btn-sm btn-primary" type="submit"
                 name="manage_catalogReindex:method" value="Update"
                 onclick="return confirm('Re-index all currently cataloged objects?\n\nThis may take a while on large sites.')">
@@ -33,7 +33,7 @@
           data corruption.
         </p>
       </div>
-      <form action="&dtml-URL1;" class="ml-3">
+      <form method="post" action="&dtml-URL1;" class="ml-3">
         <button class="btn btn-sm btn-warning" type="submit"
                 name="manage_catalogRebuild:method" value="Rebuild"
                 onclick="return confirm('This will DELETE all catalog data and rebuild from scratch.\n\nSearch will not work until the rebuild completes.\nOn large sites this can take hours.\n\nContinue?')">

--- a/tests/test_advanced_tab_forms.py
+++ b/tests/test_advanced_tab_forms.py
@@ -1,0 +1,48 @@
+"""#188: state-changing Advanced-tab forms must POST, not GET.
+
+The `Update Catalog` and `Clear and Rebuild` buttons mutate the catalog
+(Clear and Rebuild is destructive). A GET form leaves the action in the
+URL bar, so a reload / Back / prefetch silently re-runs it. They must use
+`method="post"` for a clean Post/Redirect/Get flow.
+"""
+
+import pathlib
+import re
+
+
+_DTML = (
+    pathlib.Path(__file__).parent.parent
+    / "src"
+    / "plone"
+    / "pgcatalog"
+    / "www"
+    / "catalogAdvanced.dtml"
+)
+
+
+def _form_block_for(action_name):
+    """Return the `<form ...>` tag that wraps the button for *action_name*."""
+    text = _DTML.read_text()
+    forms = re.findall(r"<form\b[^>]*>.*?</form>", text, re.DOTALL)
+    for form in forms:
+        if action_name in form:
+            # The opening <form ...> tag only.
+            return re.match(r"<form\b[^>]*>", form, re.DOTALL).group(0)
+    raise AssertionError(f"no <form> wrapping {action_name!r} found")
+
+
+def test_update_catalog_form_uses_post():
+    tag = _form_block_for("manage_catalogReindex:method")
+    assert re.search(r'method\s*=\s*["\']post["\']', tag, re.IGNORECASE), tag
+
+
+def test_clear_and_rebuild_form_uses_post():
+    tag = _form_block_for("manage_catalogRebuild:method")
+    assert re.search(r'method\s*=\s*["\']post["\']', tag, re.IGNORECASE), tag
+
+
+def test_no_advanced_form_defaults_to_get():
+    """No form in the template may omit an explicit method (GET default)."""
+    text = _DTML.read_text()
+    for tag in re.findall(r"<form\b[^>]*>", text):
+        assert re.search(r'method\s*=\s*["\']post["\']', tag, re.IGNORECASE), tag


### PR DESCRIPTION
## Problem

The **Update Catalog** and **Clear and Rebuild** buttons on the PG Catalog Tool's Advanced ZMI tab submit via **GET** — the forms in `catalogAdvanced.dtml` have no `method` (HTML defaults to GET). With Zope's `:method` publishing, the action runs as a GET whose URL stays in the address bar, so a **reload / Back / Forward / prefetch / link-scanner silently re-triggers it**.

For *Clear and Rebuild* that is destructive. Observed on a ~20k-object production site: a browser reload while the long rebuild was in flight kicked off a **second** full clear+rebuild (catalog count dropped back toward zero and started climbing again). The `onclick confirm()` is a UX guard only — it does not run on reload.

## Fix

Add `method="post"` to both forms. The handlers (`manage_catalogReindex` / `manage_catalogRebuild`) already `RESPONSE.redirect(...)` back to `manage_catalogAdvanced`, so this is a clean Post/Redirect/Get flow. This also makes the Advanced tab consistent with `catalogSlowQueries.dtml`, which already POSTs.

## Tests

`tests/test_advanced_tab_forms.py` (3): both state-changing forms use `method="post"`, and no form in the template defaults to GET.

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)