### PR TITLE
feat(query): built-in zoid/oid query operator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,21 @@
 
 ## 1.0.0b69 (unreleased)
 
+### Added
+
+- Built-in `zoid` (and `oid`) query operator: `catalog(zoid=[...])` /
+  `catalog(oid=[...])` filters the `object_state` BIGINT primary key directly
+  (the catalog rid *is* the zoid). It lets callers resolve a set of ZODB object
+  ids to their security-filtered brains **without waking the objects** — e.g.
+  `zc.relation`/`intids`: `intid -> KeyReference.oid -> int.from_bytes(...) ->
+  zoid`, replacing an object-load N+1 in relation/back-reference resolution.
+  `oid` accepts raw 8-byte ZODB oids (converted via `int.from_bytes`, matching
+  `extraction.obj_to_zoid`); `zoid` accepts ints or digit strings; both take a
+  scalar or a list. Filters the real primary-key column, so it is index-backed
+  with **no extra storage and no reindex**, and composes with the normal query
+  and the `allowedRolesAndUsers` security filter (`searchResults`). An empty set
+  matches nothing (never the whole table). #197
+
 ### Fixed
 
 - The Slow Queries tab's empty-state message now shows the actually-configured

--- a/docs/.vale/styles/config/vocabularies/Project/accept.txt
+++ b/docs/.vale/styles/config/vocabularies/Project/accept.txt
@@ -250,3 +250,10 @@ roundtrips
 [Uu]npickl(e|ed|es|ing)
 truthy
 unsortable
+[Zz]oid[s]?
+[Oo]id[s]?
+[Ii]ntid[s]?
+IOBTree
+KeyReferenceToPersistent
+RelationList
+findRelations

--- a/docs/sources/how-to/index.md
+++ b/docs/sources/how-to/index.md
@@ -38,5 +38,6 @@ titlesonly: true
 ---
 write-custom-translator
 query-raw-sql
+resolve-relations-by-zoid
 use-with-distribution
 ```

--- a/docs/sources/how-to/resolve-relations-by-zoid.md
+++ b/docs/sources/how-to/resolve-relations-by-zoid.md
@@ -1,0 +1,116 @@
+<!-- diataxis: how-to -->
+
+# Resolve relations to brains without waking objects
+
+## Problem
+
+You hold a set of ZODB object ids — typically from `zc.relation` /
+`zope.intid` (a `RelationList` field, or back-references from
+`catalog.findRelations(...)`) — and you want the catalog **brains** for
+those objects: their metadata, filtered by the current user's `View`
+permission.
+
+The naive approach wakes every object:
+
+```python
+from zope.component import getUtility
+from zope.intid.interfaces import IIntIds
+
+intids = getUtility(IIntIds)
+objs = [intids.queryObject(intid) for intid in relation_intids]  # loads each!
+```
+
+On a listing/aside tile this is an object-load N+1: each `queryObject`
+loads the object (and, for an anonymous request, walks the acquisition
+chain to check `View`). A page with a few dozen related items can cost
+hundreds of ZODB loads.
+
+## Solution
+
+pgcatalog stores every record in `object_state` keyed by its `zoid` (the
+BIGINT primary key — the catalog `rid` *is* the zoid). The built-in
+`zoid` / `oid` query operator lets you fetch the security-filtered brains
+for a set of object ids directly, **without waking the objects**:
+
+```python
+brains = catalog(zoid=[123, 456, 789])
+```
+
+Getting the zoids from relations is wake-free — the intid utility's
+`KeyReferenceToPersistent` already stores the object's oid, and
+`oid → zoid` is just `int.from_bytes(...)`:
+
+```python
+from zope.component import getUtility
+from zope.intid.interfaces import IIntIds
+
+intids = getUtility(IIntIds)
+refs = intids.refs  # IOBTree: intid -> KeyReferenceToPersistent
+
+zoids = []
+for intid in relation_intids:
+    kr = refs.get(intid)
+    if kr is not None:
+        zoids.append(int.from_bytes(kr.oid, "big"))  # no getObject()
+
+brains = catalog(zoid=zoids)  # security-filtered, no wakes
+```
+
+If you happen to hold raw 8-byte ZODB oids instead of ints, pass them to
+`oid=` and pgcatalog converts them for you:
+
+```python
+brains = catalog(oid=[obj._p_oid for obj in ...])
+```
+
+## Full example: related-items resolution
+
+```python
+from Acquisition import aq_inner
+from zc.relation.interfaces import ICatalog
+from zope.component import getUtility
+from zope.intid.interfaces import IIntIds
+
+def related_brains(context, catalog):
+    intids = getUtility(IIntIds)
+    relcat = getUtility(ICatalog)
+    refs = intids.refs
+
+    # direct references (a RelationList field) + back-references
+    tids = [rv.to_id for rv in getattr(context, "related_items", []) or []]
+    tids += [
+        rel.from_id
+        for rel in relcat.findRelations(
+            {"to_id": intids.getId(aq_inner(context)),
+             "from_attribute": "related_items"}
+        )
+    ]
+
+    zoids = []
+    for tid in dict.fromkeys(tids):          # de-dup, keep order
+        kr = refs.get(tid)
+        if kr is not None:
+            zoids.append(int.from_bytes(kr.oid, "big"))
+
+    return catalog(zoid=zoids)               # brains, view-filtered, no wakes
+```
+
+To preserve the relation order, build a `{brain zoid: brain}` map and
+iterate your `zoids` list — a plain SQL `IN`/`ANY` does not guarantee
+row order.
+
+## Notes
+
+- **Security.** `zoid` / `oid` compose with the normal query and with the
+  `allowedRolesAndUsers` filter that `searchResults` injects, so
+  `catalog(zoid=...)` returns only brains the current user may view.
+  Use `unrestrictedSearchResults(zoid=...)` to bypass the filter.
+- **No storage, no reindex.** The operator filters the existing primary-key
+  column; there is nothing to index and no migration for existing sites.
+- **Empty set matches nothing.** `catalog(zoid=[])` returns no rows (it
+  never degrades to "match the whole table").
+- **Accepted values.** `zoid` takes ints or digit strings; `oid` takes raw
+  8-byte oids; both accept a scalar or a list. Non-coercible values are
+  dropped (ZCatalog-lenient).
+- **Composes.** `catalog(zoid=[...], portal_type="Document")` ANDs the two
+  filters like any other query.

--- a/src/plone/pgcatalog/columns.py
+++ b/src/plone/pgcatalog/columns.py
@@ -68,6 +68,10 @@ class IndexType(Enum):
     TEXT = "ZCTextIndex"
     PATH = "ExtendedPathIndex"
     GOPIP = "GopipIndex"
+    # Pseudo-index: not a ZCatalog meta-type, so it is never auto-registered as
+    # a real index. Filters on the object_state `zoid` BIGINT primary key, wired
+    # via `_SPECIAL_BUILTIN_INDEX_TYPES` in query.py (`zoid`/`oid` query keys).
+    ZOID = "ZOID"
 
 
 # --------------------------------------------------------------------------
@@ -87,6 +91,12 @@ META_TYPE_MAP = {
     "PathIndex": IndexType.PATH,
     "GopipIndex": IndexType.GOPIP,
 }
+
+# IndexTypes that are pgcatalog pseudo-indexes, NOT backed by a ZCatalog
+# meta_type: they filter a real object_state column via a hardcoded query key
+# (see `_SPECIAL_BUILTIN_INDEX_TYPES` in query.py) rather than a registered
+# index, so they deliberately have no `META_TYPE_MAP` entry.
+PSEUDO_INDEX_TYPES = frozenset({IndexType.ZOID})
 
 # Indexes with special PG handling (idx_key=None): dedicated columns or
 # composite logic that can't be expressed as a simple JSONB key.

--- a/src/plone/pgcatalog/query.py
+++ b/src/plone/pgcatalog/query.py
@@ -49,6 +49,11 @@ _MAX_OFFSET = 1000000
 # Maximum search text length (characters) to prevent resource exhaustion.
 _MAX_SEARCH_LENGTH = 1000
 
+# Maximum number of zoids/oids in a single zoid query (DoS prevention). Generous
+# because a popular object can carry hundreds of back-references; well above any
+# real relation set, but bounds a hostile `zoid=[...]` from @search.
+_MAX_ZOIDS = 10000
+
 
 def _lookup_translator(name):
     """Look up an IPGIndexTranslator utility for a given index name.
@@ -88,6 +93,13 @@ _SPECIAL_BUILTIN_INDEX_TYPES: dict[str, tuple[IndexType, str | None]] = {
     "path": (IndexType.PATH, None),
     "effectiveRange": (IndexType.DATE_RANGE, None),
     "SearchableText": (IndexType.TEXT, None),
+    # Filter by the object_state `zoid` BIGINT primary key (the row's own id;
+    # the catalog rid IS the zoid). `oid` is the same filter, accepting raw
+    # 8-byte ZODB oids (converted via int.from_bytes). Lets callers resolve a
+    # set of ZODB object ids to their security-filtered brains without waking
+    # the objects — e.g. zc.relation/intids: intid -> KeyReference.oid -> zoid.
+    "zoid": (IndexType.ZOID, None),
+    "oid": (IndexType.ZOID, None),
 }
 
 
@@ -357,6 +369,7 @@ class _QueryBuilder:
         IndexType.TEXT: "_handle_text",
         IndexType.PATH: "_handle_path",
         IndexType.GOPIP: "_handle_field",  # same as field
+        IndexType.ZOID: "_handle_zoid",
     }
 
     def _process_index(self, name, raw):
@@ -604,6 +617,41 @@ class _QueryBuilder:
         else:
             self.clauses.append(f"idx->>'{idx_key}' = %({p})s")
             self.params[p] = _bool_to_lower_str(query_val)
+
+    # -- zoid / oid (object_state primary key) ------------------------------
+
+    def _handle_zoid(self, name, idx_key, spec):
+        """Filter by the object's ``zoid`` (the ``object_state`` BIGINT primary
+        key; the catalog rid *is* the zoid).
+
+        Enables wake-free resolution of a set of ZODB object ids to their
+        (security-filtered) brains — e.g. ``zc.relation``/``intids``:
+        ``intid -> KeyReference.oid -> int.from_bytes(...) -> zoid`` then
+        ``catalog(zoid=[...])``. It filters the real primary-key column, so it
+        is index-backed with no extra storage.
+
+        Accepts an int (zoid), an 8-byte ZODB oid (``oid=`` / bytes, converted
+        via ``int.from_bytes(..., "big")`` — matching ``extraction.obj_to_zoid``),
+        or a digit string; as a scalar or a list/tuple/set. Non-coercible values
+        are dropped (ZCatalog-lenient). An empty/all-dropped set matches nothing
+        (``= ANY('{}')``) — never the whole table.
+        """
+        query_val = spec.get("query")
+        if query_val is None:
+            return
+        values = (
+            list(query_val)
+            if isinstance(query_val, (list, tuple, set, frozenset))
+            else [query_val]
+        )
+        if len(values) > _MAX_ZOIDS:
+            raise ValueError("Too many zoids in query")
+        zoids = [z for z in (_coerce_zoid(v) for v in values) if z is not None]
+        p = self._pname("zoid")
+        # Explicit ::bigint[] cast so an empty list is an unambiguous empty
+        # array (matches nothing) rather than a type-inference error.
+        self.clauses.append(f"zoid = ANY(%({p})s::bigint[])")
+        self.params[p] = zoids
 
     # -- ZCTextIndex (SearchableText / Title / Description) -----------------
 
@@ -893,6 +941,25 @@ def _normalize_query(raw):
     if isinstance(raw, dict):
         return raw
     return {"query": raw}
+
+
+def _coerce_zoid(value):
+    """Coerce a query value to an integer zoid, or None if not coercible.
+
+    Accepts an int (the zoid itself), 8-byte ZODB oid bytes (converted via
+    ``int.from_bytes(..., "big")``, matching ``extraction.obj_to_zoid``), or a
+    string of digits.  ``bool`` is rejected — Python treats it as ``int`` but a
+    boolean zoid is nonsensical.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, (bytes, bytearray)):
+        return int.from_bytes(bytes(value), "big")
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return None
 
 
 def _validate_path(path):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1448,3 +1448,79 @@ class TestGetCurrentLanguage:
 
         monkeypatch.setattr(u, "getRequest", lambda: {"LANGUAGE": "eu"})
         assert u.get_current_language() == "eu"
+
+
+# ---------------------------------------------------------------------------
+# zoid / oid pseudo-index (object_state primary key)
+# ---------------------------------------------------------------------------
+
+
+class TestZoidIndex:
+    """`zoid`/`oid` filter the object_state BIGINT primary key directly."""
+
+    def test_single_int(self):
+        qr = build_query({"zoid": 42})
+        assert "zoid = ANY(" in qr["where"]
+        assert "::bigint[]" in qr["where"]  # explicit cast (empty-list safe)
+        assert _find_list_param(qr["params"]) == [42]
+
+    def test_list_of_ints(self):
+        qr = build_query({"zoid": [1, 2, 3]})
+        assert "zoid = ANY(" in qr["where"]
+        assert _find_list_param(qr["params"]) == [1, 2, 3]
+
+    def test_explicit_query_spec(self):
+        qr = build_query({"zoid": {"query": [7, 8]}})
+        assert _find_list_param(qr["params"]) == [7, 8]
+
+    def test_oid_bytes_converted(self):
+        # 8-byte ZODB oid -> int.from_bytes big-endian (== extraction.obj_to_zoid)
+        oid = (0xFF).to_bytes(8, "big")
+        qr = build_query({"oid": [oid]})
+        assert "zoid = ANY(" in qr["where"]
+        assert _find_list_param(qr["params"]) == [0xFF]
+
+    def test_oid_single_bytes_scalar(self):
+        qr = build_query({"oid": (0x42).to_bytes(8, "big")})
+        assert _find_list_param(qr["params"]) == [0x42]
+
+    def test_digit_string_coerced(self):
+        qr = build_query({"zoid": "123"})
+        assert _find_list_param(qr["params"]) == [123]
+
+    def test_bool_rejected(self):
+        # bool is an int subclass but a boolean zoid is nonsensical — drop it
+        qr = build_query({"zoid": [True, 5]})
+        assert _find_list_param(qr["params"]) == [5]
+
+    def test_non_coercible_dropped(self):
+        qr = build_query({"zoid": ["nope", 9]})
+        assert _find_list_param(qr["params"]) == [9]
+
+    def test_empty_list_matches_nothing(self):
+        # empty/all-dropped set -> ANY('{}') matches nothing, never the table
+        qr = build_query({"zoid": []})
+        assert "zoid = ANY(" in qr["where"]
+        assert _find_list_param(qr["params"]) == []
+
+    def test_too_many_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError):
+            build_query({"zoid": list(range(10001))})
+
+    def test_composes_with_other_filters(self):
+        qr = build_query({"zoid": [1, 2], "portal_type": "Document"})
+        assert "zoid = ANY(" in qr["where"]
+        assert "idx->>'portal_type'" in qr["where"]
+        assert " AND " in qr["where"]
+
+    def test_honored_by_strip_non_index_keys(self):
+        from plone.pgcatalog.query import strip_non_index_keys
+
+        cleaned = strip_non_index_keys(
+            {"zoid": [1], "oid": [b"x"], "bogus": 1}, ["portal_type"]
+        )
+        assert "zoid" in cleaned
+        assert "oid" in cleaned
+        assert "bogus" not in cleaned

--- a/tests/test_query_integration.py
+++ b/tests/test_query_integration.py
@@ -485,3 +485,40 @@ class TestSortAndPagination:
             columns="zoid",
         )
         assert [r["zoid"] for r in rows] == [204, 201, 203, 200, 202]  # 1,2,3,10,20
+
+
+# ---------------------------------------------------------------------------
+# zoid / oid pseudo-index (object_state primary key)
+# ---------------------------------------------------------------------------
+
+
+class TestZoidIndexIntegration:
+    def test_zoid_list(self, pg_conn_with_catalog):
+        conn = pg_conn_with_catalog
+        _setup_test_data(conn)
+        assert _query_zoids(conn, {"zoid": [100, 102]}) == [100, 102]
+
+    def test_zoid_scalar(self, pg_conn_with_catalog):
+        conn = pg_conn_with_catalog
+        _setup_test_data(conn)
+        assert _query_zoids(conn, {"zoid": 103}) == [103]
+
+    def test_oid_bytes(self, pg_conn_with_catalog):
+        conn = pg_conn_with_catalog
+        _setup_test_data(conn)
+        # 8-byte ZODB oid for zoid 101 -> int.from_bytes big-endian
+        assert _query_zoids(conn, {"oid": [(101).to_bytes(8, "big")]}) == [101]
+
+    def test_empty_matches_nothing(self, pg_conn_with_catalog):
+        conn = pg_conn_with_catalog
+        _setup_test_data(conn)
+        # empty set must not degrade to "match all rows"
+        assert _query_zoids(conn, {"zoid": []}) == []
+
+    def test_composes_with_field(self, pg_conn_with_catalog):
+        conn = pg_conn_with_catalog
+        _setup_test_data(conn)
+        # 100 (Document) matches; 102 (Folder) is excluded by the AND
+        assert _query_zoids(conn, {"zoid": [100, 102], "portal_type": "Document"}) == [
+            100
+        ]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -109,11 +109,15 @@ class TestMetaTypeMap:
         assert META_TYPE_MAP["GopipIndex"] == IndexType.GOPIP
 
     def test_all_index_types_covered(self):
-        """Every IndexType enum value has at least one meta_type mapping."""
+        """Every IndexType enum value has a meta_type mapping, except the
+        pseudo-index types (which filter a real column, not a ZCatalog index)."""
         from plone.pgcatalog.columns import META_TYPE_MAP
+        from plone.pgcatalog.columns import PSEUDO_INDEX_TYPES
 
         covered = set(META_TYPE_MAP.values())
         for idx_type in IndexType:
+            if idx_type in PSEUDO_INDEX_TYPES:
+                continue
             assert idx_type in covered, (
                 f"IndexType.{idx_type.name} has no META_TYPE_MAP entry"
             )


### PR DESCRIPTION
Closes #197.

## What

Adds a built-in `zoid` (and `oid`) query operator:

```python
catalog(zoid=[123, 456, ...])   # ints (the object_state PK / catalog rid)
catalog(oid=[b"\x00...", ...])  # raw 8-byte ZODB oids -> int.from_bytes
```

## Why

pgcatalog stores every record in `object_state` keyed by `zoid` (the BIGINT PK; the catalog rid **is** the zoid), but there was no way to query by it (`getMetadataForRID` is unsupported). That matters whenever you hold a set of ZODB object ids and want their **security-filtered brains without waking the objects** — the motivating case being `zc.relation`/`intids` resolution:

`intid → getUtility(IIntIds).refs[intid].oid` (wake-free) `→ int.from_bytes(..., "big") → zoid → catalog(zoid=[...])`

On a real page (51 related objects) the wake path cost ~214 cold ZODB loads (more anonymously, walking the acquisition chain for `View`); a single `catalog(zoid=[...])` returns the security-filtered brains directly. See #197 for the full analysis.

## How

- `IndexType.ZOID` pseudo-index (not a ZCatalog meta-type → never auto-registered) wired via `_SPECIAL_BUILTIN_INDEX_TYPES`, targeting the real `zoid` column rather than a JSONB `idx` key.
- `_handle_zoid` emits `zoid = ANY(%(p)s::bigint[])`. Accepts int / digit-string / 8-byte oid bytes (`_coerce_zoid`); scalar or list; `bool` rejected; non-coercible values dropped (ZCatalog-lenient). Explicit `::bigint[]` cast so an **empty set matches nothing** (`= ANY('{}')`) instead of a type-inference error — never the whole table. `_MAX_ZOIDS` bounds a hostile list.
- **No storage, no reindex** — it filters the existing primary key. Composes with the normal query and with the `allowedRolesAndUsers` security filter injected by `searchResults`. Honored by `strip_non_index_keys`.

## Tests

- `tests/test_query.py::TestZoidIndex` — 12 unit tests (no PG): single/list ints, explicit spec, oid-bytes conversion, digit strings, bool rejection, non-coercible drop, empty-matches-nothing, `_MAX_ZOIDS`, AND-composition, `strip_non_index_keys`.
- `tests/test_query_integration.py::TestZoidIndexIntegration` — 5 integration tests (real PG): zoid list/scalar, oid-bytes, empty-matches-nothing, composition with a FieldIndex.
- Full query + columns suites green (197 unit, 35 query-integration). ruff clean.

## Follow-up

Happy to add a Diataxis how-to ("resolve relations/intids to brains via zoid") if you want it in the same PR.