### PR TITLE
fix(query): make three silent sort gaps explicit (#157)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,15 @@
 
 ### Fixed
 
+- Sort handling no longer silently drops or no-ops three sort keys (#157):
+  `sort_on=effectiveRange` now sorts by the `effective` date (the range start)
+  instead of being ignored; `sort_on=SearchableText` sorts by full-text
+  relevance when a SearchableText term is queried (and logs a warning, rather
+  than dropping silently, when there is no term); and sorting on a dedicated
+  `TEXT[]` column (`allowedRolesAndUsers`, `object_provides`) — whose value
+  lives in a column, not `idx` JSONB — is now ignored with a warning instead of
+  emitting a NULL `ORDER BY`.
+
 - The Advanced-tab *Update Catalog* and *Clear and Rebuild* buttons now submit
   via `POST` instead of `GET`. The forms in `catalogAdvanced.dtml` had no
   `method`, so the (destructive) action stayed in the URL bar and a reload /

--- a/src/plone/pgcatalog/query.py
+++ b/src/plone/pgcatalog/query.py
@@ -122,6 +122,19 @@ def _builtin_index_type(name):
     return None
 
 
+def _is_dedicated_text_array_column(idx_key):
+    """True if *idx_key* is a ``TEXT[]`` ExtraIdxColumn (e.g.
+    allowedRolesAndUsers, object_provides).  Such values are popped out of
+    ``idx`` JSONB into a dedicated column, so ``idx->'key'`` is always NULL —
+    they cannot be used for ordering (#157)."""
+    from plone.pgcatalog.columns import get_extra_idx_columns
+
+    return any(
+        col.column_type == "TEXT[]" and col.idx_key == idx_key
+        for col in get_extra_idx_columns()
+    )
+
+
 def _is_numeric_range(values):
     """Return True iff every value is numeric (``int`` or ``float``).
 
@@ -813,7 +826,31 @@ class _QueryBuilder:
             if idx_key is None:
                 if idx_type == IndexType.PATH:
                     idx_key = sort_on
+                elif sort_on == "effectiveRange":
+                    # DateRangeIndex has no single column; sort by the
+                    # effective date (the range's start), which is what
+                    # callers passing effectiveRange as a default sort
+                    # expect — instead of silently dropping it (#157).
+                    parts.append(
+                        f"pgcatalog_to_timestamptz(idx->>'effective') {direction}"
+                    )
+                    continue
+                elif sort_on == "SearchableText":
+                    # Sort by full-text relevance, reusing the rank the
+                    # auto-relevance path computes — but only when a
+                    # SearchableText term was actually queried (#157).
+                    rank_expr = getattr(self, "_text_rank_expr", None)
+                    if rank_expr is not None:
+                        parts.append(f"{rank_expr} {direction}")
+                    else:
+                        log.warning(
+                            "sort_on='SearchableText' without a SearchableText "
+                            "query term has no relevance rank to sort by — "
+                            "ignoring",
+                        )
+                    continue
                 else:
+                    log.warning("sort_on=%r is not sortable — ignoring", sort_on)
                     continue
 
             if idx_type == IndexType.DATE:
@@ -822,6 +859,15 @@ class _QueryBuilder:
                 expr = f"(idx->>'{idx_key}')::integer"
             elif idx_type == IndexType.BOOLEAN:
                 expr = f"(idx->>'{idx_key}')::boolean"
+            elif _is_dedicated_text_array_column(idx_key):
+                # Value lives in a dedicated TEXT[] column, not idx JSONB, so
+                # idx->'key' would be a NULL no-op ordering (#157).
+                log.warning(
+                    "sort_on=%r maps to a dedicated TEXT[] column and cannot "
+                    "be used for ordering — ignoring",
+                    sort_on,
+                )
+                continue
             else:
                 # jsonb operator `->` instead of text `->>` so PG uses type-aware
                 # comparison: numbers sort numerically, strings lexicographically

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -666,15 +666,41 @@ class TestSortEdgeCases:
         )
         assert "::boolean" in qr["order_by"]
 
-    def test_sort_composite_index_ignored(self):
-        """effectiveRange has idx_key=None — can't sort on it."""
+    def test_sort_effective_range_aliases_to_effective(self):
+        """#157: sort_on=effectiveRange sorts by the effective date (range
+        start) instead of being silently dropped."""
         qr = build_query(
             {
                 "portal_type": "Document",
                 "sort_on": "effectiveRange",
             }
         )
+        assert qr["order_by"] == "pgcatalog_to_timestamptz(idx->>'effective') ASC"
+
+    def test_sort_effective_range_honours_direction(self):
+        qr = build_query({"sort_on": "effectiveRange", "sort_order": "descending"})
+        assert qr["order_by"] == "pgcatalog_to_timestamptz(idx->>'effective') DESC"
+
+    def test_sort_searchable_text_uses_rank_when_queried(self):
+        """#157: sort_on=SearchableText sorts by relevance when a SearchableText
+        term is present (reuses the auto-relevance rank)."""
+        qr = build_query({"SearchableText": "hello", "sort_on": "SearchableText"})
+        assert qr["order_by"] is not None
+        assert "ts_rank_cd" in qr["order_by"]
+
+    def test_sort_searchable_text_without_query_is_ignored(self):
+        """No SearchableText term → no rank to sort by → ignored (a warning is
+        logged instead of a silent drop)."""
+        qr = build_query({"portal_type": "Document", "sort_on": "SearchableText"})
         assert qr["order_by"] is None
+
+    def test_sort_dedicated_text_array_column_ignored(self):
+        """#157: sorting on a dedicated TEXT[] column (allowedRolesAndUsers,
+        object_provides) is a no-op (value not in idx JSONB) and is ignored
+        rather than emitting a NULL ORDER BY."""
+        for field in ("allowedRolesAndUsers", "object_provides"):
+            qr = build_query({"portal_type": "Document", "sort_on": field})
+            assert qr["order_by"] is None, field
 
 
 class TestDateCoercion:


### PR DESCRIPTION
Resolves the sort-audit gaps collected in #157. Each was a *silent* drop or no-op; now they either do something sensible or warn.

## Changes in `_process_sort`

1. **`sort_on=effectiveRange`** (DateRangeIndex, `idx_key=None`) was silently dropped → now sorts by `pgcatalog_to_timestamptz(idx->>'effective')` (the range's start date), honoring the requested direction. This is what Plone code passing `effectiveRange` as a default sort expects.

2. **`sort_on=SearchableText`** was silently dropped → now sorts by full-text **relevance**, reusing the `ts_rank_cd` expression the auto-relevance path already computes, **when a SearchableText term is queried**. Without a term there is nothing to rank, so it logs a warning and skips instead of dropping silently.

3. **Dedicated `TEXT[]` columns** (`allowedRolesAndUsers`, `object_provides`) produced `ORDER BY idx->'key'`, which is `NULL` for every row because the value is popped out of `idx` JSONB into a dedicated column. Now detected (`_is_dedicated_text_array_column`) and ignored with a warning instead of emitting a no-op ordering.

## Tests

`tests/test_query.py` (`TestSort`): `effectiveRange` → effective expr (+ direction); `SearchableText` → rank when queried, ignored (None) without a term; dedicated `TEXT[]` columns → ignored. The old `test_sort_composite_index_ignored` (which codified the silent `effectiveRange` drop) is replaced. Full suite: **1541 passed, 40 skipped**.

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)