### PR TITLE
chore(schema): drop project-specific idx_os_cat_events_upcoming (#131)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,16 @@
 
 ## 1.0.0b68 (unreleased)
 
+### Removed
+
+- Drop the project-specific `idx_os_cat_events_upcoming` partial index. Its
+  `WHERE` referenced `show_in_sidecalendar` (an AAF project field, not generic
+  Plone) and it was never used by the planner. The sidecalendar slowness it
+  targeted (#131) was resolved generically once `path` became a typed column
+  (#132, accurate stats for the selective path predicate) and boolean queries
+  were normalised. Existing installs self-heal via `DROP INDEX IF EXISTS` on the
+  next deploy. #131
+
 ### Changed
 
 - `TestEnqueueUnit` (Tika enqueue unit tests) now runs against a real

--- a/docs/sources/reference/schema.md
+++ b/docs/sources/reference/schema.md
@@ -97,7 +97,6 @@ VectorChord-BM25 extensions are detected at startup.
 | Index Name | Type | Expression | Purpose |
 |---|---|---|---|
 | `idx_os_cat_nav_visible` | B-tree (partial) | Navigation fields where `exclude_from_nav=false` | Navigation listings (only ~1.6% of rows) |
-| `idx_os_cat_events_upcoming` | B-tree (partial) | Event fields where `portal_type=Event` | Calendar/event queries |
 
 ### Text expression indexes
 

--- a/src/plone/pgcatalog/schema.py
+++ b/src/plone/pgcatalog/schema.py
@@ -176,13 +176,15 @@ CREATE INDEX IF NOT EXISTS idx_os_cat_nav_visible
     ON object_state (path text_pattern_ops, (idx->>'portal_type'))
     WHERE path IS NOT NULL AND (idx->>'exclude_from_nav')::boolean = false;
 
--- Partial index for upcoming events (portal_type = Event + sidecalendar).
--- Allows direct index scan on end date for calendar widgets.
-CREATE INDEX IF NOT EXISTS idx_os_cat_events_upcoming
-    ON object_state (pgcatalog_to_timestamptz(idx->>'end') DESC)
-    WHERE idx IS NOT NULL
-      AND (idx->>'portal_type') = 'Event'
-      AND (idx->>'show_in_sidecalendar')::boolean = true;
+-- Removed: idx_os_cat_events_upcoming was a project-specific partial index
+-- (its WHERE referenced `show_in_sidecalendar`, an AAF field, not a generic
+-- Plone one) and was never used by the planner (0 scans on the very
+-- deployment it was built for — superseded there by a project-applied index).
+-- The original sidecalendar slowness (#131) was resolved generically once
+-- `path` became a typed column (#132, accurate stats for the selective path
+-- predicate) and boolean queries were normalised.  DROP it so existing
+-- installs self-heal on the next deploy.
+DROP INDEX IF EXISTS idx_os_cat_events_upcoming;
 
 -- Partial index for the navigation-tree / navigation-portlet listing pattern
 -- (#130).  Plone navigation queries combine
@@ -363,7 +365,6 @@ EXPECTED_INDEXES = [
     "idx_os_cat_review_state",
     "idx_os_cat_uid",
     "idx_os_cat_nav_visible",
-    "idx_os_cat_events_upcoming",
     "idx_os_navtree",
     "idx_os_searchable_text",
     "idx_os_cat_title_tsv",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -89,6 +89,33 @@ class TestSchemaInstallation:
         assert row is not None
         assert row["attstattarget"] == 2000
 
+    def test_legacy_events_upcoming_index_self_heals(self, pg_conn_with_catalog):
+        """#131: the project-specific idx_os_cat_events_upcoming is removed
+        and self-heals (DROP) on existing installs that still have it."""
+        conn = pg_conn_with_catalog
+        # Simulate a legacy install that still carries the old index.
+        with conn.cursor() as cur:
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS idx_os_cat_events_upcoming "
+                "ON object_state (pgcatalog_to_timestamptz(idx->>'end') DESC) "
+                "WHERE idx IS NOT NULL "
+                "  AND (idx->>'portal_type') = 'Event' "
+                "  AND (idx->>'show_in_sidecalendar')::boolean = true"
+            )
+        conn.commit()
+
+        # Re-running the schema must drop it.
+        install_catalog_schema(conn)
+        conn.commit()
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM pg_indexes "
+                "WHERE indexname = 'idx_os_cat_events_upcoming'"
+            )
+            assert cur.fetchone() is None
+        assert "idx_os_cat_events_upcoming" not in EXPECTED_INDEXES
+
     def test_idempotent(self, pg_conn_with_catalog):
         """Running install_catalog_schema twice does not error."""
         # Already installed by the fixture — run again


### PR DESCRIPTION
Final generic cleanup for #131. The sidecalendar planner problem is resolved generically; what remained was a project-specific, unused index in the generic schema.

## Why

`idx_os_cat_events_upcoming` referenced `show_in_sidecalendar` — an **AAF project** field, not generic Plone — and was the only such reference in the whole package. On aaf-prod (the deployment it was built for) it had **0 scans**: the project applies its own `idx_os_cat_show_in_sidecalendar` (30 scans) instead.

The original #131 slowness was resolved **generically** by changes that landed since the April diagnosis:
- `path` became a **typed column** (#132) → the selective path predicate now has real PG statistics, so the planner is no longer JSONB-blind (this was #131's recommended direction (b)).
- boolean queries normalised to `(idx->>'…')::boolean` → the text-vs-boolean inconsistency is gone.

Empirically on aaf-prod, the sidecalendar slow-query shape dropped from **924 calls / avg 514 ms / max 1.8 s** (April) to **4 calls / avg 72 ms / max 91 ms** (last 7 days).

## Change

- Remove the `CREATE` from `schema.py`, the `EXPECTED_INDEXES` entry, and the schema-reference doc row.
- Add `DROP INDEX IF EXISTS idx_os_cat_events_upcoming;` so existing installs self-heal on the next deploy (its DDL hash change re-triggers via the schema-version gate).

## Tests

`tests/test_schema.py`: new `test_legacy_events_upcoming_index_self_heals` creates the legacy index, re-runs the schema, and asserts it's dropped. 9 passed.

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)