### PR TITLE
chore(deps): require zodb-pgjsonb>=1.14.0 for the startup-DDL gate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@
 
 ### Changed
 
+- Require `zodb-pgjsonb>=1.14.0`, the release that ships the startup-DDL
+  schema-version gate the deferred index/ANALYZE actions are tagged for
+  (bluedynamics/zodb-pgjsonb#78). The runtime still feature-detects the
+  `version=` argument, so this only raises the floor for new installs.
+
 - `TestEnqueueUnit` (Tika enqueue unit tests) now runs against a real
   `dict_row` cursor and the actual PG schema instead of a `MagicMock` cursor
   with hand-stubbed `fetchall()` rows. The mocked row shapes were the contract

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "psycopg[binary,pool]>=3.1",
     "orjson>=3.9",
     "Products.CMFPlone",
-    "zodb-pgjsonb>=1.13.0",
+    "zodb-pgjsonb>=1.14.0",
 ]
 
 [project.entry-points."z3c.autoinclude.plugin"]


### PR DESCRIPTION
Follow-up to #181. Now that zodb-pgjsonb **1.14.0** is released (it ships the double-checked startup-DDL schema-version gate, bluedynamics/zodb-pgjsonb#78 / #79), raise the dependency floor from `>=1.13.0` to `>=1.14.0`.

This guarantees new installs get the `defer_startup_action(version=)` support the deferred index/ANALYZE actions are tagged for. The runtime still feature-detects the `version=` argument (via `inspect.signature`), so behavior is unchanged on environments that already have an older zodb-pgjsonb pinned — this only moves the floor.

Metadata-only change (`pyproject.toml` + `CHANGES.md`); CI validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)