### PR TITLE
fix(zmi): show configured slow-query threshold in empty state

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.0b69 (unreleased)
+
+### Fixed
+
+- The Slow Queries tab's empty-state message now shows the actually-configured
+  threshold (via `manage_get_slow_query_threshold()`) instead of hard-coding the
+  `PGCATALOG_SLOW_QUERY_MS` default of 10 ms.
+
 ## 1.0.0b68 (2026-06-30)
 
 ### Removed

--- a/src/plone/pgcatalog/www/catalogSlowQueries.dtml
+++ b/src/plone/pgcatalog/www/catalogSlowQueries.dtml
@@ -84,8 +84,9 @@
     <dtml-else>
     <p class="text-muted p-3 mb-0">
       No slow queries recorded yet.
-      Queries exceeding the threshold (<code>PGCATALOG_SLOW_QUERY_MS</code>,
-      default 10ms) are logged here automatically.
+      Queries exceeding the configured threshold
+      (<code><dtml-var "manage_get_slow_query_threshold()">ms</code>, set via
+      <code>PGCATALOG_SLOW_QUERY_MS</code>) are logged here automatically.
     </p>
     </dtml-if>
   </div>

--- a/tests/test_slow_queries_view.py
+++ b/tests/test_slow_queries_view.py
@@ -1,0 +1,27 @@
+"""The Slow Queries empty-state shows the configured threshold, not the default.
+
+The "no slow queries yet" message used to hard-code the env var name and its
+`default 10ms`; it now surfaces the actually-configured threshold via
+`manage_get_slow_query_threshold()`.
+"""
+
+import pathlib
+
+
+_DTML = (
+    pathlib.Path(__file__).parent.parent
+    / "src"
+    / "plone"
+    / "pgcatalog"
+    / "www"
+    / "catalogSlowQueries.dtml"
+)
+
+
+def test_empty_state_uses_configured_threshold():
+    text = _DTML.read_text()
+    empty_state = text.split("No slow queries recorded yet.", 1)[1]
+    # Shows the actual value via the view method ...
+    assert "manage_get_slow_query_threshold()" in empty_state
+    # ... and no longer hard-codes the default.
+    assert "default 10ms" not in empty_state


### PR DESCRIPTION
The Slow Queries tab's empty-state message hard-coded the env var name and its default:

> Queries exceeding the threshold (`PGCATALOG_SLOW_QUERY_MS`, default 10ms) are logged here automatically.

The **actually-configured** threshold is more useful than the default. `manage_get_slow_query_threshold()` (already used for the tab header) returns it, so the message now reads e.g. *"Queries exceeding the configured threshold (25ms, set via `PGCATALOG_SLOW_QUERY_MS`) …"*.

`tests/test_slow_queries_view.py`: asserts the empty state uses the dynamic threshold and no longer hard-codes `default 10ms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)